### PR TITLE
Add an ability to introspect builders

### DIFF
--- a/sourcegen-annotations/src/main/java/io/micronaut/sourcegen/annotations/Builder.java
+++ b/sourcegen-annotations/src/main/java/io/micronaut/sourcegen/annotations/Builder.java
@@ -15,6 +15,9 @@
  */
 package io.micronaut.sourcegen.annotations;
 
+import io.micronaut.core.annotation.Introspected;
+
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -34,11 +37,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface Builder {
 
     /**
-     * If true, an {@link io.micronaut.core.annotation.Introspected} annotation will be added
-     * on the builder so that introspection can be created for it.
+     * Define what annotations should be added to the generated builder. By default,
+     * the builder will have {@link io.micronaut.core.annotation.Introspected} annotation
+     * so that introspection can be created for it.
      *
-     * @return Whether the builder needs to be introspected
+     * @return Array of annotations to apply on the builder
      */
-    boolean introspected() default true;
+    Class<? extends Annotation>[] annotatedWith() default Introspected.class;
 
 }

--- a/sourcegen-annotations/src/main/java/io/micronaut/sourcegen/annotations/Builder.java
+++ b/sourcegen-annotations/src/main/java/io/micronaut/sourcegen/annotations/Builder.java
@@ -32,4 +32,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
 public @interface Builder {
+
+    /**
+     * If true, an {@link io.micronaut.core.annotation.Introspected} annotation will be added
+     * on the builder so that introspection can be created for it.
+     *
+     * @return Whether the builder needs to be introspected
+     */
+    boolean introspected() default true;
+
 }

--- a/sourcegen-annotations/src/main/java/io/micronaut/sourcegen/annotations/SuperBuilder.java
+++ b/sourcegen-annotations/src/main/java/io/micronaut/sourcegen/annotations/SuperBuilder.java
@@ -33,4 +33,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
 public @interface SuperBuilder {
+
+    /**
+     * If true, an {@link io.micronaut.core.annotation.Introspected} annotation will be added
+     * on the builder so that introspection can be created for it.
+     *
+     * @return Whether the builder needs to be introspected
+     */
+    boolean introspected() default true;
+
 }

--- a/sourcegen-annotations/src/main/java/io/micronaut/sourcegen/annotations/SuperBuilder.java
+++ b/sourcegen-annotations/src/main/java/io/micronaut/sourcegen/annotations/SuperBuilder.java
@@ -15,6 +15,9 @@
  */
 package io.micronaut.sourcegen.annotations;
 
+import io.micronaut.core.annotation.Introspected;
+
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -35,11 +38,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface SuperBuilder {
 
     /**
-     * If true, an {@link io.micronaut.core.annotation.Introspected} annotation will be added
-     * on the builder so that introspection can be created for it.
+     * Define what annotations should be added to the generated builder. By default,
+     * the builder will have {@link io.micronaut.core.annotation.Introspected} annotation
+     * so that introspection can be created for it.
      *
-     * @return Whether the builder needs to be introspected
+     * @return Array of annotations to apply on the builder
      */
-    boolean introspected() default true;
+    Class<? extends Annotation>[] annotatedWith() default Introspected.class;
 
 }

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
@@ -43,7 +43,6 @@ import io.micronaut.sourcegen.model.StatementDef;
 import io.micronaut.sourcegen.model.TypeDef;
 import io.micronaut.sourcegen.model.VariableDef;
 
-import java.lang.annotation.Annotation;
 import java.util.HashSet;
 import java.util.Set;
 import javax.lang.model.element.Modifier;

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.sourcegen.generator.visitors;
 
