### PR TITLE
Improving enum capabilities

### DIFF
--- a/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
+++ b/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.sourcegen;
 
+import com.github.javaparser.utils.Pair;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.naming.NameUtils;
@@ -65,6 +66,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.IntStream;
+
+import static io.micronaut.sourcegen.javapoet.TypeSpec.anonymousClassBuilder;
 
 /**
  * The Java source generator.
@@ -154,8 +157,12 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
             enumBuilder.addAnnotation(asAnnotationSpec(annotation));
         }
 
-        for (String enumConstant : enumDef.getEnumConstants()) {
-            enumBuilder.addEnumConstant(enumConstant);
+        for (Pair<String,Object> enumConstant : enumDef.getEnumConstants()) {
+            if (enumConstant.b != null) {
+                enumBuilder.addEnumConstant(enumConstant.a, anonymousClassBuilder(enumConstant.b.toString()).build());
+            } else {
+                enumBuilder.addEnumConstant(enumConstant.a);
+            }
         }
 
         for (MethodDef method : enumDef.getMethods()) {

--- a/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
+++ b/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
@@ -169,9 +169,16 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
             enumBuilder.addAnnotation(asAnnotationSpec(annotation));
         }
 
-        enumDef.getEnumConstants().forEach((name, exp) -> {
-            if (exp != null) {
-                enumBuilder.addEnumConstant(name, anonymousClassBuilder(renderExpression(null, null, exp)).build());
+        enumDef.getEnumConstants().forEach((name, exps) -> {
+            if (exps != null) {
+                CodeBlock.Builder expBuilder = CodeBlock.builder();
+                for (int i = 0; i < exps.size(); i++) {
+                    expBuilder.add(renderExpression(null, null, exps.get(i)));
+                    if (i < exps.size() - 1) {
+                        expBuilder.add(", ");
+                    }
+                }
+                enumBuilder.addEnumConstant(name, anonymousClassBuilder(expBuilder.build()).build());
             } else {
                 enumBuilder.addEnumConstant(name);
             }

--- a/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
+++ b/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
@@ -291,12 +291,10 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
             ((ClassDef) objectDef).getFields() :
             ((EnumDef) objectDef).getFields();
         for (FieldDef field : fields) {
-            FieldSpec.Builder fieldBuilder = FieldSpec
-                .builder(
+            FieldSpec.Builder fieldBuilder = FieldSpec.builder(
                     asType(field.getType(), objectDef),
-                    field.getName())
-                .addModifiers(field.getModifiersArray())
-                .addModifiers(Modifier.PRIVATE, Modifier.FINAL);
+                    field.getName()
+                ).addModifiers(field.getModifiersArray());
             field.getInitializer().ifPresent(init ->
                 fieldBuilder.initializer(renderExpression(
                     null,
@@ -324,7 +322,7 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
             FieldSpec.Builder fieldBuilder = FieldSpec.builder(
                 propertyType,
                 propertyName
-            ).addModifiers(Modifier.PRIVATE, Modifier.FINAL);
+            ).addModifiers(Modifier.PRIVATE);
             for (AnnotationDef annotation : property.getAnnotations()) {
                 fieldBuilder.addAnnotation(
                     asAnnotationSpec(annotation)
@@ -338,7 +336,6 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
             String capitalizedPropertyName = NameUtils.capitalize(propertyName);
             builder.addMethod(MethodSpec.methodBuilder("get" + capitalizedPropertyName)
                 .addModifiers(property.getModifiersArray())
-                .addModifiers(Modifier.PUBLIC)
                 .returns(propertyType)
                 .addStatement("return this." + propertyName)
                 .build());

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/EnumWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/EnumWriteTest.java
@@ -49,6 +49,19 @@ public class EnumWriteTest {
             EnumDef.builder("test.Status").addEnumConstant("active").build());
         assertThrows(IllegalArgumentException.class, () ->
             EnumDef.builder("test.Status").addEnumConstant("9in progress", ExpressionDef.constant(1)).build());
+
+        EnumDef.EnumDefBuilder enumDefBuilder = EnumDef.builder("test.Status")
+            .addEnumConstant("ACTIVE", ExpressionDef.constant(2))
+            .addEnumConstant("IN_PROGRESS", ExpressionDef.constant(1))
+            .addEnumConstant("DELETED", ExpressionDef.constant(0));
+        assertThrows(IllegalStateException.class, enumDefBuilder::build);
+
+        enumDefBuilder.addNoFieldsConstructor(Modifier.PRIVATE);
+        assertThrows(IllegalStateException.class, enumDefBuilder::build);
+
+        enumDefBuilder.addField(FieldDef.builder("intValue").ofType(TypeDef.Primitive.INT).addModifiers(Modifier.PUBLIC).build())
+            .addAllFieldsConstructor(Modifier.PUBLIC);
+        assertThrows(IllegalStateException.class, enumDefBuilder::build);
     }
 
     @Test
@@ -57,6 +70,8 @@ public class EnumWriteTest {
             .addEnumConstant("ACTIVE", ExpressionDef.constant(2))
             .addEnumConstant("IN_PROGRESS", ExpressionDef.constant(1))
             .addEnumConstant("DELETED", ExpressionDef.constant(0))
+            .addField(FieldDef.builder("intValue").ofType(TypeDef.Primitive.INT).addModifiers(Modifier.PUBLIC).build())
+            .addAllFieldsConstructor(Modifier.PRIVATE)
             .build();
         var result = writeEnum(enumDef);
 
@@ -67,7 +82,13 @@ public class EnumWriteTest {
 
           ACTIVE(2),
           IN_PROGRESS(1),
-          DELETED(0)
+          DELETED(0);
+
+          public int intValue;
+
+          private Status(int intValue) {
+            this.intValue = intValue;
+          }
         }
         """;
         assertEquals(expected.strip(), result.strip());
@@ -79,6 +100,9 @@ public class EnumWriteTest {
             .addEnumConstant("ACTIVE", ExpressionDef.constant(2), ExpressionDef.trueValue())
             .addEnumConstant("IN_PROGRESS", ExpressionDef.constant(1), ExpressionDef.trueValue())
             .addEnumConstant("DELETED", ExpressionDef.constant(0), ExpressionDef.falseValue())
+            .addField(FieldDef.builder("intValue").ofType(TypeDef.Primitive.INT).addModifiers(Modifier.PUBLIC).build())
+            .addField(FieldDef.builder("boolValue").ofType(TypeDef.Primitive.BOOLEAN).addModifiers(Modifier.PUBLIC).build())
+            .addAllFieldsConstructor(Modifier.PRIVATE)
             .build();
         var result = writeEnum(enumDef);
 
@@ -89,7 +113,16 @@ public class EnumWriteTest {
 
           ACTIVE(2, true),
           IN_PROGRESS(1, true),
-          DELETED(0, false)
+          DELETED(0, false);
+
+          public int intValue;
+
+          public boolean boolValue;
+
+          private Status(int intValue, boolean boolValue) {
+            this.intValue = intValue;
+            this.boolValue = boolValue;
+          }
         }
         """;
         assertEquals(expected.strip(), result.strip());

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/EnumWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/EnumWriteTest.java
@@ -76,9 +76,9 @@ public class EnumWriteTest {
     @Test
     public void writeComplexEnumConstant2() throws IOException {
         EnumDef enumDef = EnumDef.builder("test.Status")
-            .addEnumConstant("ACTIVE", ExpressionDef.constant(2))
-            .addEnumConstant("IN_PROGRESS", ExpressionDef.constant(1))
-            .addEnumConstant("DELETED", ExpressionDef.constant(0))
+            .addEnumConstant("ACTIVE", ExpressionDef.constant(2), ExpressionDef.trueValue())
+            .addEnumConstant("IN_PROGRESS", ExpressionDef.constant(1), ExpressionDef.trueValue())
+            .addEnumConstant("DELETED", ExpressionDef.constant(0), ExpressionDef.falseValue())
             .build();
         var result = writeEnum(enumDef);
 
@@ -87,9 +87,9 @@ public class EnumWriteTest {
 
         enum Status {
 
-          ACTIVE(2),
-          IN_PROGRESS(1),
-          DELETED(0)
+          ACTIVE(2, true),
+          IN_PROGRESS(1, true),
+          DELETED(0, false)
         }
         """;
         assertEquals(expected.strip(), result.strip());

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/EnumWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/EnumWriteTest.java
@@ -136,7 +136,7 @@ public class EnumWriteTest {
             .addEnumConstant("active")
             .addEnumConstant("in-progress")
             .addEnumConstant("deleted")
-            .addProperty(PropertyDef.builder("value").ofType(TypeDef.STRING).build())
+            .addProperty(PropertyDef.builder("value").ofType(TypeDef.STRING).addModifiers(Modifier.PUBLIC).build())
             .build();
         var result = writeEnum(enumDef);
 
@@ -151,7 +151,7 @@ public class EnumWriteTest {
           IN_PROGRESS,
           DELETED;
 
-          private final String value;
+          private String value;
 
           public String getValue() {
             return this.value;
@@ -187,7 +187,7 @@ public class EnumWriteTest {
           IN_PROGRESS,
           DELETED;
 
-          private final String value;
+          String value;
 
           public String getValue() {
             return "value";

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/EnumWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/EnumWriteTest.java
@@ -3,6 +3,7 @@ package io.micronaut.sourcegen.javapoet.write;
 import io.micronaut.sourcegen.JavaPoetSourceGenerator;
 import io.micronaut.sourcegen.model.EnumDef;
 import io.micronaut.sourcegen.model.ExpressionDef;
+import io.micronaut.sourcegen.model.FieldDef;
 import io.micronaut.sourcegen.model.MethodDef;
 import io.micronaut.sourcegen.model.PropertyDef;
 import io.micronaut.sourcegen.model.StatementDef;
@@ -152,8 +153,8 @@ public class EnumWriteTest {
 
           private final String value;
 
-          public Status(String value) {
-            this.value = value;
+          public String getValue() {
+            return this.value;
           }
         }
         """;
@@ -166,7 +167,7 @@ public class EnumWriteTest {
             .addEnumConstant("active")
             .addEnumConstant("in-progress")
             .addEnumConstant("deleted")
-            .addProperty(PropertyDef.builder("value").ofType(TypeDef.STRING).build())
+            .addField(FieldDef.builder("value").ofType(TypeDef.STRING).build())
             .addMethod(MethodDef.builder("getValue")
                 .returns(TypeDef.STRING)
                 .addModifiers(Modifier.PUBLIC)
@@ -187,10 +188,6 @@ public class EnumWriteTest {
           DELETED("deleted");
 
           private final String value;
-
-          public Status(String value) {
-            this.value = value;
-          }
 
           public String getValue() {
             return "value";

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/EnumWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/EnumWriteTest.java
@@ -1,0 +1,101 @@
+package io.micronaut.sourcegen.javapoet.write;
+
+import io.micronaut.sourcegen.JavaPoetSourceGenerator;
+import io.micronaut.sourcegen.model.EnumDef;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class EnumWriteTest {
+    @Test
+    public void writeSimpleEnum() throws IOException {
+        EnumDef enumDef = EnumDef.builder("test.Status")
+            .addEnumConstant("ACTIVE")
+            .addEnumConstant("IN_PROGRESS")
+            .addEnumConstant("DELETED")
+            .build();
+        var result = writeEnum(enumDef);
+
+        var expected = """
+        package test;
+
+        enum Status {
+
+          ACTIVE,
+          IN_PROGRESS,
+          DELETED
+        }
+        """;
+        assertEquals(expected.strip(), result.strip());
+    }
+
+    @Test
+    public void writeComplexEnumConstant() throws IOException {
+        EnumDef enumDef = EnumDef.builder("test.Status")
+            .addEnumConstant("ACTIVE", "active")
+            .addEnumConstant("IN_PROGRESS", "in progress")
+            .addEnumConstant("DELETED", "deleted")
+            .build();
+        var result = writeEnum(enumDef);
+
+        var expected = """
+        package test;
+
+        enum Status {
+
+          ACTIVE,
+          IN_PROGRESS,
+          DELETED
+        }
+        """;
+        assertEquals(expected.strip(), result.strip());
+    }
+
+    @Test
+    public void writeComplexEnumConstant2() throws IOException {
+        EnumDef enumDef = EnumDef.builder("test.Status")
+            .addEnumConstant("ACTIVE", 2)
+            .addEnumConstant("IN_PROGRESS", 1)
+            .addEnumConstant("DELETED", 0)
+            .build();
+        var result = writeEnum(enumDef);
+
+        var expected = """
+        package test;
+
+        enum Status {
+
+          ACTIVE,
+          IN_PROGRESS,
+          DELETED
+        }
+        """;
+        assertEquals(expected.strip(), result.strip());
+    }
+
+    private String writeEnum(EnumDef enumDef) throws IOException {
+        JavaPoetSourceGenerator generator = new JavaPoetSourceGenerator();
+        String result;
+        try (StringWriter writer = new StringWriter()) {
+            generator.write(enumDef, writer);
+            result = writer.toString();
+        }
+
+        // The regex will skip the imports and make sure it is a record
+        final Pattern ENUM_REGEX = Pattern.compile("package [^;]+;[^/]+" +
+            "enum " + enumDef.getSimpleName() + " \\{\\s+" +
+            "([\\s\\S]+)\\s+}\\s+");
+        Matcher matcher = ENUM_REGEX.matcher(result);
+        if (!matcher.matches()) {
+            fail("Expected enum to match regex: \n" + ENUM_REGEX + "\nbut is: \n" + result);
+        }
+        return matcher.group(0);
+    }
+
+}

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/EnumWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/EnumWriteTest.java
@@ -2,6 +2,9 @@ package io.micronaut.sourcegen.javapoet.write;
 
 import io.micronaut.sourcegen.JavaPoetSourceGenerator;
 import io.micronaut.sourcegen.model.EnumDef;
+import io.micronaut.sourcegen.model.ExpressionDef;
+import io.micronaut.sourcegen.model.PropertyDef;
+import io.micronaut.sourcegen.model.TypeDef;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -38,9 +41,9 @@ public class EnumWriteTest {
     @Test
     public void writeComplexEnumConstant() throws IOException {
         EnumDef enumDef = EnumDef.builder("test.Status")
-            .addEnumConstant("ACTIVE", "active")
-            .addEnumConstant("IN_PROGRESS", "in progress")
-            .addEnumConstant("DELETED", "deleted")
+            .addEnumConstant("active")
+            .addEnumConstant("in-progress")
+            .addEnumConstant("deleted")
             .build();
         var result = writeEnum(enumDef);
 
@@ -49,9 +52,9 @@ public class EnumWriteTest {
 
         enum Status {
 
-          ACTIVE,
-          IN_PROGRESS,
-          DELETED
+          ACTIVE("active"),
+          IN_PROGRESS("in-progress"),
+          DELETED("deleted")
         }
         """;
         assertEquals(expected.strip(), result.strip());
@@ -60,9 +63,9 @@ public class EnumWriteTest {
     @Test
     public void writeComplexEnumConstant2() throws IOException {
         EnumDef enumDef = EnumDef.builder("test.Status")
-            .addEnumConstant("ACTIVE", 2)
-            .addEnumConstant("IN_PROGRESS", 1)
-            .addEnumConstant("DELETED", 0)
+            .addEnumConstant("ACTIVE", ExpressionDef.constant(2))
+            .addEnumConstant("IN_PROGRESS", ExpressionDef.constant(1))
+            .addEnumConstant("DELETED", ExpressionDef.constant(0))
             .build();
         var result = writeEnum(enumDef);
 
@@ -71,13 +74,45 @@ public class EnumWriteTest {
 
         enum Status {
 
-          ACTIVE,
-          IN_PROGRESS,
-          DELETED
+          ACTIVE(2),
+          IN_PROGRESS(1),
+          DELETED(0)
         }
         """;
         assertEquals(expected.strip(), result.strip());
     }
+
+    @Test
+    public void writeComplexEnumWithProperty() throws IOException {
+        EnumDef enumDef = EnumDef.builder("test.Status")
+            .addEnumConstant("active")
+            .addEnumConstant("in-progress")
+            .addEnumConstant("deleted")
+            .addProperty(PropertyDef.builder("value").ofType(TypeDef.STRING).build())
+            .build();
+        var result = writeEnum(enumDef);
+
+        var expected = """
+        package test;
+
+        import java.lang.String;
+
+        enum Status {
+
+          ACTIVE("active"),
+          IN_PROGRESS("in-progress"),
+          DELETED("deleted");
+
+          private final String value;
+
+          public Status(String value) {
+            this.value = value;
+          }
+        }
+        """;
+        assertEquals(expected.strip(), result.strip());
+    }
+
 
     private String writeEnum(EnumDef enumDef) throws IOException {
         JavaPoetSourceGenerator generator = new JavaPoetSourceGenerator();

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/EnumWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/EnumWriteTest.java
@@ -3,10 +3,13 @@ package io.micronaut.sourcegen.javapoet.write;
 import io.micronaut.sourcegen.JavaPoetSourceGenerator;
 import io.micronaut.sourcegen.model.EnumDef;
 import io.micronaut.sourcegen.model.ExpressionDef;
+import io.micronaut.sourcegen.model.MethodDef;
 import io.micronaut.sourcegen.model.PropertyDef;
+import io.micronaut.sourcegen.model.StatementDef;
 import io.micronaut.sourcegen.model.TypeDef;
 import org.junit.Test;
 
+import javax.lang.model.element.Modifier;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.regex.Matcher;
@@ -83,6 +86,50 @@ public class EnumWriteTest {
     }
 
     @Test
+    public void writeComplexEnumConstant3() throws IOException {
+        EnumDef enumDef = EnumDef.builder("test.Status")
+            .addEnumConstant("active", ExpressionDef.constant(2))
+            .addEnumConstant("in progress", ExpressionDef.constant(1))
+            .addEnumConstant("deleted", ExpressionDef.constant(0))
+            .build();
+        var result = writeEnum(enumDef);
+
+        var expected = """
+        package test;
+
+        enum Status {
+
+          ACTIVE(2),
+          IN_PROGRESS(1),
+          DELETED(0)
+        }
+        """;
+        assertEquals(expected.strip(), result.strip());
+    }
+
+    @Test
+    public void writeComplexEnumConstant4() throws IOException {
+        EnumDef enumDef = EnumDef.builder("test.Status")
+            .addEnumConstant("active_by heart")
+            .addEnumConstant("9 Jump in progress")
+            .addEnumConstant("isItEven deleted")
+            .build();
+        var result = writeEnum(enumDef);
+
+        var expected = """
+        package test;
+
+        enum Status {
+
+          ACTIVE_BY_HEART("active_by heart"),
+          JUMP_IN_PROGRESS("9 Jump in progress"),
+          IS_IT_EVEN_DELETED("isItEven deleted")
+        }
+        """;
+        assertEquals(expected.strip(), result.strip());
+    }
+
+    @Test
     public void writeComplexEnumWithProperty() throws IOException {
         EnumDef enumDef = EnumDef.builder("test.Status")
             .addEnumConstant("active")
@@ -107,6 +154,46 @@ public class EnumWriteTest {
 
           public Status(String value) {
             this.value = value;
+          }
+        }
+        """;
+        assertEquals(expected.strip(), result.strip());
+    }
+
+    @Test
+    public void writeComplexEnumWithPropertyMethod() throws IOException {
+        EnumDef enumDef = EnumDef.builder("test.Status")
+            .addEnumConstant("active")
+            .addEnumConstant("in-progress")
+            .addEnumConstant("deleted")
+            .addProperty(PropertyDef.builder("value").ofType(TypeDef.STRING).build())
+            .addMethod(MethodDef.builder("getValue")
+                .returns(TypeDef.STRING)
+                .addModifiers(Modifier.PUBLIC)
+                .addStatement(new StatementDef.Return(ExpressionDef.constant("value")))
+                .build())
+            .build();
+        var result = writeEnum(enumDef);
+
+        var expected = """
+        package test;
+
+        import java.lang.String;
+
+        enum Status {
+
+          ACTIVE("active"),
+          IN_PROGRESS("in-progress"),
+          DELETED("deleted");
+
+          private final String value;
+
+          public Status(String value) {
+            this.value = value;
+          }
+
+          public String getValue() {
+            return "value";
           }
         }
         """;

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/EnumWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/EnumWriteTest.java
@@ -56,9 +56,9 @@ public class EnumWriteTest {
 
         enum Status {
 
-          ACTIVE("active"),
-          IN_PROGRESS("in-progress"),
-          DELETED("deleted")
+          ACTIVE,
+          IN_PROGRESS,
+          DELETED
         }
         """;
         assertEquals(expected.strip(), result.strip());
@@ -122,9 +122,9 @@ public class EnumWriteTest {
 
         enum Status {
 
-          ACTIVE_BY_HEART("active_by heart"),
-          JUMP_IN_PROGRESS("9 Jump in progress"),
-          IS_IT_EVEN_DELETED("isItEven deleted")
+          ACTIVE_BY_HEART,
+          JUMP_IN_PROGRESS,
+          IS_IT_EVEN_DELETED
         }
         """;
         assertEquals(expected.strip(), result.strip());
@@ -147,9 +147,9 @@ public class EnumWriteTest {
 
         enum Status {
 
-          ACTIVE("active"),
-          IN_PROGRESS("in-progress"),
-          DELETED("deleted");
+          ACTIVE,
+          IN_PROGRESS,
+          DELETED;
 
           private final String value;
 
@@ -183,9 +183,9 @@ public class EnumWriteTest {
 
         enum Status {
 
-          ACTIVE("active"),
-          IN_PROGRESS("in-progress"),
-          DELETED("deleted");
+          ACTIVE,
+          IN_PROGRESS,
+          DELETED;
 
           private final String value;
 

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/EnumWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/EnumWriteTest.java
@@ -17,6 +17,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 public class EnumWriteTest {
@@ -43,11 +44,19 @@ public class EnumWriteTest {
     }
 
     @Test
+    public void testExceptions() {
+        assertThrows(IllegalArgumentException.class, () ->
+            EnumDef.builder("test.Status").addEnumConstant("active").build());
+        assertThrows(IllegalArgumentException.class, () ->
+            EnumDef.builder("test.Status").addEnumConstant("9in progress", ExpressionDef.constant(1)).build());
+    }
+
+    @Test
     public void writeComplexEnumConstant() throws IOException {
         EnumDef enumDef = EnumDef.builder("test.Status")
-            .addEnumConstant("active")
-            .addEnumConstant("in-progress")
-            .addEnumConstant("deleted")
+            .addEnumConstant("ACTIVE", ExpressionDef.constant(2))
+            .addEnumConstant("IN_PROGRESS", ExpressionDef.constant(1))
+            .addEnumConstant("DELETED", ExpressionDef.constant(0))
             .build();
         var result = writeEnum(enumDef);
 
@@ -56,9 +65,9 @@ public class EnumWriteTest {
 
         enum Status {
 
-          ACTIVE,
-          IN_PROGRESS,
-          DELETED
+          ACTIVE(2),
+          IN_PROGRESS(1),
+          DELETED(0)
         }
         """;
         assertEquals(expected.strip(), result.strip());
@@ -87,55 +96,11 @@ public class EnumWriteTest {
     }
 
     @Test
-    public void writeComplexEnumConstant3() throws IOException {
-        EnumDef enumDef = EnumDef.builder("test.Status")
-            .addEnumConstant("active", ExpressionDef.constant(2))
-            .addEnumConstant("in progress", ExpressionDef.constant(1))
-            .addEnumConstant("deleted", ExpressionDef.constant(0))
-            .build();
-        var result = writeEnum(enumDef);
-
-        var expected = """
-        package test;
-
-        enum Status {
-
-          ACTIVE(2),
-          IN_PROGRESS(1),
-          DELETED(0)
-        }
-        """;
-        assertEquals(expected.strip(), result.strip());
-    }
-
-    @Test
-    public void writeComplexEnumConstant4() throws IOException {
-        EnumDef enumDef = EnumDef.builder("test.Status")
-            .addEnumConstant("active_by heart")
-            .addEnumConstant("9 Jump in progress")
-            .addEnumConstant("isItEven deleted")
-            .build();
-        var result = writeEnum(enumDef);
-
-        var expected = """
-        package test;
-
-        enum Status {
-
-          ACTIVE_BY_HEART,
-          JUMP_IN_PROGRESS,
-          IS_IT_EVEN_DELETED
-        }
-        """;
-        assertEquals(expected.strip(), result.strip());
-    }
-
-    @Test
     public void writeComplexEnumWithProperty() throws IOException {
         EnumDef enumDef = EnumDef.builder("test.Status")
-            .addEnumConstant("active")
-            .addEnumConstant("in-progress")
-            .addEnumConstant("deleted")
+            .addEnumConstant("ACTIVE")
+            .addEnumConstant("IN_PROGRESS")
+            .addEnumConstant("DELETED")
             .addProperty(PropertyDef.builder("value").ofType(TypeDef.STRING).addModifiers(Modifier.PUBLIC).build())
             .build();
         var result = writeEnum(enumDef);
@@ -164,9 +129,9 @@ public class EnumWriteTest {
     @Test
     public void writeComplexEnumWithPropertyMethod() throws IOException {
         EnumDef enumDef = EnumDef.builder("test.Status")
-            .addEnumConstant("active")
-            .addEnumConstant("in-progress")
-            .addEnumConstant("deleted")
+            .addEnumConstant("ACTIVE")
+            .addEnumConstant("IN_PROGRESS")
+            .addEnumConstant("DELETED")
             .addField(FieldDef.builder("value").ofType(TypeDef.STRING).build())
             .addMethod(MethodDef.builder("getValue")
                 .returns(TypeDef.STRING)

--- a/sourcegen-generator-kotlin/build.gradle.kts
+++ b/sourcegen-generator-kotlin/build.gradle.kts
@@ -7,4 +7,14 @@ dependencies {
     implementation(projects.sourcegenGenerator)
     implementation(libs.managed.kotlinpoet)
     implementation(libs.managed.kotlinpoet.javapoet)
+
+    testImplementation(mnTest.micronaut.test.junit5)
+    testImplementation(libs.junit.jupiter.engine)
+}
+
+tasks.withType(Test::class).configureEach {
+    useJUnit()
+    predictiveSelection {
+        enabled = false
+    }
 }

--- a/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
+++ b/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
@@ -160,68 +160,8 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             .forEach { annotationSpec: AnnotationSpec -> classBuilder.addAnnotation(annotationSpec) }
 
         var companionBuilder: TypeSpec.Builder? = null
-        val notNullProperties: MutableList<PropertyDef> = ArrayList()
-        for (property in classDef.properties) {
-            var propertySpec: PropertySpec
-            if (property.type.isNullable) {
-                propertySpec = buildProperty(
-                    property.name,
-                    property.type.makeNullable(),
-                    property.modifiers,
-                    property.annotations,
-                    property.javadoc,
-                    null,
-                    classDef
-                )
-            } else {
-                propertySpec = buildConstructorProperty(
-                    property.name,
-                    property.type,
-                    property.modifiers,
-                    property.annotations,
-                    property.javadoc,
-                    classDef
-                )
-                notNullProperties.add(property)
-            }
-            classBuilder.addProperty(
-                propertySpec
-            )
-        }
-        if (notNullProperties.isNotEmpty()) {
-            classBuilder.primaryConstructor(
-                FunSpec.constructorBuilder().addModifiers(KModifier.PUBLIC).addParameters(
-                    notNullProperties.stream()
-                        .map { prop: PropertyDef ->
-                            ParameterSpec.builder(
-                                prop.name,
-                                asType(prop.type, classDef)
-                            ).build()
-                        }.toList()
-                ).build()
-            )
-        }
-        for (field in classDef.fields) {
-            val modifiers = field.modifiers
-            if (modifiers.contains(Modifier.STATIC)) {
-                if (companionBuilder == null) {
-                    companionBuilder = TypeSpec.companionObjectBuilder()
-                }
-                companionBuilder.addProperty(
-                    buildProperty(field, stripStatic(modifiers), field.javadoc, classDef)
-                )
-            } else {
-                if (field.type.isNullable) {
-                    classBuilder.addProperty(
-                        buildProperty(field, modifiers, field.javadoc, classDef)
-                    )
-                } else {
-                    classBuilder.addProperty(
-                        buildProperty(field, modifiers, field.javadoc, classDef)
-                    )
-                }
-            }
-        }
+        buildProperties(classDef, classBuilder)
+        companionBuilder = buildFields(classDef, companionBuilder, classBuilder)
 
         for (method in classDef.methods) {
             var modifiers = method.modifiers
@@ -343,6 +283,9 @@ class KotlinPoetSourceGenerator : SourceGenerator {
         }
 
         var companionBuilder: TypeSpec.Builder? = null
+        buildProperties(enumDef, enumBuilder)
+        companionBuilder = buildFields(enumDef, companionBuilder, enumBuilder)
+
         for (method in enumDef.methods) {
             var modifiers = method.modifiers
             if (modifiers.contains(Modifier.STATIC)) {
@@ -366,6 +309,90 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             .addType(enumBuilder.build())
             .build()
             .writeTo(writer)
+    }
+
+    private fun buildProperties(
+        objectDef: ObjectDef,
+        builder: TypeSpec.Builder
+    ) {
+        val notNullProperties: MutableList<PropertyDef> = ArrayList()
+        for (property in objectDef.properties) {
+            var propertySpec: PropertySpec
+            if (property.type.isNullable) {
+                propertySpec = buildProperty(
+                    property.name,
+                    property.type.makeNullable(),
+                    property.modifiers,
+                    property.annotations,
+                    property.javadoc,
+                    null,
+                    objectDef
+                )
+            } else {
+                propertySpec = buildConstructorProperty(
+                    property.name,
+                    property.type,
+                    property.modifiers,
+                    property.annotations,
+                    property.javadoc,
+                    objectDef
+                )
+                notNullProperties.add(property)
+            }
+            builder.addProperty(
+                propertySpec
+            )
+        }
+        if (notNullProperties.isNotEmpty()) {
+            builder.primaryConstructor(
+                FunSpec.constructorBuilder().addModifiers(KModifier.PUBLIC).addParameters(
+                    notNullProperties.stream()
+                        .map { prop: PropertyDef ->
+                            ParameterSpec.builder(
+                                prop.name,
+                                asType(prop.type, objectDef)
+                            ).build()
+                        }.toList()
+                ).build()
+            )
+        }
+    }
+
+    private fun buildFields(
+        objectDef: ObjectDef,
+        companionBuilder: TypeSpec.Builder?,
+        builder: TypeSpec.Builder
+    ): TypeSpec.Builder? {
+        var companionBuilderTmp = companionBuilder
+        var fields: List<FieldDef>
+        if (objectDef is ClassDef)
+            fields = objectDef.fields
+        else if (objectDef is EnumDef)
+            fields = objectDef.fields
+        else return builder
+
+        for (field in fields) {
+            val modifiers = field.modifiers
+            if (modifiers.contains(Modifier.STATIC)) {
+                if (companionBuilderTmp == null) {
+                    companionBuilderTmp = TypeSpec.companionObjectBuilder()
+                }
+                companionBuilderTmp.addProperty(
+                    buildProperty(field, stripStatic(modifiers), field.javadoc, objectDef)
+                )
+            } else {
+                if (field.type.isNullable) {
+                    builder.addProperty(
+                        buildProperty(field, modifiers, field.javadoc, objectDef)
+                    )
+                } else {
+                    builder.addProperty(
+                        buildProperty(field, modifiers, field.javadoc, objectDef)
+                    )
+                }
+            }
+        }
+        return companionBuilderTmp
     }
 
     private fun buildProperty(
@@ -496,6 +523,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             return mutable
         }
 
+        @OptIn(KotlinPoetJavaPoetPreview::class)
         private fun asClassName(classType: ClassTypeDef): ClassName {
             val packageName = classType.packageName
             val simpleName = classType.simpleName

--- a/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
+++ b/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
@@ -1210,6 +1210,8 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 checkNotNull(objectDef) { "Field 'this' is not available" }
                 if (objectDef is ClassDef) {
                     objectDef.getField(variableDef.name) // Check if exists
+                } else if (objectDef is EnumDef) {
+                    objectDef.getField(variableDef.name) // Check if exists
                 } else {
                     throw IllegalStateException("Field access no supported on the object definition: $objectDef")
                 }

--- a/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
+++ b/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
@@ -274,7 +274,9 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 enumBuilder.addEnumConstant(
                     name,
                     TypeSpec.anonymousClassBuilder()
-                        .addInitializerBlock(renderExpressionCode(null, MethodDef.builder("").build(), exp))
+                        .addInitializerBlock(renderExpressionCode(null,
+                            MethodDef.builder("").returns(TypeDef.VOID).build(),
+                            exp))
                         .build()
                 )
             } else {

--- a/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
+++ b/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
@@ -299,8 +299,8 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             if (exp != null) {
                 enumBuilder.addEnumConstant(
                     name,
-                    TypeSpec.anonymousClassBuilder()
-                        .addInitializerBlock(renderExpressionCode(null,
+                    TypeSpec.companionObjectBuilder().addSuperclassConstructorParameter(
+                        renderExpressionCode(null,
                             MethodDef.builder("").returns(TypeDef.VOID).build(),
                             exp))
                         .build()

--- a/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/EnumWriteTest.kt
+++ b/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/EnumWriteTest.kt
@@ -33,30 +33,18 @@ class EnumWriteTest {
     }
 
     @Test
-    @Throws(IOException::class)
-    fun writeComplexEnumConstant() {
-        val enumDef = EnumDef.builder("test.Status")
-            .addEnumConstant("active")
-            .addEnumConstant("in-progress")
-            .addEnumConstant("deleted")
-            .build()
-        val result = writeEnum(enumDef)
-
-        val expected = """
-        package test
-
-        public enum class Status {
-          ACTIVE,
-          IN_PROGRESS,
-          DELETED,
-        }
-        """.trimIndent()
-        Assert.assertEquals(expected.trim(), result.trim())
+    fun testExceptions() {
+        Assert.assertThrows(
+            IllegalArgumentException::class.java
+        ) { EnumDef.builder("test.Status").addEnumConstant("active").build() }
+        Assert.assertThrows(
+            IllegalArgumentException::class.java
+        ) { EnumDef.builder("test.Status").addEnumConstant("9in progress", ExpressionDef.constant(1)).build() }
     }
 
     @Test
     @Throws(IOException::class)
-    fun writeComplexEnumConstant2() {
+    fun writeComplexEnumConstant() {
         val enumDef = EnumDef.builder("test.Status")
             .addEnumConstant("ACTIVE", ExpressionDef.constant(2))
             .addEnumConstant("IN_PROGRESS", ExpressionDef.constant(1))
@@ -79,57 +67,11 @@ class EnumWriteTest {
 
     @Test
     @Throws(IOException::class)
-    fun writeComplexEnumConstant3() {
-        val enumDef = EnumDef.builder("test.Status")
-            .addEnumConstant("active", ExpressionDef.constant(2))
-            .addEnumConstant("in progress", ExpressionDef.constant(1))
-            .addEnumConstant("deleted", ExpressionDef.constant(0))
-            .build()
-        val result = writeEnum(enumDef)
-
-        val expected = """
-        package test
-
-        public enum class Status {
-          ACTIVE(2),
-          IN_PROGRESS(1),
-          DELETED(0),
-        }
-
-        """.trimIndent()
-        Assert.assertEquals(expected.trim(), result.trim())
-    }
-
-    @Test
-    @Throws(IOException::class)
-    fun writeComplexEnumConstant4() {
-        val enumDef = EnumDef.builder("test.Status")
-            .addEnumConstant("active_by heart")
-            .addEnumConstant("9 Jump in progress")
-            .addEnumConstant("isItEven deleted")
-            .build()
-        val result = writeEnum(enumDef)
-
-        val expected = """
-        package test
-
-        public enum class Status {
-          ACTIVE_BY_HEART,
-          JUMP_IN_PROGRESS,
-          IS_IT_EVEN_DELETED,
-        }
-
-        """.trimIndent()
-        Assert.assertEquals(expected.trim(), result.trim())
-    }
-
-    @Test
-    @Throws(IOException::class)
     fun writeComplexEnumWithProperty() {
         val enumDef = EnumDef.builder("test.Status")
-            .addEnumConstant("active")
-            .addEnumConstant("in-progress")
-            .addEnumConstant("deleted")
+            .addEnumConstant("ACTIVE")
+            .addEnumConstant("IN_PROGRESS")
+            .addEnumConstant("DELETED")
             .addProperty(PropertyDef.builder("strValue").ofType(TypeDef.STRING).build())
             .build()
         val generator = KotlinPoetSourceGenerator()
@@ -160,9 +102,9 @@ class EnumWriteTest {
     @Throws(IOException::class)
     fun writeComplexEnumWithFieldMethod() {
         val enumDef = EnumDef.builder("test.Status")
-            .addEnumConstant("active")
-            .addEnumConstant("in-progress")
-            .addEnumConstant("deleted")
+            .addEnumConstant("ACTIVE")
+            .addEnumConstant("IN_PROGRESS")
+            .addEnumConstant("DELETED")
             .addField(FieldDef.builder("strValue").ofType(TypeDef.STRING).build())
             .addMethod(
                 MethodDef.builder("getValue")

--- a/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/EnumWriteTest.kt
+++ b/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/EnumWriteTest.kt
@@ -1,0 +1,214 @@
+package io.micronaut.sourcegen
+
+import io.micronaut.sourcegen.model.*
+import org.junit.Assert
+import org.junit.Test
+import java.io.IOException
+import java.io.StringWriter
+import java.util.regex.Pattern
+import javax.lang.model.element.Modifier
+
+class EnumWriteTest {
+    @Test
+    @Throws(IOException::class)
+    fun writeSimpleEnum() {
+        val enumDef = EnumDef.builder("test.Status")
+            .addEnumConstant("ACTIVE")
+            .addEnumConstant("IN_PROGRESS")
+            .addEnumConstant("DELETED")
+            .build()
+        val result = writeEnum(enumDef)
+
+        val expected = """
+        package test
+
+        public enum class Status {
+          ACTIVE,
+          IN_PROGRESS,
+          DELETED,
+        }
+
+        """.trimIndent()
+        Assert.assertEquals(expected.trim(), result.trim())
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun writeComplexEnumConstant() {
+        val enumDef = EnumDef.builder("test.Status")
+            .addEnumConstant("active")
+            .addEnumConstant("in-progress")
+            .addEnumConstant("deleted")
+            .build()
+        val result = writeEnum(enumDef)
+
+        val expected = """
+        package test
+
+        public enum class Status {
+          ACTIVE,
+          IN_PROGRESS,
+          DELETED,
+        }
+        """.trimIndent()
+        Assert.assertEquals(expected.trim(), result.trim())
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun writeComplexEnumConstant2() {
+        val enumDef = EnumDef.builder("test.Status")
+            .addEnumConstant("ACTIVE", ExpressionDef.constant(2))
+            .addEnumConstant("IN_PROGRESS", ExpressionDef.constant(1))
+            .addEnumConstant("DELETED", ExpressionDef.constant(0))
+            .build()
+        val result = writeEnum(enumDef)
+
+        val expected = """
+        package test
+
+        public enum class Status {
+          ACTIVE(2),
+          IN_PROGRESS(1),
+          DELETED(0),
+        }
+
+        """.trimIndent()
+        Assert.assertEquals(expected.trim(), result.trim())
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun writeComplexEnumConstant3() {
+        val enumDef = EnumDef.builder("test.Status")
+            .addEnumConstant("active", ExpressionDef.constant(2))
+            .addEnumConstant("in progress", ExpressionDef.constant(1))
+            .addEnumConstant("deleted", ExpressionDef.constant(0))
+            .build()
+        val result = writeEnum(enumDef)
+
+        val expected = """
+        package test
+
+        public enum class Status {
+          ACTIVE(2),
+          IN_PROGRESS(1),
+          DELETED(0),
+        }
+
+        """.trimIndent()
+        Assert.assertEquals(expected.trim(), result.trim())
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun writeComplexEnumConstant4() {
+        val enumDef = EnumDef.builder("test.Status")
+            .addEnumConstant("active_by heart")
+            .addEnumConstant("9 Jump in progress")
+            .addEnumConstant("isItEven deleted")
+            .build()
+        val result = writeEnum(enumDef)
+
+        val expected = """
+        package test
+
+        public enum class Status {
+          ACTIVE_BY_HEART,
+          JUMP_IN_PROGRESS,
+          IS_IT_EVEN_DELETED,
+        }
+
+        """.trimIndent()
+        Assert.assertEquals(expected.trim(), result.trim())
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun writeComplexEnumWithProperty() {
+        val enumDef = EnumDef.builder("test.Status")
+            .addEnumConstant("active")
+            .addEnumConstant("in-progress")
+            .addEnumConstant("deleted")
+            .addProperty(PropertyDef.builder("value").ofType(TypeDef.STRING).build())
+            .build()
+        val result = writeEnum(enumDef)
+
+        val expected = """
+        package test
+
+        public enum class Status {
+          ACTIVE,
+          IN_PROGRESS,
+          DELETED;
+
+          private final String value;
+
+          public String getValue() {
+            return this.value;
+          }
+        }
+
+        """.trimIndent()
+        Assert.assertEquals(expected.trim(), result.trim())
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun writeComplexEnumWithPropertyMethod() {
+        val enumDef = EnumDef.builder("test.Status")
+            .addEnumConstant("active")
+            .addEnumConstant("in-progress")
+            .addEnumConstant("deleted")
+            .addField(FieldDef.builder("value").ofType(TypeDef.STRING).build())
+            .addMethod(
+                MethodDef.builder("getValue")
+                    .returns(TypeDef.STRING)
+                    .addModifiers(Modifier.PUBLIC)
+                    .addStatement(StatementDef.Return(ExpressionDef.constant("value")))
+                    .build()
+            )
+            .build()
+        val result = writeEnum(enumDef)
+
+        val expected = """
+        package test
+
+        public enum class Status {
+          ACTIVE,
+          IN_PROGRESS,
+          DELETED;
+
+          private final String value;
+
+          public String getValue() {
+            return "value";
+          }
+        }
+
+        """.trimIndent()
+        Assert.assertEquals(expected.trim(), result.trim())
+    }
+
+
+    @Throws(IOException::class)
+    private fun writeEnum(enumDef: EnumDef): String {
+        val generator: KotlinPoetSourceGenerator = KotlinPoetSourceGenerator()
+        var result: String
+        StringWriter().use { writer ->
+            generator.write(enumDef, writer)
+            result = writer.toString()
+        }
+        // The regex will skip the imports and make sure it is a record
+        val ENUM_REGEX = Pattern.compile(
+            "package [^;]+[^/]+" +
+                    "public enum class " + enumDef.simpleName + " \\{\\s+" +
+                    "([\\s\\S]+)\\s+}\\s+"
+        )
+        val matcher = ENUM_REGEX.matcher(result)
+        if (!matcher.matches()) {
+            Assert.fail("Expected enum to match regex: \n$ENUM_REGEX\nbut is: \n$result")
+        }
+        return matcher.group(0)
+    }
+}

--- a/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/EnumWriteTest.kt
+++ b/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/EnumWriteTest.kt
@@ -49,18 +49,28 @@ class EnumWriteTest {
             .addEnumConstant("ACTIVE", ExpressionDef.constant(2))
             .addEnumConstant("IN_PROGRESS", ExpressionDef.constant(1))
             .addEnumConstant("DELETED", ExpressionDef.constant(0))
+            .addField(FieldDef.builder("intValue").ofType(TypeDef.Primitive.INT).addModifiers(Modifier.PUBLIC).build())
+            .addAllFieldsConstructor(Modifier.PRIVATE)
             .build()
         val result = writeEnum(enumDef)
 
         val expected = """
         package test
 
+        import kotlin.Int
+
         public enum class Status {
           ACTIVE(2),
           IN_PROGRESS(1),
           DELETED(0),
-        }
+          ;
 
+          public var intValue: Int
+
+          private constructor(intValue: Int) {
+            this. intValue = intValue
+          }
+        }
         """.trimIndent()
         Assert.assertEquals(expected.trim(), result.trim())
     }
@@ -72,16 +82,32 @@ class EnumWriteTest {
             .addEnumConstant("ACTIVE", ExpressionDef.constant(2), ExpressionDef.trueValue())
             .addEnumConstant("IN_PROGRESS", ExpressionDef.constant(1), ExpressionDef.trueValue())
             .addEnumConstant("DELETED", ExpressionDef.constant(0), ExpressionDef.falseValue())
+            .addField(FieldDef.builder("intValue").ofType(TypeDef.Primitive.INT).addModifiers(Modifier.PUBLIC).build())
+            .addField(FieldDef.builder("boolValue").ofType(TypeDef.Primitive.BOOLEAN).addModifiers(Modifier.PUBLIC).build())
+            .addAllFieldsConstructor(Modifier.PRIVATE)
             .build()
         val result = writeEnum(enumDef)
 
         val expected = """
         package test
 
+        import kotlin.Boolean
+        import kotlin.Int
+
         public enum class Status {
           ACTIVE(2, true),
           IN_PROGRESS(1, true),
           DELETED(0, false),
+          ;
+
+          public var intValue: Int
+
+          public var boolValue: Boolean
+
+          private constructor(intValue: Int, boolValue: Boolean) {
+            this. intValue = intValue
+            this. boolValue = boolValue
+          }
         }
         """.trimIndent()
         Assert.assertEquals(expected.trim(), result.trim())

--- a/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/EnumWriteTest.kt
+++ b/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/EnumWriteTest.kt
@@ -67,6 +67,28 @@ class EnumWriteTest {
 
     @Test
     @Throws(IOException::class)
+    fun writeComplexEnumConstant2() {
+        val enumDef = EnumDef.builder("test.Status")
+            .addEnumConstant("ACTIVE", ExpressionDef.constant(2), ExpressionDef.trueValue())
+            .addEnumConstant("IN_PROGRESS", ExpressionDef.constant(1), ExpressionDef.trueValue())
+            .addEnumConstant("DELETED", ExpressionDef.constant(0), ExpressionDef.falseValue())
+            .build()
+        val result = writeEnum(enumDef)
+
+        val expected = """
+        package test
+
+        public enum class Status {
+          ACTIVE(2, true),
+          IN_PROGRESS(1, true),
+          DELETED(0, false),
+        }
+        """.trimIndent()
+        Assert.assertEquals(expected.trim(), result.trim())
+    }
+
+    @Test
+    @Throws(IOException::class)
     fun writeComplexEnumWithProperty() {
         val enumDef = EnumDef.builder("test.Status")
             .addEnumConstant("ACTIVE")

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassDef.java
@@ -36,7 +36,6 @@ import java.util.List;
 public final class ClassDef extends ObjectDef {
 
     private final List<FieldDef> fields;
-    private final List<PropertyDef> properties;
     private final List<TypeDef.TypeVariable> typeVariables;
     private final ClassTypeDef superclass;
 
@@ -50,9 +49,8 @@ public final class ClassDef extends ObjectDef {
                      List<TypeDef.TypeVariable> typeVariables,
                      List<TypeDef> superinterfaces,
                      ClassTypeDef superclass) {
-        super(name, modifiers, annotations, javadoc, methods, superinterfaces);
+        super(name, modifiers, annotations, javadoc, methods, properties, superinterfaces);
         this.fields = fields;
-        this.properties = properties;
         this.typeVariables = typeVariables;
         this.superclass = superclass;
     }
@@ -63,10 +61,6 @@ public final class ClassDef extends ObjectDef {
 
     public List<FieldDef> getFields() {
         return fields;
-    }
-
-    public List<PropertyDef> getProperties() {
-        return properties;
     }
 
     public List<TypeDef.TypeVariable> getTypeVariables() {
@@ -85,7 +79,7 @@ public final class ClassDef extends ObjectDef {
                 return field;
             }
         }
-        for (PropertyDef property : properties) {
+        for (PropertyDef property : getProperties()) {
             if (property.getName().equals(name)) {
                 return FieldDef.builder(property.getName()).ofType(property.getType()).build();
             }
@@ -143,7 +137,6 @@ public final class ClassDef extends ObjectDef {
     public static final class ClassDefBuilder extends ObjectDefBuilder<ClassDefBuilder> {
 
         private final List<FieldDef> fields = new ArrayList<>();
-        private final List<PropertyDef> properties = new ArrayList<>();
         private final List<TypeDef.TypeVariable> typeVariables = new ArrayList<>();
         private ClassTypeDef superclass;
 
@@ -158,11 +151,6 @@ public final class ClassDef extends ObjectDef {
 
         public ClassDefBuilder addField(FieldDef field) {
             fields.add(field);
-            return this;
-        }
-
-        public ClassDefBuilder addProperty(PropertyDef property) {
-            properties.add(property);
             return this;
         }
 

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/EnumDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/EnumDef.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.sourcegen.model;
 
+import com.github.javaparser.utils.Pair;
 import io.micronaut.core.annotation.Experimental;
 
 import javax.lang.model.element.Modifier;
@@ -31,14 +32,14 @@ import java.util.List;
 @Experimental
 public final class EnumDef extends ObjectDef {
 
-    private final List<String> enumConstants;
+    private final List<Pair<String,Object>> enumConstants;
 
     private EnumDef(String name,
                     EnumSet<Modifier> modifiers,
                     List<MethodDef> methods,
                     List<AnnotationDef> annotations,
                     List<String> javadoc,
-                    List<String> enumConstants,
+                    List<Pair<String,Object>> enumConstants,
                     List<TypeDef> superinterfaces) {
         super(name, modifiers, annotations, javadoc, methods, superinterfaces);
         this.enumConstants = enumConstants;
@@ -48,7 +49,7 @@ public final class EnumDef extends ObjectDef {
         return new EnumDefBuilder(name);
     }
 
-    public List<String> getEnumConstants() {
+    public List<Pair<String,Object>> getEnumConstants() {
         return enumConstants;
     }
 
@@ -61,14 +62,19 @@ public final class EnumDef extends ObjectDef {
     @Experimental
     public static final class EnumDefBuilder extends ObjectDefBuilder<EnumDefBuilder> {
 
-        private final List<String> enumConstants = new ArrayList<>();
+        private final List<Pair<String,Object>> enumConstants = new ArrayList<>();
 
         private EnumDefBuilder(String name) {
             super(name);
         }
 
         public EnumDefBuilder addEnumConstant(String name) {
-            enumConstants.add(name);
+            enumConstants.add(new Pair<>(name,null));
+            return this;
+        }
+
+        public EnumDefBuilder addEnumConstant(String name, Object value) {
+            enumConstants.add(new Pair<>(name,value));
             return this;
         }
 

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/EnumDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/EnumDef.java
@@ -94,11 +94,7 @@ public final class EnumDef extends ObjectDef {
 
     public boolean hasField(String name) {
         FieldDef property = findField(name);
-        if (property != null) {
-            return true;
-        }
-        // TODO: check outer classes
-        return false;
+        return property != null;
     }
 
     /**
@@ -197,15 +193,23 @@ public final class EnumDef extends ObjectDef {
 
             // Split into words
             String[] words = cleanedInput.split("\\s+");
+            try {
+                // Check if the input is acceptable
+                if (words.length == 0 || words[0].isEmpty()) {
+                    throw new IllegalArgumentException("The enum constant name is not an acceptable identifier name.");
+                }
+                for (int i = 0; i < words.length; i++) {
+                    words[i] = words[i].toUpperCase();
+                }
+                String constantName = join("_", words);
 
-            // Check if the input is acceptable
-            if (words.length == 0 || words[0].isEmpty()) {
-                throw new IllegalArgumentException("Property name is not an acceptable enum constant name");
+                if (!constantName.equals(input)) {
+                    throw new IllegalArgumentException("The enum constant name does not follow the conventions for constants, it should be changed accordingly.");
+                }
+                return constantName;
+            } catch (IllegalArgumentException e) {
+                throw e;
             }
-            for (int i = 0; i < words.length; i++) {
-                words[i] = words[i].toUpperCase();
-            }
-            return join("_", words);
         }
 
     }

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/EnumDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/EnumDef.java
@@ -123,10 +123,7 @@ public final class EnumDef extends ObjectDef {
 
         public EnumDefBuilder addEnumConstant(String name) {
             String constName = getConstantName(name);
-            if (!constName.equals(name)) {
-                return addEnumConstant(constName, ExpressionDef.constant(name));
-            }
-            enumConstants.put(name, null);
+            enumConstants.put(constName, null);
             return this;
         }
 

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/EnumDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/EnumDef.java
@@ -39,7 +39,7 @@ import static java.lang.String.join;
 public final class EnumDef extends ObjectDef {
 
     private final List<FieldDef> fields;
-    private final LinkedHashMap<String, ExpressionDef> enumConstants;
+    private final LinkedHashMap<String, List<ExpressionDef>> enumConstants;
 
     private EnumDef(String name,
                     EnumSet<Modifier> modifiers,
@@ -48,7 +48,7 @@ public final class EnumDef extends ObjectDef {
                     List<PropertyDef> properties,
                     List<AnnotationDef> annotations,
                     List<String> javadoc,
-                    LinkedHashMap<String, ExpressionDef> enumConstants,
+                    LinkedHashMap<String, List<ExpressionDef>> enumConstants,
                     List<TypeDef> superinterfaces,
                     List<ObjectDef> innerTypes) {
         super(name, modifiers, annotations, javadoc, methods, properties, superinterfaces, innerTypes);
@@ -64,7 +64,7 @@ public final class EnumDef extends ObjectDef {
         return fields;
     }
 
-    public LinkedHashMap<String, ExpressionDef> getEnumConstants() {
+    public LinkedHashMap<String, List<ExpressionDef>> getEnumConstants() {
         return enumConstants;
     }
 
@@ -107,7 +107,7 @@ public final class EnumDef extends ObjectDef {
     public static final class EnumDefBuilder extends ObjectDefBuilder<EnumDefBuilder> {
 
         private final List<FieldDef> fields = new ArrayList<>();
-        private final LinkedHashMap<String, ExpressionDef> enumConstants = new LinkedHashMap<>();
+        private final LinkedHashMap<String, List<ExpressionDef>> enumConstants = new LinkedHashMap<>();
 
         private EnumDefBuilder(String name) {
             super(name);
@@ -124,9 +124,9 @@ public final class EnumDef extends ObjectDef {
             return this;
         }
 
-        public EnumDefBuilder addEnumConstant(String name, ExpressionDef value) {
+        public EnumDefBuilder addEnumConstant(String name, ExpressionDef... values) {
             String constName = getConstantName(name);
-            enumConstants.put(constName, value);
+            enumConstants.put(constName, List.of(values));
             return this;
         }
 

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/EnumDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/EnumDef.java
@@ -15,13 +15,15 @@
  */
 package io.micronaut.sourcegen.model;
 
