### PR TITLE
Extend JavaPoetSourceGenerator.renderExpression to String[]

### DIFF
--- a/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
+++ b/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
@@ -49,6 +49,7 @@ import io.micronaut.sourcegen.model.StatementDef;
 import io.micronaut.sourcegen.model.TypeDef;
 import io.micronaut.sourcegen.model.VariableDef;
 
+import java.util.Arrays;
 import javax.lang.model.element.Modifier;
 import java.io.IOException;
 import java.io.Writer;
@@ -422,6 +423,17 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
                     case "double" -> CodeBlock.of(constant.value() + "d");
                     default -> CodeBlock.of("$L", constant.value());
                 };
+            } else if (type instanceof TypeDef.Array array) {
+                if (array.componentType() instanceof ClassTypeDef arrayClassTypeDef &&
+                        constant.value() instanceof String[] stringArray) {
+                    final var values = Arrays.stream(stringArray)
+                            .map(string -> CodeBlock.of("$S", string))
+                            .collect(CodeBlock.joining(", "));
+                    return CodeBlock.concat(
+                            CodeBlock.of("new $N[] {", arrayClassTypeDef.getSimpleName()),
+                            values,
+                            CodeBlock.of("}"));
+                }
             } else if (type instanceof ClassTypeDef classTypeDef) {
                 String name = classTypeDef.getName();
                 if (ClassUtils.isJavaLangType(name)) {

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
@@ -52,4 +52,12 @@ public class ExpressionWriteTest extends AbstractWriteTest {
         assertEquals("this.equals(\"hello\")", result);
     }
 
+    @Test
+    public void returnConstantArray() throws IOException {
+        ExpressionDef stringArray = new VariableDef.Constant(TypeDef.array(ClassTypeDef.of(String.class)),
+            new String[] {"hello", "world"});
+        String result = writeMethodWithExpression(stringArray);
+
+        assertEquals("new String[] {\"hello\", \"world\"}", result);
+    }
 }

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
@@ -53,11 +53,29 @@ public class ExpressionWriteTest extends AbstractWriteTest {
     }
 
     @Test
-    public void returnConstantArray() throws IOException {
+    public void returnConstantStringArray() throws IOException {
         ExpressionDef stringArray = new VariableDef.Constant(TypeDef.array(ClassTypeDef.of(String.class)),
             new String[] {"hello", "world"});
         String result = writeMethodWithExpression(stringArray);
 
         assertEquals("new String[] {\"hello\", \"world\"}", result);
+    }
+
+    @Test
+    public void returnConstantIntegerArray() throws IOException {
+        ExpressionDef integerArray = new VariableDef.Constant(TypeDef.array(ClassTypeDef.of(Integer.class)),
+            new Integer[] {1, 2});
+        String result = writeMethodWithExpression(integerArray);
+
+        assertEquals("new Integer[] {1, 2}", result);
+    }
+
+    @Test
+    public void returnConstantIntArray() throws IOException {
+        ExpressionDef integerArray = new VariableDef.Constant(TypeDef.array(TypeDef.primitive(Integer.TYPE)),
+            new int[] {1, 2});
+        String result = writeMethodWithExpression(integerArray);
+
+        assertEquals("new int[] {1, 2}", result);
     }
 }


### PR DESCRIPTION
Expand JavaPoetSourceGenerator.renderExpression to accept a TypeDef.Array when values are String[].