### PR TITLE
Processing ClassTypeDef separately in Annotation values

### DIFF
--- a/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
+++ b/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
@@ -418,6 +418,8 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
             builder.addMember(memberName, "$Lf", value);
         } else if (value instanceof Character) {
             builder.addMember(memberName, "'$L'", Util.characterLiteralWithoutSingleQuotes((char) value));
+        } else if (value instanceof ClassTypeDef typeDef) {
+            builder.addMember(memberName, "$L.class", typeDef.getSimpleName());
         } else {
             builder.addMember(memberName, "$L", value);
         }

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/RecordWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/RecordWriteTest.java
@@ -142,4 +142,35 @@ public class RecordWriteTest {
         return matcher.group(1);
     }
 
+
+    @Test
+    public void annotationClassValue() throws IOException {
+        RecordDef recordDef = RecordDef.builder("test.$TestRecord")
+            .addAnnotation(AnnotationDef.builder(ClassTypeDef.of("jackson.annotation.JsonSubTypes.Type"))
+                .addMember("value", ClassTypeDef.STRING)
+                .addMember("name", "string")
+                .build())
+            .build();
+        JavaPoetSourceGenerator generator = new JavaPoetSourceGenerator();
+        String result;
+        try (StringWriter writer = new StringWriter()) {
+            generator.write(recordDef, writer);
+            result = writer.toString();
+        }
+
+        var expected = """
+        package test;
+
+        import jackson.annotation.JsonSubTypes;
+
+        @JsonSubTypes.Type(
+            value = String.class,
+            name = "string"
+        )
+        record $TestRecord() {
+        }
+        """;
+        assertEquals(expected.strip(), result.strip());
+    }
+
 }


### PR DESCRIPTION
Representing ClassTypeDef as a Class<> in the Annotation values. 

Desired usage:
```
AnnotationDef.builder(ClassTypeDef.of("jackson.annotation.JsonSubTypes.Type"))
                .addMember("value", ClassTypeDef.of("Account"))
                .addMember("name", "string")
                .build()
```
This PR would generate:
```
@JsonSubTypes.Type(
            value = Account.class,
            name = "string"
        )
```

Base branch generates:
```
@JsonSubTypes.Type(
            value = ClassName[className=Account, nullable=false],
            name = "string"
        )
```