+import io.micronaut.core.annotation.Creator;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
@@ -157,7 +158,8 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
     }
 
     private MethodDef createAllPropertiesConstructor(ClassTypeDef builderType, List<PropertyElement> properties) {
-        MethodDef.MethodDefBuilder builder = MethodDef.constructor();
+        MethodDef.MethodDefBuilder builder = MethodDef.constructor()
+            .addAnnotation(Creator.class);
         VariableDef.This self = new VariableDef.This(builderType);
         for (PropertyElement parameter : properties) {
             ParameterDef parameterDef = ParameterDef.of(parameter.getName(), TypeDef.of(parameter.getType()));

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
@@ -16,6 +16,7 @@
 package io.micronaut.sourcegen.generator.visitors;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.bind.annotation.Bindable;
@@ -71,6 +72,8 @@ import static io.micronaut.sourcegen.generator.visitors.Singulars.singularize;
 @Internal
 public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builder, Object> {
 
+    public static final String BUILDER_INTROSPECTED_MEMBER = "introspected";
+
     private final Set<String> processed = new HashSet<>();
 
     @Override
@@ -101,6 +104,9 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
 
             ClassDef.ClassDefBuilder builder = ClassDef.builder(builderClassName)
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
+            if (element.booleanValue(Builder.class, BUILDER_INTROSPECTED_MEMBER).orElse(true)) {
+                builder.addAnnotation(Introspected.class);
+            }
 
             List<PropertyElement> properties = element.getBeanProperties();
             for (PropertyElement beanProperty : properties) {

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
@@ -157,7 +157,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
         }
     }
 
-    private MethodDef createAllPropertiesConstructor(ClassTypeDef builderType, List<PropertyElement> properties) {
+    static MethodDef createAllPropertiesConstructor(ClassTypeDef builderType, List<PropertyElement> properties) {
         MethodDef.MethodDefBuilder builder = MethodDef.constructor()
             .addAnnotation(Creator.class);
         VariableDef.This self = new VariableDef.This(builderType);
@@ -188,7 +188,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
         return builder.build();
     }
 
-    private StatementDef iterableToArrayListStatement(VariableDef.This self, ParameterDef parameterDef) {
+    private static StatementDef iterableToArrayListStatement(VariableDef.This self, ParameterDef parameterDef) {
         return ClassTypeDef.of(ArrayList.class)
             .instantiate()
             .newLocal(parameterDef.getName() + "ArrayList", arrayListVar ->
@@ -206,7 +206,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                             )));
     }
 
-    private StatementDef mapToArrayListStatement(VariableDef.This self, ParameterDef parameterDef) {
+    private static StatementDef mapToArrayListStatement(VariableDef.This self, ParameterDef parameterDef) {
         return self.field(parameterDef.getName(), parameterDef.getType())
             .assign(
                 ClassTypeDef.of(ArrayList.class)

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/SuperBuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/SuperBuilderAnnotationVisitor.java
@@ -26,6 +26,7 @@ import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.sourcegen.annotations.SuperBuilder;
 import io.micronaut.sourcegen.generator.SourceGenerator;
 import io.micronaut.sourcegen.generator.SourceGenerators;
+import io.micronaut.sourcegen.model.AnnotationDef;
 import io.micronaut.sourcegen.model.ClassDef;
 import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.MethodDef;
@@ -152,7 +153,8 @@ public final class SuperBuilderAnnotationVisitor implements TypeElementVisitor<S
                         )
                     );
                 if (element.booleanValue(SuperBuilder.class, SUPER_BUILDER_INTROSPECTED_MEMBER).orElse(true)) {
-                    builder.addAnnotation(Introspected.class);
+                    builder.addAnnotation(AnnotationDef.builder(Introspected.class)
+                        .addMember("withPrefix", "").build());
                 }
 
                 builder.addMethod(createSelfMethod());

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/SuperBuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/SuperBuilderAnnotationVisitor.java
@@ -16,6 +16,7 @@
 package io.micronaut.sourcegen.generator.visitors;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.PropertyElement;
@@ -45,6 +46,8 @@ import static io.micronaut.sourcegen.generator.visitors.BuilderAnnotationVisitor
  */
 @Internal
 public final class SuperBuilderAnnotationVisitor implements TypeElementVisitor<SuperBuilder, Object> {
+
+    public static final String SUPER_BUILDER_INTROSPECTED_MEMBER = "introspected";
 
     private final Set<String> processed = new HashSet<>();
 
@@ -148,6 +151,9 @@ public final class SuperBuilderAnnotationVisitor implements TypeElementVisitor<S
                             )
                         )
                     );
+                if (element.booleanValue(SuperBuilder.class, SUPER_BUILDER_INTROSPECTED_MEMBER).orElse(true)) {
+                    builder.addAnnotation(Introspected.class);
+                }
 
                 builder.addMethod(createSelfMethod());
                 builder.addMethod(BuilderAnnotationVisitor.createBuildMethod(element));

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/SuperBuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/SuperBuilderAnnotationVisitor.java
@@ -153,8 +153,12 @@ public final class SuperBuilderAnnotationVisitor implements TypeElementVisitor<S
                         )
                     );
                 if (element.booleanValue(SuperBuilder.class, SUPER_BUILDER_INTROSPECTED_MEMBER).orElse(true)) {
-                    builder.addAnnotation(AnnotationDef.builder(Introspected.class)
-                        .addMember("withPrefix", "").build());
+                    builder.addAnnotation(Introspected.class);
+                }
+
+                builder.addMethod(MethodDef.constructor().build());
+                if (!properties.isEmpty()) {
+                    builder.addMethod(BuilderAnnotationVisitor.createAllPropertiesConstructor(builderType, properties));
                 }
 
                 builder.addMethod(createSelfMethod());

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/SuperBuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/SuperBuilderAnnotationVisitor.java
@@ -26,7 +26,6 @@ import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.sourcegen.annotations.SuperBuilder;
 import io.micronaut.sourcegen.generator.SourceGenerator;
 import io.micronaut.sourcegen.generator.SourceGenerators;