-import com.github.javaparser.utils.Pair;
 import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.Nullable;
 
 import javax.lang.model.element.Modifier;
-import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+
+import static java.lang.String.join;
 
 /**
  * The enum definition.
@@ -32,16 +34,17 @@ import java.util.List;
 @Experimental
 public final class EnumDef extends ObjectDef {
 
-    private final List<Pair<String,Object>> enumConstants;
+    private final LinkedHashMap<String, ExpressionDef> enumConstants;
 
     private EnumDef(String name,
                     EnumSet<Modifier> modifiers,
                     List<MethodDef> methods,
+                    List<PropertyDef> properties,
                     List<AnnotationDef> annotations,
                     List<String> javadoc,
-                    List<Pair<String,Object>> enumConstants,
+                    LinkedHashMap<String, ExpressionDef> enumConstants,
                     List<TypeDef> superinterfaces) {
-        super(name, modifiers, annotations, javadoc, methods, superinterfaces);
+        super(name, modifiers, annotations, javadoc, methods, properties, superinterfaces);
         this.enumConstants = enumConstants;
     }
 
@@ -49,8 +52,27 @@ public final class EnumDef extends ObjectDef {
         return new EnumDefBuilder(name);
     }
 
-    public List<Pair<String,Object>> getEnumConstants() {
+    public LinkedHashMap<String, ExpressionDef> getEnumConstants() {
         return enumConstants;
+    }
+
+    @Nullable
+    public PropertyDef findProperty(String name) {
+        for (PropertyDef property : getProperties()) {
+            if (property.getName().equals(name)) {
+                return property;
+            }
+        }
+        return null;
+    }
+
+    public boolean hasProperty(String name) {
+        PropertyDef property = findProperty(name);
+        if (property != null) {
+            return true;
+        }
+        // TODO: check outer classes
+        return false;
     }
 
     /**
@@ -62,24 +84,55 @@ public final class EnumDef extends ObjectDef {
     @Experimental
     public static final class EnumDefBuilder extends ObjectDefBuilder<EnumDefBuilder> {
 
-        private final List<Pair<String,Object>> enumConstants = new ArrayList<>();
+        private final LinkedHashMap<String, ExpressionDef> enumConstants = new LinkedHashMap<>();
 
         private EnumDefBuilder(String name) {
             super(name);
         }
 
         public EnumDefBuilder addEnumConstant(String name) {
-            enumConstants.add(new Pair<>(name,null));
+            String constName = getConstantName(name);
+            if (!constName.equals(name)) {
+                return addEnumConstant(constName, ExpressionDef.constant(name));
+            }
+            enumConstants.put(name, null);
             return this;
         }
 
-        public EnumDefBuilder addEnumConstant(String name, Object value) {
-            enumConstants.add(new Pair<>(name,value));
+        public EnumDefBuilder addEnumConstant(String name, ExpressionDef value) {
+            String constName = getConstantName(name);
+            enumConstants.put(constName, value);
             return this;
         }
 
         public EnumDef build() {
-            return new EnumDef(name, modifiers, methods, annotations, javadoc, enumConstants, superinterfaces);
+            return new EnumDef(name, modifiers, methods, properties, annotations, javadoc, enumConstants, superinterfaces);
+        }
+
+        private static String getConstantName(String input) {
+            if (input.equals(input.toUpperCase())) {
+                return input;
+            }
+            String cleanedInput = input.replaceAll("[-_]", " ")
+                .replaceAll("(?<!^)(?=[A-Z])", " ")
+                .replaceAll("[^a-zA-Z0-9 ]", "")
+                .trim();
+
+            while (!Character.isJavaIdentifierStart(cleanedInput.charAt(0))) {
+                cleanedInput = cleanedInput.substring(1);
+            }
+
+            // Split into words
+            String[] words = cleanedInput.split("\\s+");
+
+            // Check if the input is acceptable
+            if (words.length == 0 || words[0].isEmpty()) {
+                throw new IllegalArgumentException("Property name is not an acceptable enum constant name");
+            }
+            for (int i = 0; i < words.length; i++) {
+                words[i] = words[i].toUpperCase();
+            }
+            return join("_", words);
         }
 
     }

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/InterfaceDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/InterfaceDef.java
@@ -43,7 +43,6 @@ public final class InterfaceDef extends ObjectDef {
                          List<TypeDef> superinterfaces,
                          List<ObjectDef> innerTypes) {
         super(name, modifiers, annotations, javadoc, methods, properties, superinterfaces, innerTypes);
-        this.properties = properties;
         this.typeVariables = typeVariables;
     }
 

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/InterfaceDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/InterfaceDef.java
@@ -31,7 +31,6 @@ import java.util.List;
 @Experimental
 public final class InterfaceDef extends ObjectDef {
 
-    private final List<PropertyDef> properties;
     private final List<TypeDef.TypeVariable> typeVariables;
 
     private InterfaceDef(String name,
@@ -42,17 +41,12 @@ public final class InterfaceDef extends ObjectDef {
                          List<String> javadoc,
                          List<TypeDef.TypeVariable> typeVariables,
                          List<TypeDef> superinterfaces) {
-        super(name, modifiers, annotations, javadoc, methods, superinterfaces);
-        this.properties = properties;
+        super(name, modifiers, annotations, javadoc, methods, properties, superinterfaces);
         this.typeVariables = typeVariables;
     }
 
     public static InterfaceDefBuilder builder(String name) {
         return new InterfaceDefBuilder(name);
-    }
-
-    public List<PropertyDef> getProperties() {
-        return properties;
     }
 
     public List<TypeDef.TypeVariable> getTypeVariables() {
@@ -68,16 +62,10 @@ public final class InterfaceDef extends ObjectDef {
     @Experimental
     public static final class InterfaceDefBuilder extends ObjectDefBuilder<InterfaceDefBuilder> {
 
-        private final List<PropertyDef> properties = new ArrayList<>();
         private final List<TypeDef.TypeVariable> typeVariables = new ArrayList<>();
 
         private InterfaceDefBuilder(String name) {
             super(name);
-        }
-
-        public InterfaceDefBuilder addProperty(PropertyDef property) {
-            properties.add(property);
-            return this;
         }
 
         public InterfaceDefBuilder addTypeVariable(TypeDef.TypeVariable typeVariable) {

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/MethodDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/MethodDef.java
@@ -127,6 +127,13 @@ public final class MethodDef extends AbstractElement {
         return override;
     }
 
+    /**
+     * @return True if method is a constructor
+     */
+    public boolean isConstructor() {
+        return CONSTRUCTOR.equals(getName());
+    }
+
     public static MethodDefBuilder builder(String name) {
         return new MethodDefBuilder(name);
     }

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ObjectDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ObjectDef.java
@@ -32,19 +32,26 @@ import java.util.Set;
 public abstract sealed class ObjectDef extends AbstractElement permits ClassDef, EnumDef, InterfaceDef, RecordDef {
 
     private final List<MethodDef> methods;
+    private final List<PropertyDef> properties;
     private final List<TypeDef> superinterfaces;
 
     ObjectDef(
-            String name, Set<Modifier> modifiers, List<AnnotationDef> annotations,
-            List<String> javadoc, List<MethodDef> methods, List<TypeDef> superinterfaces
+        String name, Set<Modifier> modifiers, List<AnnotationDef> annotations,
+        List<String> javadoc, List<MethodDef> methods, List<PropertyDef> properties,
+        List<TypeDef> superinterfaces
     ) {
         super(name, modifiers, annotations, javadoc);
         this.methods = methods;
+        this.properties = properties;
         this.superinterfaces = superinterfaces;
     }
 
     public final List<MethodDef> getMethods() {
         return methods;
+    }
+
+    public final List<PropertyDef> getProperties() {
+        return properties;
     }
 
     public final List<TypeDef> getSuperinterfaces() {

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ObjectDefBuilder.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ObjectDefBuilder.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.sourcegen.model;
 
+import io.micronaut.context.annotation.Property;
 import io.micronaut.core.annotation.Experimental;
 
 import java.util.ArrayList;
@@ -34,6 +35,7 @@ public sealed class ObjectDefBuilder<ThisType>
                 RecordDef.RecordDefBuilder, EnumDef.EnumDefBuilder {
 
     protected final List<MethodDef> methods = new ArrayList<>();
+    protected final List<PropertyDef> properties = new ArrayList<>();
     protected final List<TypeDef> superinterfaces = new ArrayList<>();
 
     protected ObjectDefBuilder(String name) {
@@ -42,6 +44,11 @@ public sealed class ObjectDefBuilder<ThisType>
 
     public final ThisType addMethod(MethodDef method) {
         methods.add(method);
+        return thisInstance;
+    }
+
+    public final ThisType addProperty(PropertyDef property) {
+        properties.add(property);
         return thisInstance;
     }
 

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ObjectDefBuilder.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ObjectDefBuilder.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.sourcegen.model;
 
-import io.micronaut.context.annotation.Property;
 import io.micronaut.core.annotation.Experimental;
 
 import java.util.ArrayList;

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/RecordDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/RecordDef.java
@@ -43,7 +43,6 @@ public final class RecordDef extends ObjectDef {
                       List<TypeDef> superinterfaces,
                       List<ObjectDef> innerTypes) {
         super(name, modifiers, annotations, javadoc, methods, properties, superinterfaces, innerTypes);
-        this.properties = properties;
         this.typeVariables = typeVariables;
     }
 

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/RecordDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/RecordDef.java
@@ -31,7 +31,6 @@ import java.util.List;
 @Experimental
 public final class RecordDef extends ObjectDef {
 
-    private final List<PropertyDef> properties;
     private final List<TypeDef.TypeVariable> typeVariables;
 
     private RecordDef(String name,
@@ -42,17 +41,12 @@ public final class RecordDef extends ObjectDef {
                       List<String> javadoc,
                       List<TypeDef.TypeVariable> typeVariables,
                       List<TypeDef> superinterfaces) {
-        super(name, modifiers, annotations, javadoc, methods, superinterfaces);
-        this.properties = properties;
+        super(name, modifiers, annotations, javadoc, methods, properties, superinterfaces);
         this.typeVariables = typeVariables;
     }
 
     public static RecordDefBuilder builder(String name) {
         return new RecordDefBuilder(name);
-    }
-
-    public List<PropertyDef> getProperties() {
-        return properties;
     }
 
     public List<TypeDef.TypeVariable> getTypeVariables() {
@@ -68,16 +62,10 @@ public final class RecordDef extends ObjectDef {
     @Experimental
     public static final class RecordDefBuilder extends ObjectDefBuilder<RecordDefBuilder> {
 
-        private final List<PropertyDef> properties = new ArrayList<>();
         private final List<TypeDef.TypeVariable> typeVariables = new ArrayList<>();
 
         private RecordDefBuilder(String name) {
             super(name);
-        }
-
-        public RecordDefBuilder addProperty(PropertyDef property) {
-            properties.add(property);
-            return this;
         }
 
         public RecordDefBuilder addTypeVariable(TypeDef.TypeVariable typeVariable) {

--- a/test-suite-custom-annotations/src/main/java/io/micronaut/sourcegen/custom/example/GenerateMyEnum2.java
+++ b/test-suite-custom-annotations/src/main/java/io/micronaut/sourcegen/custom/example/GenerateMyEnum2.java
@@ -13,27 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.sourcegen.example;
+package io.micronaut.sourcegen.custom.example;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
-import io.micronaut.sourcegen.custom.example.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import java.util.List;
-
-@GenerateMyBean1
-@GenerateMyBean2
-@GenerateMyBean3
-@GenerateMyRecord1
-@GenerateMyRecord3
-@GenerateInterface
-@GenerateMyRepository1
-@GenerateMyEnum1
-@GenerateIfsPredicate
-@GenerateSwitch
-@GenerateArray
-@GenerateAnnotatedType
-@GenerateInnerTypes
-@GenerateMyEnum2
-public class Trigger {
-    public List<String> copyAddresses;
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+public @interface GenerateMyEnum2 {
 }

--- a/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateMyEnum2Visitor.java
+++ b/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateMyEnum2Visitor.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.custom.visitor;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.processing.ProcessingException;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+import io.micronaut.sourcegen.custom.example.GenerateMyEnum2;
+import io.micronaut.sourcegen.generator.SourceGenerator;
+import io.micronaut.sourcegen.generator.SourceGenerators;
+import io.micronaut.sourcegen.model.ClassTypeDef;
+import io.micronaut.sourcegen.model.EnumDef;
+import io.micronaut.sourcegen.model.ExpressionDef;
+import io.micronaut.sourcegen.model.FieldDef;
+import io.micronaut.sourcegen.model.MethodDef;
+import io.micronaut.sourcegen.model.ParameterDef;
+import io.micronaut.sourcegen.model.TypeDef;
+
+import javax.lang.model.element.Modifier;
+import java.util.List;
+
+@Internal
+public final class GenerateMyEnum2Visitor implements TypeElementVisitor<GenerateMyEnum2, Object> {
+
+    @Override
+    public @NonNull VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        String enumClassName = element.getPackageName() + ".MyEnum2";
+
+        ClassTypeDef enumTypeDef = ClassTypeDef.of(enumClassName);
+        EnumDef beanDef = EnumDef.builder(enumClassName)
+            .addModifiers(Modifier.PUBLIC)
+            .addEnumConstant("A", ExpressionDef.constant(0))
+            .addEnumConstant("B", ExpressionDef.constant(1))
+            .addEnumConstant("C", ExpressionDef.constant(2))
+            .addField(FieldDef.builder("myValue").ofType(TypeDef.Primitive.INT).addModifiers(Modifier.PUBLIC).build())
+            .addMethod(MethodDef.builder("myName")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(TypeDef.STRING)
+                .build((aThis, parameters) ->
+                    aThis.invoke("toString", TypeDef.STRING, List.of()).returning()))
+            .addConstructor(List.of(ParameterDef.of("myValue", TypeDef.Primitive.INT)), Modifier.PRIVATE)
+            .build();
+
+        SourceGenerator sourceGenerator = SourceGenerators.findByLanguage(context.getLanguage()).orElse(null);
+        if (sourceGenerator == null) {
+            return;
+        }
+        context.visitGeneratedSourceFile(beanDef.getPackageName(), beanDef.getSimpleName(), element)
+            .ifPresent(generatedFile -> {
+                try {
+                    generatedFile.write(writer -> sourceGenerator.write(beanDef, writer));
+                } catch (Exception e) {
+                    throw new ProcessingException(element, e.getMessage(), e);
+                }
+            });
+    }
+
+}

--- a/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateMyEnum2Visitor.java
+++ b/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateMyEnum2Visitor.java
@@ -24,12 +24,10 @@ import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.sourcegen.custom.example.GenerateMyEnum2;
 import io.micronaut.sourcegen.generator.SourceGenerator;
 import io.micronaut.sourcegen.generator.SourceGenerators;
-import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.EnumDef;
 import io.micronaut.sourcegen.model.ExpressionDef;
 import io.micronaut.sourcegen.model.FieldDef;
 import io.micronaut.sourcegen.model.MethodDef;
-import io.micronaut.sourcegen.model.ParameterDef;
 import io.micronaut.sourcegen.model.TypeDef;
 
 import javax.lang.model.element.Modifier;
@@ -47,7 +45,6 @@ public final class GenerateMyEnum2Visitor implements TypeElementVisitor<Generate
     public void visitClass(ClassElement element, VisitorContext context) {
         String enumClassName = element.getPackageName() + ".MyEnum2";
 
-        ClassTypeDef enumTypeDef = ClassTypeDef.of(enumClassName);
         EnumDef beanDef = EnumDef.builder(enumClassName)
             .addModifiers(Modifier.PUBLIC)
             .addEnumConstant("A", ExpressionDef.constant(0))
@@ -59,7 +56,7 @@ public final class GenerateMyEnum2Visitor implements TypeElementVisitor<Generate
                 .returns(TypeDef.STRING)
                 .build((aThis, parameters) ->
                     aThis.invoke("toString", TypeDef.STRING, List.of()).returning()))
-            .addConstructor(List.of(ParameterDef.of("myValue", TypeDef.Primitive.INT)), Modifier.PRIVATE)
+            .addAllFieldsConstructor(Modifier.PRIVATE)
             .build();
 
         SourceGenerator sourceGenerator = SourceGenerators.findByLanguage(context.getLanguage()).orElse(null);

--- a/test-suite-custom-generators/src/main/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/test-suite-custom-generators/src/main/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -16,3 +16,4 @@ io.micronaut.sourcegen.custom.visitor.innerTypes.GenerateInnerTypeInRecordVisito
 io.micronaut.sourcegen.custom.visitor.innerTypes.GenerateInnerTypeInClassVisitor
 io.micronaut.sourcegen.custom.visitor.innerTypes.GenerateInnerTypeInInterfaceVisitor
 io.micronaut.sourcegen.custom.visitor.GenerateAnnotatedTypeVisitor
+io.micronaut.sourcegen.custom.visitor.GenerateMyEnum2Visitor

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/MyEnum2Test.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/MyEnum2Test.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MyEnum2Test {
+
+    @Test
+    void test() {
+        assertEquals(3, MyEnum2.values().length);
+        assertEquals("A", MyEnum2.A.myName());
+        assertEquals("B", MyEnum2.B.myName());
+        assertEquals("C", MyEnum2.C.myName());
+    }
+
+    @Test
+    void testValues() {
+        assertEquals(0, MyEnum2.A.myValue);
+        assertEquals(1, MyEnum2.B.myValue);
+        assertEquals(2, MyEnum2.C.myValue);
+    }
+}
+

--- a/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/Trigger.kt
+++ b/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/Trigger.kt
@@ -29,4 +29,5 @@ import io.micronaut.sourcegen.custom.example.*
 @GenerateArray
 @GenerateAnnotatedType
 @GenerateInnerTypes
+@GenerateMyEnum2
 class Trigger

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/sourcegen/example/MyEnum2Test.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/sourcegen/example/MyEnum2Test.kt
@@ -1,0 +1,25 @@
+package io.micronaut.sourcegen.example
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MyEnum2Test {
+
+    @Test
+    @Throws(Exception::class)
+    fun test() {
+        assertEquals(3, MyEnum2.entries.size)
+        assertEquals("A", MyEnum2.A.myName())
+        assertEquals("B", MyEnum2.B.myName())
+        assertEquals("C", MyEnum2.C.myName())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testValues() {
+        assertEquals(0, MyEnum2.A.myValue)
+        assertEquals(1, MyEnum2.B.myValue)
+        assertEquals(2, MyEnum2.C.myValue)
+    }
+}
+


### PR DESCRIPTION
Implementation of [this issue](https://github.com/micronaut-projects/micronaut-sourcegen/issues/165#issue-2614122027).

- using Java/Kotlin enum constant definition.
- checking enum constant naming.
- adding fields, properties, constructors and methods to enums.
- a **private** all fields constructor **needs to be added** on enums with constant object values.

Generated enum class example:
```
package io.micronaut.sourcegen.example;

import java.lang.String;

public enum MyEnum2 {

  A(0),
  B(1),
  C(2);

  public int myValue;

  private MyEnum2(int myValue) {
    this.myValue = myValue;
  }

  public String myName() {
    return this.toString();
  }
}
```

From the following definition:
```
EnumDef enumDef = EnumDef.builder(enumClassName)
            .addModifiers(Modifier.PUBLIC)
            .addEnumConstant("A", ExpressionDef.constant(0))
            .addEnumConstant("B", ExpressionDef.constant(1))
            .addEnumConstant("C", ExpressionDef.constant(2))
            .addField(FieldDef.builder("myValue").ofType(TypeDef.Primitive.INT).addModifiers(Modifier.PUBLIC).build())
            .addMethod(MethodDef.builder("myName")
                .addModifiers(Modifier.PUBLIC)
                .returns(TypeDef.STRING)
                .build((aThis, parameters) ->
                    aThis.invoke("toString", TypeDef.STRING, List.of()).returning()))
            .addAllFieldsConstructor(Modifier.PRIVATE)
            .build();
```
