### PR TITLE
Javadoc bug fix

### DIFF
--- a/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/javapoet/FieldSpec.java
+++ b/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/javapoet/FieldSpec.java
@@ -122,7 +122,7 @@ public final class FieldSpec {
     }
 
     public Builder addJavadoc(String format, Object... args) {
-      javadoc.add(format, args);
+      javadoc.add(format.replaceAll("\\$", "\\$\\$"), args);
       return this;
     }
 


### PR DESCRIPTION
A "$" in the javadoc of a field of a class was causing a crash in the build but the same problem does not exist in records.

So, I added the existing check in `ParameterSpec::addJavadoc` to `FieldSpec::addJavadoc`.