-import io.micronaut.sourcegen.model.AnnotationDef;
 import io.micronaut.sourcegen.model.ClassDef;
 import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.MethodDef;

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/SuperBuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/SuperBuilderAnnotationVisitor.java
@@ -16,7 +16,6 @@
 package io.micronaut.sourcegen.generator.visitors;
 
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.PropertyElement;
@@ -31,11 +30,12 @@ import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.MethodDef;
 import io.micronaut.sourcegen.model.TypeDef;
 
-import java.util.HashSet;
-import java.util.Set;
 import javax.lang.model.element.Modifier;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
+import static io.micronaut.sourcegen.generator.visitors.BuilderAnnotationVisitor.addAnnotations;
 import static io.micronaut.sourcegen.generator.visitors.BuilderAnnotationVisitor.createModifyPropertyMethod;
 
 /**
@@ -46,8 +46,6 @@ import static io.micronaut.sourcegen.generator.visitors.BuilderAnnotationVisitor
  */
 @Internal
 public final class SuperBuilderAnnotationVisitor implements TypeElementVisitor<SuperBuilder, Object> {
-
-    public static final String SUPER_BUILDER_INTROSPECTED_MEMBER = "introspected";
 
     private final Set<String> processed = new HashSet<>();
 
@@ -151,9 +149,7 @@ public final class SuperBuilderAnnotationVisitor implements TypeElementVisitor<S
                             )
                         )
                     );
