### PR TITLE
Support generating delegate classes

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
 
       - name: "🔧 Setup GraalVM CE"
-        uses: graalvm/setup-graalvm@v1.2.3
+        uses: graalvm/setup-graalvm@v1.2.4
         with:
           distribution: 'graalvm'
           java-version: ${{ matrix.java }}

--- a/sourcegen-annotations/src/main/java/io/micronaut/sourcegen/annotations/Delegate.java
+++ b/sourcegen-annotations/src/main/java/io/micronaut/sourcegen/annotations/Delegate.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The delegate annotation on a bean should create a delegate base class.
+ *
+ * @author Andriy Dmytruk
+ * @since 1.3
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+public @interface Delegate {
+
+    /**
+     * Define what the class that delegate should be created for.
+     *
+     * @return The class to create delegate for
+     */
+    Class<?> type() default Void.class;
+
+}

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ConstructorWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ConstructorWriteTest.java
@@ -1,0 +1,71 @@
+package io.micronaut.sourcegen.javapoet.write;
+
+import io.micronaut.sourcegen.model.ClassDef;
+import io.micronaut.sourcegen.model.ParameterDef;
+import io.micronaut.sourcegen.model.PropertyDef;
+import io.micronaut.sourcegen.model.TypeDef;
+import org.junit.Test;
+
+import javax.lang.model.element.Modifier;
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConstructorWriteTest extends AbstractWriteTest {
+
+    @Test
+    public void writeAllFieldsConstructor() throws IOException {
+        ClassDef classDef = ClassDef.builder("test.Test")
+                .addModifiers(Modifier.PUBLIC)
+                .addProperty(PropertyDef.builder("name").ofType(String.class).build())
+                .addProperty(PropertyDef.builder("age").ofType(Integer.class).build())
+                .addAllFieldsConstructor()
+                .build();
+        var result = writeClassAndGetConstructor(classDef);
+
+        var expected = """
+        Test(String name, Integer age) {
+          this.name = name;
+          this.age = age;
+        }
+        """;
+        assertEquals(expected.strip(), result.trim());
+    }
+
+    @Test
+    public void writeNoFieldsConstructor() throws IOException {
+        ClassDef classDef = ClassDef.builder("test.Test")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(PropertyDef.builder("name").ofType(String.class).build())
+            .addProperty(PropertyDef.builder("age").ofType(Integer.class).build())
+            .addNoFieldsConstructor(Modifier.PUBLIC)
+            .build();
+        var result = writeClassAndGetConstructor(classDef);
+
+        var expected = """
+        public Test() {
+        }
+        """;
+        assertEquals(expected.strip(), result.trim());
+    }
+
+    @Test
+    public void writeConstructor() throws IOException {
+        ClassDef classDef = ClassDef.builder("test.Test")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(PropertyDef.builder("name").ofType(String.class).build())
+            .addProperty(PropertyDef.builder("age").ofType(Integer.class).build())
+            .addConstructor(List.of(ParameterDef.of("name", TypeDef.of(String.class))), Modifier.PROTECTED)
+            .build();
+        var result = writeClassAndGetConstructor(classDef);
+
+        var expected = """
+        protected Test(String name) {
+          this.name = name;
+        }
+        """;
+        assertEquals(expected.strip(), result.trim());
+    }
+
+}

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/DelegateAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/DelegateAnnotationVisitor.java
@@ -38,7 +38,6 @@ import io.micronaut.sourcegen.model.ParameterDef;
 import io.micronaut.sourcegen.model.StatementDef;
 import io.micronaut.sourcegen.model.TypeDef;
 import io.micronaut.sourcegen.model.TypeDef.TypeVariable;
-import io.micronaut.sourcegen.model.VariableDef;
 import io.micronaut.sourcegen.model.VariableDef.This;
 
 import javax.lang.model.element.Modifier;
@@ -188,9 +187,9 @@ public final class DelegateAnnotationVisitor implements TypeElementVisitor<Deleg
                 methodBuilder.addParameter(def);
                 parameters.add(def.asVariable());
             }
