### PR TITLE
Javadoc bug fix

### DIFF
--- a/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/javapoet/FieldSpec.java
+++ b/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/javapoet/FieldSpec.java
@@ -122,7 +122,7 @@ public final class FieldSpec {
     }
 
     public Builder addJavadoc(String format, Object... args) {
-      javadoc.add(format, args);
+      javadoc.add(format.replaceAll("\\$", "\\$\\$"), args);
       return this;
     }
 

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassTypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassTypeDef.java
@@ -376,7 +376,7 @@ public sealed interface ClassTypeDef extends TypeDef {
      */
     @Experimental
     record AnnotatedClassTypeDef(ClassTypeDef typeDef,
-                                 List<AnnotationDef> annotations) implements Annotated {
+                                 List<AnnotationDef> annotations) implements TypeDef.Annotated {
     }
 
 }


### PR DESCRIPTION
A "$" in the comments of a field of a class was crashing the build. 
The same check exists in ParameterSpec::addJavadoc, so I added the same check into FieldSpec::addJavadoc.