-                if (element.booleanValue(SuperBuilder.class, SUPER_BUILDER_INTROSPECTED_MEMBER).orElse(true)) {
-                    builder.addAnnotation(Introspected.class);
-                }
+                addAnnotations(builder, element.getAnnotation(SuperBuilder.class));
 
                 builder.addMethod(MethodDef.constructor().build());
                 if (!properties.isEmpty()) {

--- a/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitorSpec.groovy
+++ b/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitorSpec.groovy
@@ -10,7 +10,7 @@ class BuilderAnnotationVisitorSpec extends AbstractTypeElementSpec {
         package test;
         import io.micronaut.sourcegen.annotations.Builder;
 
-        @Builder(introspected = false)
+        @Builder(annotatedWith = {})
         public record Walrus(
               String name,
               int age,
@@ -35,7 +35,7 @@ class BuilderAnnotationVisitorSpec extends AbstractTypeElementSpec {
         package test;
         import io.micronaut.sourcegen.annotations.Builder;
 
-        @Builder(introspected = false)
+        @Builder(annotatedWith = {})
         public record Walrus() {
         }
         """)

--- a/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitorSpec.groovy
+++ b/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitorSpec.groovy
@@ -10,7 +10,7 @@ class BuilderAnnotationVisitorSpec extends AbstractTypeElementSpec {
         package test;
         import io.micronaut.sourcegen.annotations.Builder;
 
-        @Builder
+        @Builder(introspected = false)
         public record Walrus(
               String name,
               int age,
@@ -35,7 +35,7 @@ class BuilderAnnotationVisitorSpec extends AbstractTypeElementSpec {
         package test;
         import io.micronaut.sourcegen.annotations.Builder;
 
-        @Builder
+        @Builder(introspected = false)
         public record Walrus() {
         }
         """)

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/AnimalSuperBuilderTest.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/AnimalSuperBuilderTest.java
@@ -16,9 +16,12 @@
 package io.micronaut.sourcegen.example;
 
 import java.lang.reflect.Modifier;
+
+import io.micronaut.core.beans.BeanIntrospection;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AnimalSuperBuilderTest {
@@ -60,6 +63,12 @@ class AnimalSuperBuilderTest {
         assertTrue(dog.isBig());
     }
 //end::test[]
+
+    @Test
+    public void dogIntrospection() {
+        var introspection = BeanIntrospection.getIntrospection(DogSuperBuilder.class);
+        assertNotNull(introspection);
+    }
 
     @Test
     public void internalTest() {

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/AnimalSuperBuilderTest.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/AnimalSuperBuilderTest.java
@@ -68,7 +68,8 @@ class AnimalSuperBuilderTest {
     public void dogIntrospection() {
         var introspection = BeanIntrospection.getIntrospection(DogSuperBuilder.class);
         assertNotNull(introspection);
-        assertEquals(6, introspection.getBeanProperties().size());
+        assertEquals(0, introspection.getBeanProperties().size());
+        assertEquals(6, introspection.getConstructorArguments().length);
     }
 
     @Test

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/AnimalSuperBuilderTest.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/AnimalSuperBuilderTest.java
@@ -68,6 +68,7 @@ class AnimalSuperBuilderTest {
     public void dogIntrospection() {
         var introspection = BeanIntrospection.getIntrospection(DogSuperBuilder.class);
         assertNotNull(introspection);
+        assertEquals(6, introspection.getBeanProperties().size());
     }
 
     @Test

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/PersonBuilderTest.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/PersonBuilderTest.java
@@ -15,10 +15,12 @@
  */
 package io.micronaut.sourcegen.example;
 
+import io.micronaut.core.beans.BeanIntrospection;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class PersonBuilderTest {
 
@@ -35,6 +37,12 @@ class PersonBuilderTest {
         assertEquals(123L, person.id());
     }
 //end::test[]
+
+    @Test
+    public void personIntrospection() {
+        var introspection = BeanIntrospection.getIntrospection(PersonBuilder.class);
+        assertNotNull(introspection);
+    }
 
     @Test
     public void buildsPersonWithPrimitiveDefaults() {

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/PersonBuilderTest.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/PersonBuilderTest.java
@@ -42,6 +42,8 @@ class PersonBuilderTest {
     public void personIntrospection() {
         var introspection = BeanIntrospection.getIntrospection(PersonBuilder.class);
         assertNotNull(introspection);
+        assertEquals(0, introspection.getBeanProperties().size());
+        assertEquals(3, introspection.getConstructorArguments().length);
     }
 
     @Test


### PR DESCRIPTION
Adds the ability to introspect builders with a configuration in the annotations:`@Builder(intropsected=)` and `@SuperBuilder(introspected=)`. By default it is set to true.