### PR TITLE
fix empty builder generation

### DIFF
--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
@@ -108,7 +108,9 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
             }
 
             builder.addMethod(MethodDef.constructor().build());
-            builder.addMethod(createAllPropertiesConstructor(builderType, properties));
+            if (!properties.isEmpty()) {
+                builder.addMethod(createAllPropertiesConstructor(builderType, properties));
+            }
 
             builder.addMethod(createBuilderMethod(builderType));
             builder.addMethod(createBuildMethod(element));

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/SuperBuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/SuperBuilderAnnotationVisitor.java
@@ -151,6 +151,7 @@ public final class SuperBuilderAnnotationVisitor implements TypeElementVisitor<S
 
                 builder.addMethod(createSelfMethod());
                 builder.addMethod(BuilderAnnotationVisitor.createBuildMethod(element));
+                builder.addMethod(createBuilderMethod(builderType));
 
                 ClassDef builderDef = builder.build();
                 context.visitGeneratedSourceFile(builderDef.getPackageName(), builderDef.getSimpleName(), element).ifPresent(sourceFile -> {
@@ -176,6 +177,14 @@ public final class SuperBuilderAnnotationVisitor implements TypeElementVisitor<S
                 })
             );
         }
+    }
+
+    private MethodDef createBuilderMethod(ClassTypeDef builderType) {
+        return MethodDef.builder("builder")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .returns(builderType)
+            .addStatement(builderType.instantiate().returning())
+            .build();
     }
 
     private MethodDef createSelfMethod() {

--- a/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitorSpec.groovy
+++ b/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitorSpec.groovy
@@ -29,4 +29,22 @@ class BuilderAnnotationVisitorSpec extends AbstractTypeElementSpec {
         walrus.age == 1
     }
 
+    void "test empty builder"() {
+        given:
+        var classLoader = buildClassLoader("test.Walrus", """
+        package test;
+        import io.micronaut.sourcegen.annotations.Builder;
+
+        @Builder
+        public record Walrus() {
+        }
+        """)
+        var walrusBuilderClass = classLoader.loadClass("test.WalrusBuilder")
+
+        expect:
+        var walrusBuilder = walrusBuilderClass.newInstance(new Object[]{})
+        var walrus = walrusBuilder.build()
+        walrus != null
+    }
+
 }

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/EmptyChild.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/EmptyChild.java
@@ -15,8 +15,9 @@
  */
 package io.micronaut.sourcegen.example;
 
-import io.micronaut.sourcegen.annotations.Builder;
 
-@Builder
-public class EmptyThing {
+import io.micronaut.sourcegen.annotations.SuperBuilder;
+
+@SuperBuilder
+public class EmptyChild extends EmptyParent {
 }

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/EmptyParent.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/EmptyParent.java
@@ -15,8 +15,8 @@
  */
 package io.micronaut.sourcegen.example;
 
-import io.micronaut.sourcegen.annotations.Builder;
+import io.micronaut.sourcegen.annotations.SuperBuilder;
 
-@Builder
-public class EmptyThing {
+@SuperBuilder
+public class EmptyParent {
 }

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/EmptyThing.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/EmptyThing.java
@@ -1,0 +1,7 @@
+package io.micronaut.sourcegen.example;
+
+import io.micronaut.sourcegen.annotations.Builder;
+
+@Builder
+public class EmptyThing {
+}

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/EmptyTest.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/EmptyTest.java
@@ -1,0 +1,19 @@
+package io.micronaut.sourcegen.example;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class EmptyTest {
+
+    @Test
+    void testEmptyBuilder() {
+        EmptyThing built = EmptyThingBuilder.builder().build();
+        Assertions.assertNotNull(built);
+    }
+
+    @Test
+    void testEmptySuperBuilder() {
+        EmptyChild built = EmptyChildSuperBuilder.builder().build();
+        Assertions.assertNotNull(built);
+    }
+}


### PR DESCRIPTION
Prior to this change if a record or java bean had no properties a duplicate constructor was generated, one for the default constructor and another for an empty list properties. This resulted in a compilation error for duplicate constructors. This fixes that.