-            ExpressionDef.CallInstanceMethod delegateCall = ExpressionDef.invoke(new VariableDef.Field(
-                new This(delegateType), DELEGATEE_MEMBER, typeDef
-            ), method.getName(), parameters, returnType);
+            ExpressionDef.CallInstanceMethod delegateCall = new This(delegateType)
+                .field(DELEGATEE_MEMBER, typeDef)
+                .invoke(method.getName(), returnType, parameters);
             if (!method.getReturnType().isVoid()) {
                 methodBuilder.addStatement(new StatementDef.Return(delegateCall));
             } else {

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/DelegateAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/DelegateAnnotationVisitor.java
@@ -22,7 +22,6 @@ import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.GenericPlaceholderElement;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.ParameterElement;
-import io.micronaut.inject.ast.WildcardElement;
 import io.micronaut.inject.processing.ProcessingException;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
@@ -40,7 +39,6 @@ import io.micronaut.sourcegen.model.ParameterDef;
 import io.micronaut.sourcegen.model.StatementDef;
 import io.micronaut.sourcegen.model.TypeDef;
 import io.micronaut.sourcegen.model.TypeDef.TypeVariable;
-import io.micronaut.sourcegen.model.TypeDef.Wildcard;
 import io.micronaut.sourcegen.model.VariableDef;
 import io.micronaut.sourcegen.model.VariableDef.This;
 

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/DelegateAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/DelegateAnnotationVisitor.java
@@ -19,7 +19,6 @@ import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.inject.ast.ClassElement;
-import io.micronaut.inject.ast.GenericPlaceholderElement;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.processing.ProcessingException;
@@ -44,14 +43,9 @@ import io.micronaut.sourcegen.model.VariableDef.This;
 
 import javax.lang.model.element.Modifier;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Queue;
 import java.util.Set;
 
 /**
@@ -122,8 +116,8 @@ public final class DelegateAnnotationVisitor implements TypeElementVisitor<Deleg
                 );
                 typeDef = TypeDef.parameterized(
                     typeDef,
-                    element.getTypeArguments().entrySet().stream().map(
-                        v -> (TypeDef) new TypeVariable(v.getKey())
+                    element.getTypeArguments().keySet().stream().map(
+                        classElement -> (TypeDef) new TypeVariable(classElement)
                     ).toList()
                 );
             }

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/DelegateAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/DelegateAnnotationVisitor.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.generator.visitors;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.ast.ParameterElement;
+import io.micronaut.inject.processing.ProcessingException;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+import io.micronaut.sourcegen.annotations.Delegate;
+import io.micronaut.sourcegen.generator.SourceGenerator;
+import io.micronaut.sourcegen.generator.SourceGenerators;
+import io.micronaut.sourcegen.model.ClassDef;
+import io.micronaut.sourcegen.model.ClassDef.ClassDefBuilder;
+import io.micronaut.sourcegen.model.ClassTypeDef;
+import io.micronaut.sourcegen.model.ExpressionDef;
+import io.micronaut.sourcegen.model.FieldDef;
+import io.micronaut.sourcegen.model.MethodDef;
+import io.micronaut.sourcegen.model.MethodDef.MethodDefBuilder;
+import io.micronaut.sourcegen.model.ParameterDef;
+import io.micronaut.sourcegen.model.StatementDef;
+import io.micronaut.sourcegen.model.TypeDef;
+import io.micronaut.sourcegen.model.VariableDef;
+import io.micronaut.sourcegen.model.VariableDef.This;
+
+import javax.lang.model.element.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+
+/**
+ * The visitor that is generation a delegate.
+ *
+ * @author Andriy Dmytruk
+ * @since 1.3
+ */
+@Internal
+public final class DelegateAnnotationVisitor implements TypeElementVisitor<Delegate, Object> {
+
+    public static final String DELEGATE_TYPE_MEMBER = "type";
+    public static final String DELEGATEE_MEMBER = "delegatee";
+    public static final String NAME_SUFFIX = "Delegate";
+
+    private final Set<String> processed = new HashSet<>();
+
+    @Override
+    public @NonNull VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
+
+    @Override
+    public void start(VisitorContext visitorContext) {
+        processed.clear();
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationNames() {
+        return Set.of(Delegate.class.getName());
+    }
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        AnnotationValue<?> annotation = element.getAnnotation(Delegate.class);
+        Optional<Class<?>> type = annotation.classValue("type");
+
+        if (type.isPresent() && !type.get().equals(Void.class)) {
+            ClassElement typeElement = context.getClassElement(type.get()).orElseThrow(
+                () -> new ProcessingException(element, "Could not find required type " + type.get().getName()));
+            createDelegate(typeElement, context);
+        } else {
+            createDelegate(element, context);
+        }
+    }
+
+    private void createDelegate(ClassElement element, VisitorContext context) {
+        if (processed.contains(element.getName())) {
+            return;
+        }
+        if (!element.isInterface()) {
+            throw new ProcessingException(element, "Only interfaces are supported for delegate creation. But '"
+                + element.getName() + "' is annotated with @Delegate");
+        }
+
+        try {
+            String simpleName = element.getSimpleName() + NAME_SUFFIX;
+            String delegateClassName = element.getPackageName() + "." + simpleName;
+
+            ClassTypeDef typeDef = ClassTypeDef.of(element);
+            ClassTypeDef delegateType = ClassTypeDef.of(delegateClassName);
+            ClassDefBuilder delegate = ClassDef.builder(delegateClassName)
+                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                .addField(FieldDef.builder(DELEGATEE_MEMBER).ofType(typeDef).build())
+                .addAllFieldsConstructor()
+                .addSuperinterface(typeDef);
+
+            Set<MethodSignature> createdMethods = new HashSet<>();
+            addDelegateMethods(element, delegate, typeDef, delegateType, createdMethods);
+            for (ClassElement interfaceElement : getAllInterfaces(element)) {
+                addDelegateMethods(interfaceElement, delegate, typeDef, delegateType, createdMethods);
+            }
+
+            SourceGenerator sourceGenerator = SourceGenerators.findByLanguage(context.getLanguage()).orElse(null);
+            if (sourceGenerator == null) {
+                return;
+            }
+
+            ClassDef builderDef = delegate.build();
+            processed.add(element.getName());
+            context.visitGeneratedSourceFile(
+                builderDef.getPackageName(),
+                builderDef.getSimpleName(),
+                element
+            ).ifPresent(sourceFile -> {
+                try {
+                    sourceFile.write(
+                        writer -> sourceGenerator.write(builderDef, writer)
+                    );
+                } catch (Exception e) {
+                    throw new ProcessingException(element, "Failed to generate a delegate: " + e.getMessage(), e);
+                }
+            });
+        } catch (ProcessingException e) {
+            throw e;
+        } catch (Exception e) {
+            SourceGenerators.handleFatalException(
+                element,
+                Delegate.class,
+                e,
+                (exception -> {
+                    processed.remove(element.getName());
+                    throw exception;
+                })
+            );
+        }
+    }
+
+    private Collection<ClassElement> getAllInterfaces(ClassElement element) {
+        Queue<ClassElement> interfaces = new LinkedList<>();
+        Set<ClassElement> visited = new HashSet<>();
+        interfaces.addAll(element.getInterfaces());
+
+        while (!interfaces.isEmpty()) {
+            ClassElement current = interfaces.poll();
+            visited.add(current);
+            for (ClassElement iface : current.getInterfaces()) {
+                if (!visited.contains(iface)) {
+                    interfaces.add(iface);
+                }
+            }
+        }
+        return visited;
+    }
+
+    private void addDelegateMethods(
+            ClassElement element, ClassDefBuilder builder,
+            TypeDef typeDef, TypeDef delegateType, Set<MethodSignature> createdMethods
+    ) {
+        for (MethodElement method: element.getMethods()) {
+            if (method.isPrivate()) {
+                continue;
+            }
+            MethodSignature signature = new MethodSignature(
+                method.getName(),
+                Arrays.stream(method.getParameters()).map(v -> v.getType().getName()).toList()
+            );
+            if (createdMethods.contains(signature)) {
+                continue;
+            }
+            createdMethods.add(signature);
+
+            TypeDef returnType = TypeDef.of(method.getReturnType());
+            MethodDefBuilder methodBuilder = MethodDef.builder(method.getName())
+                .overrides()
+                .returns(returnType);
+            List<ExpressionDef> parameters = new ArrayList<>();
+            if (method.isPublic()) {
+                methodBuilder.addModifiers(Modifier.PUBLIC);
+            } else if (method.isProtected()) {
+                methodBuilder.addModifiers(Modifier.PROTECTED);
+            }
+            for (ParameterElement parameter: method.getParameters()) {
+                ParameterDef def = ParameterDef.builder(
+                    parameter.getName(), TypeDef.of(parameter.getType())
+                ).build();
+                methodBuilder.addParameter(def);
+                parameters.add(def.asVariable());
+            }
+            ExpressionDef.CallInstanceMethod delegateCall = ExpressionDef.invoke(new VariableDef.Field(
+                new This(delegateType), DELEGATEE_MEMBER, typeDef
+            ), method.getName(), parameters, returnType);
+            if (!method.getReturnType().isVoid()) {
+                methodBuilder.addStatement(new StatementDef.Return(delegateCall));
+            } else {
+                methodBuilder.addStatement(delegateCall);
+            }
+            builder.addMethod(methodBuilder.build());
+        }
+    }
+
+    private record MethodSignature(
+        String name,
+        List<String> parameterTypes
+    ) {
+    }
+
+}

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/DelegateAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/DelegateAnnotationVisitor.java
@@ -117,16 +117,9 @@ public final class DelegateAnnotationVisitor implements TypeElementVisitor<Deleg
                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT);
 
             if (!element.getTypeArguments().isEmpty()) {
-                for (Entry<String, ClassElement> type: element.getTypeArguments().entrySet()) {
-                    if (type.getValue() instanceof GenericPlaceholderElement placeholderElement) {
-                        delegate.addTypeVariable(new TypeVariable(
-                            type.getKey(),
-                            placeholderElement.getBounds().stream().map(TypeDef::of).toList()
-                        ));
-                    } else {
-                        delegate.addTypeVariable(new TypeVariable(type.getKey()));
-                    }
-                }
+                element.getTypeArguments().forEach(
+                    (k, v) -> delegate.addTypeVariable(TypeVariable.of(k, v))
+                );
                 typeDef = TypeDef.parameterized(
                     typeDef,
                     element.getTypeArguments().entrySet().stream().map(

--- a/sourcegen-generator/src/main/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/sourcegen-generator/src/main/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -2,3 +2,4 @@ io.micronaut.sourcegen.generator.visitors.BuilderAnnotationVisitor
 io.micronaut.sourcegen.generator.visitors.WitherAnnotationVisitor
 io.micronaut.sourcegen.generator.visitors.SuperBuilderAnnotationVisitor
 io.micronaut.sourcegen.generator.visitors.ObjectAnnotationVisitor
+io.micronaut.sourcegen.generator.visitors.DelegateAnnotationVisitor

--- a/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/DelegateAnnotationVisitorSpec.groovy
+++ b/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/DelegateAnnotationVisitorSpec.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.sourcegen.generator.visitors;
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec;
+
+class DelegateAnnotationVisitorSpec extends AbstractTypeElementSpec {
+
+    void "test delegate"() {
+        given:
+        var classLoader = buildClassLoader("test.Worker", """
+        package test;
+        import io.micronaut.sourcegen.annotations.Delegate;
+        import java.util.List;
+
+        @Delegate
+        public interface Worker<T extends String> {
+            String name();
+            double tasksPerDay();
+            boolean canComplete(List<T> tasks);
+            T currentTask();
+            List<String> competencies();
+        }
+        """)
+        var workerDelegateClass = classLoader.loadClass("test.WorkerDelegate")
+
+        expect:
+        workerDelegateClass != null
+    }
+
+}

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassDef.java
@@ -21,6 +21,8 @@ import io.micronaut.core.annotation.Nullable;
 
 import javax.lang.model.element.Modifier;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -93,6 +95,11 @@ public final class ClassDef extends AbstractElement implements ObjectDef {
         for (FieldDef field : fields) {
             if (field.getName().equals(name)) {
                 return field;
+            }
+        }
+        for (PropertyDef property : properties) {
+            if (property.getName().equals(name)) {
+                return FieldDef.builder(property.getName()).ofType(property.getType()).build();
             }
         }
         return null;
@@ -190,6 +197,50 @@ public final class ClassDef extends AbstractElement implements ObjectDef {
 
         public ClassDef build() {
             return new ClassDef(name, modifiers, fields, methods, properties, annotations, javadoc, typeVariables, superinterfaces, superclass);
+        }
+
+        /**
+         * Add a constructor.
+         *
+         * @param parameterDefs The fields to set in the constructor
+         * @param modifiers The method modifiers
+         * @return this
+         */
+        public ClassDefBuilder addConstructor(Collection<ParameterDef> parameterDefs, Modifier... modifiers) {
+            return this.addMethod(
+                MethodDef.constructor(ClassTypeDef.of(name), parameterDefs, modifiers)
+            );
+        }
+
+        /**
+         * Add a constructor for all fields.
+         *
+         * @param modifiers The modifiers
+         * @return this
+         */
+        public ClassDefBuilder addAllFieldsConstructor(Modifier... modifiers) {
+            List<ParameterDef> constructorParameters = new ArrayList<>();
+            for (PropertyDef property : properties) {
+                constructorParameters.add(ParameterDef.of(property.getName(), property.getType()));
+            }
+            for (FieldDef field: fields) {
+                constructorParameters.add(ParameterDef.of(field.getName(), field.getType()));
+            }
+            return this.addMethod(
+                MethodDef.constructor(ClassTypeDef.of(name), constructorParameters, modifiers)
+            );
+        }
+
+        /**
+         * Add a constructor with no arguments.
+         *
+         * @param modifiers The method modifiers
+         * @return this
+         */
+        public ClassDefBuilder addNoFieldsConstructor(Modifier... modifiers) {
+            return this.addMethod(
+                MethodDef.constructor(ClassTypeDef.of(name), Collections.emptyList(), modifiers)
+            );
         }
 
     }

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ExpressionDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ExpressionDef.java
@@ -300,7 +300,7 @@ public sealed interface ExpressionDef
      * @return The call to the instance method
      * @since 1.2
      */
-    default CallInstanceMethod invoke(String name, TypeDef returning, List<ExpressionDef> parameters) {
+    default CallInstanceMethod invoke(String name, TypeDef returning, List<? extends ExpressionDef> parameters) {
         return new CallInstanceMethod(
             this,
             name,
@@ -587,7 +587,7 @@ public sealed interface ExpressionDef
     @Experimental
     record CallInstanceMethod(ExpressionDef instance,
                               String name,
-                              List<ExpressionDef> parameters,
+                              List<? extends ExpressionDef> parameters,
                               TypeDef returningType) implements ExpressionDef, StatementDef {
 
         public CallInstanceMethod(ExpressionDef instance, MethodDef methodDef) {

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/MethodDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/MethodDef.java
@@ -69,9 +69,10 @@ public final class MethodDef extends AbstractElement {
      *
      * @param thisType      The type to be constructed
      * @param parameterDefs The parameters of the body
+     * @param modifiers     The constructor modifiers
      * @return A new constructor with a body.
      */
-    public static MethodDef constructor(ClassTypeDef thisType, Collection<ParameterDef> parameterDefs) {
+    public static MethodDef constructor(ClassTypeDef thisType, Collection<ParameterDef> parameterDefs, Modifier... modifiers) {
         MethodDefBuilder builder = MethodDef.builder(CONSTRUCTOR);
         for (ParameterDef parameterDef : parameterDefs) {
             builder.addParameter(parameterDef);
@@ -84,6 +85,7 @@ public final class MethodDef extends AbstractElement {
                 parameterDef.asExpression()
             ));
         }
+        builder.addModifiers(modifiers);
         return builder.build();
     }
 

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
@@ -220,6 +220,12 @@ public sealed interface TypeDef permits ClassTypeDef, TypeDef.Array, TypeDef.Pri
         if (classElement.isPrimitive()) {
             return primitive(classElement.getName());
         }
+        if (classElement instanceof GenericPlaceholderElement placeholderElement) {
+            return new TypeVariable(
+                placeholderElement.getVariableName(),
+                placeholderElement.getBounds().stream().map(TypeDef::of).toList()
+            );
+        }
         if (classElement instanceof WildcardElement wildcardElement) {
             return new Wildcard(
                 wildcardElement.getUpperBounds().stream().map(TypeDef::of).toList(),

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
@@ -403,6 +403,17 @@ public sealed interface TypeDef permits ClassTypeDef, TypeDef.Array, TypeDef.Pri
             this(name, List.of());
         }
 
+        public static TypeVariable of(String name, ClassElement classElement) {
+            if (classElement instanceof GenericPlaceholderElement placeholderElement) {
+                return new TypeVariable(
+                    name,
+                    placeholderElement.getBounds().stream().map(TypeDef::of).toList()
+                );
+            } else {
+                return new TypeVariable(name);
+            }
+        }
+
     }
 
     /**

--- a/src/main/docs/guide/annotations/delegate.adoc
+++ b/src/main/docs/guide/annotations/delegate.adoc
@@ -1,0 +1,25 @@
+If you annotate a Java interface with `@Delegate`, a `<type>Delegate` abstract class is generated at compilation-time.
+
+[source,java]
+----
+include::test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/Worker.java[tags=clazz,indent=0]
+----
+
+[source,java]
+----
+include::test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/SimpleWorker.java[tags=clazz,indent=0]
+----
+
+You can use a delegate pattern to change the behavior of a Worker delegatee:
+
+[source,java]
+----
+include::test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/OvertimeWorker.java[tags=clazz,indent=0]
+----
+
+The delegate will delegate the behavior to inner object except for changed methods:
+
+[source,java]
+----
+include::test-suite-java/src/test/java/io/micronaut/sourcegen/example/delegate/DelegateWorkerTest.java[tags=test,indent=0]
+----

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -11,5 +11,6 @@ annotations:
   singular: Singular
   toString: ToString
   equalsAndHashCode: Equals and HashCode
+  delegate: Delegate
 repository: Repository
 

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/OvertimeWorker.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/OvertimeWorker.java
@@ -18,9 +18,9 @@ package io.micronaut.sourcegen.example.delegate;
 /**
  * An implementation of worker interface
  */
-public class OvertimeWorker extends WorkerDelegate {
+public class OvertimeWorker<T> extends WorkerDelegate<T> {
 
-    OvertimeWorker(Worker delegatee) {
+    OvertimeWorker(Worker<T> delegatee) {
         super(delegatee);
     }
 

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/OvertimeWorker.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/OvertimeWorker.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example.delegate;
+
+/**
+ * An implementation of worker interface
+ */
+public class OvertimeWorker extends WorkerDelegate {
+
+    OvertimeWorker(Worker delegatee) {
+        super(delegatee);
+    }
+
+    @Override
+    public double tasksPerDay() {
+        return super.tasksPerDay() * 1.2;
+    }
+}

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/OvertimeWorker.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/OvertimeWorker.java
@@ -15,8 +15,9 @@
  */
 package io.micronaut.sourcegen.example.delegate;
 
+// tag::clazz[]
 /**
- * An implementation of worker interface
+ * A delegate changing tasks per day.
  */
 public class OvertimeWorker<T> extends WorkerDelegate<T> {
 
@@ -29,3 +30,4 @@ public class OvertimeWorker<T> extends WorkerDelegate<T> {
         return super.tasksPerDay() * 1.2;
     }
 }
+// end::clazz[]

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/RobotWorker.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/RobotWorker.java
@@ -16,18 +16,21 @@
 package io.micronaut.sourcegen.example.delegate;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * An implementation of worker interface
  */
-public record RobotWorker(
+public record RobotWorker<T>(
     String name,
     double tasksPerDay,
-    List<String> competencies
-) implements Worker {
+    List<String> competencies,
+    T currentTask,
+    Set<?> complaints
+) implements Worker<T> {
 
     @Override
-    public boolean canComplete(List<String> tasks) {
+    public boolean canComplete(List<T> tasks) {
         return tasks.size() <= tasksPerDay;
     }
 

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/RobotWorker.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/RobotWorker.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example.delegate;
+
+import java.util.List;
+
+/**
+ * An implementation of worker interface
+ */
+public record RobotWorker(
+    String name,
+    double tasksPerDay,
+    List<String> competencies
+) implements Worker {
+
+    @Override
+    public boolean canComplete(List<String> tasks) {
+        return tasks.size() <= tasksPerDay;
+    }
+
+}

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/SimpleWorker.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/SimpleWorker.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.sourcegen.example.delegate;
 
+// tag::clazz[]
 /**
  * A simple worker interface.
  */
@@ -25,3 +26,4 @@ public interface SimpleWorker {
     double tasksPerDay();
 
 }
+// end::clazz[]

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/SimpleWorker.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/SimpleWorker.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example.delegate;
+
+/**
+ * A simple worker interface.
+ */
+public interface SimpleWorker {
+
+    String name();
+
+    double tasksPerDay();
+
+}

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/Worker.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/Worker.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example.delegate;
+
+import io.micronaut.sourcegen.annotations.Delegate;
+
+import java.util.List;
+
+/**
+ * A worker interface that delegate will be generated for.
+ */
+@Delegate
+public interface Worker extends SimpleWorker {
+
+    String name();
+
+    boolean canComplete(List<String> tasks);
+
+    List<String> competencies();
+
+}

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/Worker.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/Worker.java
@@ -18,17 +18,22 @@ package io.micronaut.sourcegen.example.delegate;
 import io.micronaut.sourcegen.annotations.Delegate;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * A worker interface that delegate will be generated for.
  */
 @Delegate
-public interface Worker extends SimpleWorker {
+public interface Worker<T> extends SimpleWorker {
 
     String name();
 
-    boolean canComplete(List<String> tasks);
+    boolean canComplete(List<T> tasks);
+
+    T currentTask();
 
     List<String> competencies();
+
+    Set<?> complaints();
 
 }

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/Worker.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/delegate/Worker.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.sourcegen.example.delegate;
 
+//tag::clazz[]
 import io.micronaut.sourcegen.annotations.Delegate;
 
 import java.util.List;
@@ -37,3 +38,4 @@ public interface Worker<T> extends SimpleWorker {
     Set<?> complaints();
 
 }
+//end::clazz[]

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/delegate/DelegateWorkerTest.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/delegate/DelegateWorkerTest.java
@@ -26,6 +26,7 @@ class DelegateWorkerTest {
 
     @Test
     void test() {
+        // tag::test[]
         OvertimeWorker<String> worker = new OvertimeWorker<>(new RobotWorker<String>(
             "robot",
             10,
@@ -38,6 +39,7 @@ class DelegateWorkerTest {
         assertEquals(12, worker.tasksPerDay()); // increased because of delegate
         assertEquals(List.of("does everything"), worker.competencies());
         assertEquals("wash flowers", worker.currentTask());
+        // end::test[]
     }
 
 }

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/delegate/DelegateWorkerTest.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/delegate/DelegateWorkerTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example.delegate;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DelegateWorkerTest {
+
+    @Test
+    void test() {
+        OvertimeWorker worker = new OvertimeWorker(new RobotWorker(
+            "robot",
+            10,
+            List.of("does everything")
+        ));
+
+        assertEquals("robot", worker.name());
+        assertEquals(12, worker.tasksPerDay()); // increased because of delegate
+        assertEquals(List.of("does everything"), worker.competencies()); // increased because of delegate
+    }
+
+}

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/delegate/DelegateWorkerTest.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/delegate/DelegateWorkerTest.java
@@ -18,6 +18,7 @@ package io.micronaut.sourcegen.example.delegate;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -25,15 +26,18 @@ class DelegateWorkerTest {
 
     @Test
     void test() {
-        OvertimeWorker worker = new OvertimeWorker(new RobotWorker(
+        OvertimeWorker<String> worker = new OvertimeWorker<>(new RobotWorker<String>(
             "robot",
             10,
-            List.of("does everything")
+            List.of("does everything"),
+            "wash flowers",
+            Set.of()
         ));
 
         assertEquals("robot", worker.name());
         assertEquals(12, worker.tasksPerDay()); // increased because of delegate
         assertEquals(List.of("does everything"), worker.competencies());
+        assertEquals("wash flowers", worker.currentTask());
     }
 
 }

--- a/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/delegate/OvertimeWorker.kt
+++ b/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/delegate/OvertimeWorker.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example.delegate;
+
+/**
+ * An implementation of worker interface
+ */
+//class OvertimeWorker: WorkerDelegate {
+//
+//    constructor(delegatee: Worker) {
+//        super(delegatee)
+//    }
+//
+//    override public tasksPerDay(): Double {
+//        return super.tasksPerDay() * 1.2
+//    }
+//}

--- a/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/delegate/OvertimeWorker.kt
+++ b/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/delegate/OvertimeWorker.kt
@@ -18,13 +18,9 @@ package io.micronaut.sourcegen.example.delegate;
 /**
  * An implementation of worker interface
  */
-//class OvertimeWorker: WorkerDelegate {
-//
-//    constructor(delegatee: Worker) {
-//        super(delegatee)
-//    }
-//
-//    override public tasksPerDay(): Double {
-//        return super.tasksPerDay() * 1.2
-//    }
-//}
+class OvertimeWorker(delegatee: Worker) : WorkerDelegate(delegatee) {
+
+    override fun tasksPerDay(): Double {
+        return super.tasksPerDay() * 1.2
+    }
+}

--- a/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/delegate/OvertimeWorker.kt
+++ b/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/delegate/OvertimeWorker.kt
@@ -18,7 +18,7 @@ package io.micronaut.sourcegen.example.delegate;
 /**
  * An implementation of worker interface
  */
-class OvertimeWorker(delegatee: Worker) : WorkerDelegate(delegatee) {
+class OvertimeWorker<T>(delegatee: Worker<T>) : WorkerDelegate<T>(delegatee) {
 
     override fun tasksPerDay(): Double {
         return super.tasksPerDay() * 1.2

--- a/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/delegate/RobotWorker.kt
+++ b/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/delegate/RobotWorker.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example.delegate;
+
+/**
+ * An implementation of worker interface
+ */
+class RobotWorker (
+    var name: String,
+    var tasksPerDay: Double,
+    var competencies: List<String>
+) : Worker {
+
+    override fun name(): String {
+        return name
+    }
+
+    override fun competencies(): List<String> {
+        return competencies
+    }
+
+    override fun tasksPerDay(): Double {
+        return tasksPerDay
+    }
+
+    override fun canComplete(tasks: List<String>): Boolean {
+        return tasks.size <= tasksPerDay()
+    }
+
+}

--- a/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/delegate/RobotWorker.kt
+++ b/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/delegate/RobotWorker.kt
@@ -18,11 +18,12 @@ package io.micronaut.sourcegen.example.delegate;
 /**
  * An implementation of worker interface
  */
-class RobotWorker (
+class RobotWorker<T> (
     var name: String,
     var tasksPerDay: Double,
-    var competencies: List<String>
-) : Worker {
+    var competencies: List<String>,
+    var currentTask: T
+) : Worker<T> {
 
     override fun name(): String {
         return name
@@ -36,8 +37,12 @@ class RobotWorker (
         return tasksPerDay
     }
 
-    override fun canComplete(tasks: List<String>): Boolean {
+    override fun canComplete(tasks: List<T>): Boolean {
         return tasks.size <= tasksPerDay()
+    }
+
+    override fun currentTask(): T {
+        return currentTask
     }
 
 }

--- a/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/delegate/SimpleWorker.kt
+++ b/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/delegate/SimpleWorker.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example.delegate;
+
+/**
+ * A simple worker interface.
+ */
+interface SimpleWorker {
+
+    fun name(): String
+
+    fun tasksPerDay(): Double
+
+}

--- a/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/delegate/Worker.kt
+++ b/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/delegate/Worker.kt
@@ -21,12 +21,14 @@ import io.micronaut.sourcegen.annotations.Delegate;
  * A worker interface that delegate will be generated for.
  */
 @Delegate
-interface Worker: SimpleWorker {
+interface Worker<T>: SimpleWorker {
 
     override fun name(): String
 
-    fun canComplete(tasks: List<String>): Boolean
+    fun canComplete(tasks: List<T>): Boolean
 
     fun competencies(): List<String>
+
+    fun currentTask(): T
 
 }

--- a/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/delegate/Worker.kt
+++ b/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/delegate/Worker.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example.delegate;
+
+import io.micronaut.sourcegen.annotations.Delegate;
+
+/**
+ * A worker interface that delegate will be generated for.
+ */
+@Delegate
+interface Worker: SimpleWorker {
+
+    override fun name(): String
+
+    fun canComplete(tasks: List<String>): Boolean
+
+    fun competencies(): List<String>
+
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/sourcegen/example/delegate/DelegateWorkerTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/sourcegen/example/delegate/DelegateWorkerTest.kt
@@ -22,15 +22,17 @@ internal class DelegateWorkerTest {
 
     @Test
     fun test() {
-        val worker = OvertimeWorker(RobotWorker(
+        val worker = OvertimeWorker<String>(RobotWorker<String>(
             "robot",
             10.0,
-            listOf("does everything")
+            listOf("does everything"),
+            "water flowers"
         ))
 
         Assertions.assertEquals("robot", worker.name())
         Assertions.assertEquals(12.0, worker.tasksPerDay()) // increased because of delegate
         Assertions.assertEquals(listOf("does everything"), worker.competencies())
+        Assertions.assertEquals("water flowers", worker.currentTask())
     }
 
 }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/sourcegen/example/delegate/DelegateWorkerTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/sourcegen/example/delegate/DelegateWorkerTest.kt
@@ -15,25 +15,22 @@
  */
 package io.micronaut.sourcegen.example.delegate;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-class DelegateWorkerTest {
+internal class DelegateWorkerTest {
 
     @Test
-    void test() {
-        OvertimeWorker worker = new OvertimeWorker(new RobotWorker(
+    fun test() {
+        val worker = OvertimeWorker(RobotWorker(
             "robot",
-            10,
-            List.of("does everything")
-        ));
+            10.0,
+            listOf("does everything")
+        ))
 
-        assertEquals("robot", worker.name());
-        assertEquals(12, worker.tasksPerDay()); // increased because of delegate
-        assertEquals(List.of("does everything"), worker.competencies());
+        Assertions.assertEquals("robot", worker.name())
+        Assertions.assertEquals(12.0, worker.tasksPerDay()) // increased because of delegate
+        Assertions.assertEquals(listOf("does everything"), worker.competencies())
     }
 
 }


### PR DESCRIPTION
### Feature description

The change allows generating classes implementing delegation/wrapper pattern.

An example of generated class would be:
```java
public abstract class WorkerDelegate implements Worker {
  Worker delegatee;

  WorkerDelegate(Worker delegatee) {
    this.delegatee = delegatee;
  }

  @Override
  public double tasksPerDay() {
    return this.delegatee.tasksPerDay();
  }

  @Override
  public String name() {
    return this.delegatee.name();
  }

  @Override
  public boolean canComplete(List<String> tasks) {
    return this.delegatee.canComplete(tasks);
  }

  @Override
  public List<String> competencies() {
    return this.delegatee.competencies();
  }
}
```

User would then extend it to customize only some of the behavior, like:
```java
public class OvertimeWorker extends WorkerDelegate {

    OvertimeWorker(Worker delegatee) {
        super(delegatee);
    }

    @Override
    public double tasksPerDay() {
        return super.tasksPerDay() * 1.2;
    }
}
```

For Kotlin:
```kotlin
public abstract class WorkerDelegate : Worker {
  public var delegatee: Worker

  public constructor(delegatee: Worker) {
    this. delegatee = delegatee
  }

  public override fun tasksPerDay(): Double {
    return this. delegatee.tasksPerDay()
  }

  public override fun name(): String {
    return this. delegatee.name()
  }

  public override fun canComplete(tasks: List<String>): Boolean {
    return this. delegatee.canComplete(tasks)
  }

  public override fun competencies(): List<String> {
    return this. delegatee.competencies()
  }
}
```

### Issues

We do not seem to support generic parameters for methods very well, so that is not supported. Class generic parameters are also not supported.