### PR TITLE
Generator improvements

### DIFF
--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/AbstractConditionalWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/AbstractConditionalWriter.java
@@ -75,6 +75,18 @@ public abstract class AbstractConditionalWriter {
                 generatorAdapter.ifNull(elseLabel);
                 return;
             }
+            if (conditionExpressionDef instanceof ExpressionDef.IsTrue isTrue) {
+                ExpressionWriter.writeExpression(generatorAdapter, context, isTrue.expression());
+                generatorAdapter.push(true);
+                generatorAdapter.ifCmp(Type.BOOLEAN_TYPE, GeneratorAdapter.NE, elseLabel);
+                return;
+            }
+            if (conditionExpressionDef instanceof ExpressionDef.IsFalse isFalse) {
+                ExpressionWriter.writeExpression(generatorAdapter, context, isFalse.expression());
+                generatorAdapter.push(true);
+                generatorAdapter.ifCmp(Type.BOOLEAN_TYPE, GeneratorAdapter.EQ, elseLabel);
+                return;
+            }
             if (conditionExpressionDef instanceof ExpressionDef.EqualsReferentially equalsReferentially) {
                 pushEqualsReferentially(generatorAdapter, context, equalsReferentially, elseLabel, GeneratorAdapter.NE);
                 return;
@@ -133,6 +145,18 @@ public abstract class AbstractConditionalWriter {
             if (conditionExpressionDef instanceof ExpressionDef.IsNotNull isNotNull) {
                 ExpressionWriter.writeExpression(generatorAdapter, context, isNotNull.expression());
                 generatorAdapter.ifNonNull(ifLabel);
+                return;
+            }
+            if (conditionExpressionDef instanceof ExpressionDef.IsTrue isTrue) {
+                ExpressionWriter.writeExpression(generatorAdapter, context, isTrue.expression());
+                generatorAdapter.push(true);
+                generatorAdapter.ifCmp(Type.BOOLEAN_TYPE, GeneratorAdapter.EQ, ifLabel);
+                return;
+            }
+            if (conditionExpressionDef instanceof ExpressionDef.IsFalse isFalse) {
+                ExpressionWriter.writeExpression(generatorAdapter, context, isFalse.expression());
+                generatorAdapter.push(true);
+                generatorAdapter.ifCmp(Type.BOOLEAN_TYPE, GeneratorAdapter.NE, ifLabel);
                 return;
             }
             if (conditionExpressionDef instanceof ExpressionDef.EqualsReferentially equalsReferentially) {

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
@@ -74,7 +74,7 @@ public final class ByteCodeWriter {
     private final boolean visitMaxs;
 
     public ByteCodeWriter() {
-        this(true, true);
+        this(false, true);
     }
 
     public ByteCodeWriter(boolean checkClass, boolean visitMaxs) {

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/EnumGenUtils.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/EnumGenUtils.java
@@ -30,7 +30,6 @@ import io.micronaut.sourcegen.model.TypeDef;
 
 import javax.lang.model.element.Modifier;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/MethodContext.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/MethodContext.java
@@ -19,8 +19,10 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.sourcegen.model.MethodDef;
 import io.micronaut.sourcegen.model.ObjectDef;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Type;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -29,15 +31,27 @@ import java.util.Map;
  * @param objectDef The current object definition
  * @param methodDef The current method definition.
  * @param locals    The locals
+ * @since 1.5
  */
 @Internal
 public record MethodContext(@Nullable ObjectDef objectDef,
                             MethodDef methodDef,
-                            Map<String, Integer> locals) {
+                            Map<String, LocalData> locals) {
 
     public MethodContext(@Nullable ObjectDef objectDef,
                          MethodDef methodDef) {
-        this(objectDef, methodDef, new HashMap<>());
+        this(objectDef, methodDef, new LinkedHashMap<>());
+    }
+
+    /**
+     * The local data.
+     *
+     * @param name  The name
+     * @param type  The type
+     * @param start The start label
+     * @param index The index
+     */
+    public record LocalData(String name, Type type, Label start, int index) {
     }
 
 }

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/expression/CastExpressionWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/expression/CastExpressionWriter.java
@@ -34,7 +34,15 @@ final class CastExpressionWriter implements ExpressionWriter {
     @Override
     public void write(GeneratorAdapter generatorAdapter, MethodContext context) {
         ExpressionDef exp = castExpressionDef.expressionDef();
+        while (exp instanceof ExpressionDef.Cast cast) {
+            // Only keep the last cast
+            exp = cast.expressionDef();
+        }
         ExpressionWriter.writeExpression(generatorAdapter, context, exp);
+        if (exp instanceof ExpressionDef.Constant constant && constant.value() == null) {
+            // Avoid casting null to anything
+            return;
+        }
         cast(generatorAdapter, context, exp.type(), castExpressionDef.type());
     }
 

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/expression/VariableExpressionWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/expression/VariableExpressionWriter.java
@@ -17,6 +17,7 @@ package io.micronaut.sourcegen.bytecode.expression;
 
 import io.micronaut.sourcegen.bytecode.MethodContext;
 import io.micronaut.sourcegen.bytecode.TypeUtils;
+import io.micronaut.sourcegen.bytecode.statement.TryCatchStatementWriter;
 import io.micronaut.sourcegen.model.ParameterDef;
 import io.micronaut.sourcegen.model.TypeDef;
 import io.micronaut.sourcegen.model.VariableDef;
@@ -31,14 +32,14 @@ final class VariableExpressionWriter implements ExpressionWriter {
 
     @Override
     public void write(GeneratorAdapter generatorAdapter, MethodContext context) {
-        if (variableDef instanceof VariableDef.ExceptionVar exceptionVar) {
-            int index = context.locals().get("@exception");
-            generatorAdapter.loadLocal(index, TypeUtils.getType(exceptionVar.type(), context.objectDef()));
+        if (variableDef instanceof VariableDef.ExceptionVar) {
+            MethodContext.LocalData localData = context.locals().get(TryCatchStatementWriter.EXCEPTION_NAME);
+            generatorAdapter.loadLocal(localData.index(), localData.type());
             return;
         }
         if (variableDef instanceof VariableDef.Local localVariableDef) {
-            int index = context.locals().get(localVariableDef.name());
-            generatorAdapter.loadLocal(index, TypeUtils.getType(localVariableDef.type(), context.objectDef()));
+            MethodContext.LocalData localData = context.locals().get(localVariableDef.name());
+            generatorAdapter.loadLocal(localData.index(), localData.type());
             return;
         }
         if (variableDef instanceof VariableDef.MethodParameter parameterVariableDef) {

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/statement/AssignVariableStatementWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/statement/AssignVariableStatementWriter.java
@@ -16,11 +16,9 @@
 package io.micronaut.sourcegen.bytecode.statement;
 
 import io.micronaut.sourcegen.bytecode.MethodContext;
-import io.micronaut.sourcegen.bytecode.TypeUtils;
 import io.micronaut.sourcegen.bytecode.expression.ExpressionWriter;
 import io.micronaut.sourcegen.model.StatementDef;
 import io.micronaut.sourcegen.model.VariableDef;
-import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
 
 final class AssignVariableStatementWriter implements StatementWriter {
@@ -33,10 +31,9 @@ final class AssignVariableStatementWriter implements StatementWriter {
 
     @Override
     public void write(GeneratorAdapter generatorAdapter, MethodContext context, Runnable finallyBlock) {
-        VariableDef.Local local = assign.variable();
-        Type localType = TypeUtils.getType(local.type(), context.objectDef());
-        ExpressionWriter.writeExpressionCheckCast(generatorAdapter, context, assign.expression(), local.type());
-        Integer localIndex = context.locals().get(local.name());
-        generatorAdapter.storeLocal(localIndex, localType);
+        VariableDef.Local var = assign.variable();
+        ExpressionWriter.writeExpressionCheckCast(generatorAdapter, context, assign.expression(), var.type());
+        MethodContext.LocalData local = context.locals().get(var.name());
+        generatorAdapter.storeLocal(local.index(), local.type());
     }
 }

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/statement/IfElseStatementWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/statement/IfElseStatementWriter.java
@@ -33,9 +33,9 @@ final class IfElseStatementWriter extends AbstractConditionalWriter implements S
         Label elseLabel = new Label();
         pushElseConditionalExpression(generatorAdapter, context, ifStatement.condition(), elseLabel);
         Label end = new Label();
-        StatementWriter.of(ifStatement.statement()).write(generatorAdapter, context, finallyBlock);
+        StatementWriter.of(ifStatement.statement()).writeScoped(generatorAdapter, context, finallyBlock);
         generatorAdapter.visitLabel(end);
         generatorAdapter.visitLabel(elseLabel);
-        StatementWriter.of(ifStatement.elseStatement()).write(generatorAdapter, context, finallyBlock);
+        StatementWriter.of(ifStatement.elseStatement()).writeScoped(generatorAdapter, context, finallyBlock);
     }
 }

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/statement/IfStatementWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/statement/IfStatementWriter.java
@@ -32,7 +32,7 @@ final class IfStatementWriter extends AbstractConditionalWriter implements State
     public void write(GeneratorAdapter generatorAdapter, MethodContext context, Runnable finallyBlock) {
         Label elseLabel = new Label();
         pushElseConditionalExpression(generatorAdapter, context, ifStatement.condition(), elseLabel);
-        StatementWriter.of(ifStatement.statement()).write(generatorAdapter, context, finallyBlock);
+        StatementWriter.of(ifStatement.statement()).writeScoped(generatorAdapter, context, finallyBlock);
         generatorAdapter.visitLabel(elseLabel);
     }
 }

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/statement/SwitchStatementWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/statement/SwitchStatementWriter.java
@@ -92,7 +92,7 @@ final class SwitchStatementWriter extends AbstractSwitchWriter implements Statem
                 generatorAdapter.invokeVirtual(stringType, Method.getMethod(ReflectionUtils.getRequiredMethod(String.class, "equals", Object.class)));
                 generatorAdapter.push(true);
                 generatorAdapter.ifCmp(Type.BOOLEAN_TYPE, GeneratorAdapter.NE, defaultEnd);
-                StatementWriter.of(e.getValue()).write(generatorAdapter, context, finallyBlock);
+                StatementWriter.of(e.getValue()).writeScoped(generatorAdapter, context, finallyBlock);
                 generatorAdapter.goTo(finalEnd);
             }
 
@@ -104,7 +104,7 @@ final class SwitchStatementWriter extends AbstractSwitchWriter implements Statem
 
         generatorAdapter.visitLabel(defaultEnd);
         if (aSwitch.defaultCase() != null) {
-            StatementWriter.of(aSwitch.defaultCase()).write(generatorAdapter, context, finallyBlock);
+            StatementWriter.of(aSwitch.defaultCase()).writeScoped(generatorAdapter, context, finallyBlock);
         }
         generatorAdapter.visitLabel(finalEnd);
     }
@@ -158,7 +158,7 @@ final class SwitchStatementWriter extends AbstractSwitchWriter implements Statem
                 generatorAdapter.visitTableSwitchInsn(min, max, defaultLabel, labels);
                 for (Map.Entry<Label, StatementDef> e : result) {
                     generatorAdapter.mark(e.getKey());
-                    StatementWriter.of(e.getValue()).write(generatorAdapter, context, finallyBlock);
+                    StatementWriter.of(e.getValue()).writeScoped(generatorAdapter, context, finallyBlock);
                     generatorAdapter.goTo(endLabel);
                 }
             } else {
@@ -180,14 +180,14 @@ final class SwitchStatementWriter extends AbstractSwitchWriter implements Statem
                 generatorAdapter.visitLookupSwitchInsn(defaultLabel, keys, labels);
                 for (Map.Entry<Label, StatementDef> e : result) {
                     generatorAdapter.mark(e.getKey());
-                    StatementWriter.of(e.getValue()).write(generatorAdapter, context, finallyBlock);
+                    StatementWriter.of(e.getValue()).writeScoped(generatorAdapter, context, finallyBlock);
                     generatorAdapter.goTo(endLabel);
                 }
             }
         }
         generatorAdapter.mark(defaultLabel);
         if (defaultCase != null) {
-            StatementWriter.of(defaultCase).write(generatorAdapter, context, finallyBlock);
+            StatementWriter.of(defaultCase).writeScoped(generatorAdapter, context, finallyBlock);
         }
         generatorAdapter.mark(endLabel);
     }

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/statement/SynchronizedStatementWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/statement/SynchronizedStatementWriter.java
@@ -49,7 +49,7 @@ final class SynchronizedStatementWriter implements StatementWriter {
 
         generatorAdapter.visitLabel(synchronizedStart);
 
-        StatementWriter.of(aSynchronized.statement()).write(generatorAdapter, context, () -> {
+        StatementWriter.of(aSynchronized.statement()).writeScoped(generatorAdapter, context, () -> {
             generatorAdapter.loadLocal(monitorLocal);
             generatorAdapter.monitorExit();
             if (finallyBlock != null) {

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/statement/WhileLoopStatementWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/statement/WhileLoopStatementWriter.java
@@ -38,7 +38,7 @@ final class WhileLoopStatementWriter implements StatementWriter {
         ExpressionWriter.writeExpressionCheckCast(generatorAdapter, context, aWhile.expression(), TypeDef.Primitive.BOOLEAN);
         generatorAdapter.push(true);
         generatorAdapter.ifCmp(Type.BOOLEAN_TYPE, GeneratorAdapter.NE, end);
-        StatementWriter.of(aWhile.statement()).write(generatorAdapter, context, finallyBlock);
+        StatementWriter.of(aWhile.statement()).writeScoped(generatorAdapter, context, finallyBlock);
         generatorAdapter.goTo(whileLoop);
         generatorAdapter.visitLabel(end);
     }

--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
@@ -37,7 +37,7 @@ class ByteCodeWriterTest {
                 .overrides()
                 .returns(boolean.class)
                 .build((aThis, methodParameters) -> StatementDef.multi(
-                    methodParameters.get(0).isNull().asConditionIf(TypeDef.Primitive.TRUE.returning()),
+                    methodParameters.get(0).isNull().doIf(TypeDef.Primitive.TRUE.returning()),
                     TypeDef.Primitive.FALSE.returning()
                 )))
             .build();
@@ -62,13 +62,16 @@ class example/IfPredicate {
 
   // access flags 0x1
   public test(Ljava/lang/Object;)Z
+   L0
     ALOAD 1
-    IFNONNULL L0
+    IFNONNULL L1
     ICONST_1
     IRETURN
-   L0
+   L1
     ICONST_0
     IRETURN
+   L2
+    LOCALVARIABLE param Ljava/lang/Object; L0 L2 1
 }
 """, bytecode);
 
@@ -76,8 +79,8 @@ class example/IfPredicate {
 package example;
 
 class IfPredicate {
-   public boolean test(Object var1) {
-      return var1 == null;
+   public boolean test(Object param) {
+      return param == null;
    }
 }
 """, decompileToJava(bytes));
@@ -114,10 +117,13 @@ class example/IfPredicate {
 
   // access flags 0x1
   public test(Ljava/lang/Integer;)I
+   L0
     ALOAD 1
     CHECKCAST java/lang/Number
     INVOKEVIRTUAL java/lang/Number.intValue ()I
     IRETURN
+   L1
+    LOCALVARIABLE param Ljava/lang/Integer; L0 L1 1
 }
 """, bytecode);
 
@@ -125,8 +131,8 @@ class example/IfPredicate {
 package example;
 
 class IfPredicate {
-   public int test(Integer var1) {
-      return ((Number)var1).intValue();
+   public int test(Integer param) {
+      return ((Number)param).intValue();
    }
 }
 """, decompileToJava(bytes));
@@ -163,9 +169,12 @@ class example/IfPredicate {
 
   // access flags 0x1
   public test(I)Ljava/lang/Integer;
+   L0
     ILOAD 1
     INVOKESTATIC java/lang/Integer.valueOf (I)Ljava/lang/Integer;
     ARETURN
+   L1
+    LOCALVARIABLE param I L0 L1 1
 }
 """, bytecode);
 
@@ -174,8 +183,8 @@ class example/IfPredicate {
 package example;
 
 class IfPredicate {
-   public Integer test(int var1) {
-      return var1;
+   public Integer test(int param) {
+      return param;
    }
 }
 """, decompileToJava(bytes));
@@ -232,11 +241,15 @@ final enum MyEnum extends java/lang/Enum {
 
   // access flags 0x2
   private <init>(Ljava/lang/String;I)V
+   L0
     ALOAD 0
     ALOAD 1
     ILOAD 2
     INVOKESPECIAL java/lang/Enum.<init> (Ljava/lang/String;I)V
     RETURN
+   L1
+    LOCALVARIABLE arg0 Ljava/lang/String; L0 L1 1
+    LOCALVARIABLE arg1 I L0 L1 2
 
   // access flags 0xA
   private static $values()[LMyEnum;
@@ -265,11 +278,14 @@ final enum MyEnum extends java/lang/Enum {
 
   // access flags 0x9
   public static valueOf(Ljava/lang/String;)LMyEnum;
+   L0
     LDC LMyEnum;.class
     ALOAD 0
     INVOKESTATIC java/lang/Enum.valueOf (Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Enum;
     CHECKCAST MyEnum
     ARETURN
+   L1
+    LOCALVARIABLE value Ljava/lang/String; L0 L1 1
 }
 """, bytecode);
     }
@@ -292,12 +308,12 @@ final enum MyEnum extends java/lang/Enum {
                     VariableDef.Field targetFieldAccess = aThis.field(targetField);
                     return StatementDef.multi(
                         targetFieldAccess.newLocal("target", targetVar ->
-                            targetVar.isNull(
+                            targetVar.ifNull(
                                 new StatementDef.Synchronized(
                                     aThis,
                                     StatementDef.multi(
                                         targetVar.assign(targetFieldAccess),
-                                        targetVar.isNull(
+                                        targetVar.ifNull(
                                             StatementDef.multi(
                                                 targetFieldAccess.assign(ExpressionDef.nullValue()),
                                                 aThis.field(beanResolutionContextField).assign(ExpressionDef.nullValue())
@@ -338,23 +354,24 @@ class test/MyClass {
 
   // access flags 0x1
   public interceptedTarget()Ljava/lang/Object;
+   L0
     ALOAD 0
     GETFIELD test/MyClass.target : Ltest/SomeTarget;
     ASTORE 1
     ALOAD 1
-    IFNONNULL L0
-    TRYCATCHBLOCK L1 L2 L3 null
-    TRYCATCHBLOCK L3 L4 L3 null
+    IFNONNULL L1
+    TRYCATCHBLOCK L2 L3 L4 null
+    TRYCATCHBLOCK L4 L5 L4 null
     ALOAD 0
     DUP
     ASTORE 2
     MONITORENTER
-   L1
+   L2
     ALOAD 0
     GETFIELD test/MyClass.target : Ltest/SomeTarget;
     ASTORE 1
     ALOAD 1
-    IFNONNULL L5
+    IFNONNULL L6
     ALOAD 0
     ACONST_NULL
     CHECKCAST test/SomeTarget
@@ -363,23 +380,25 @@ class test/MyClass {
     ACONST_NULL
     CHECKCAST io/micronaut/context/BeanResolutionContext
     PUTFIELD test/MyClass.$beanResolutionContext : Lio/micronaut/context/BeanResolutionContext;
-   L5
+   L6
     ALOAD 2
     MONITOREXIT
-   L2
-    GOTO L6
    L3
+    GOTO L7
+   L4
     ASTORE 3
     ALOAD 2
     MONITOREXIT
-   L4
+   L5
     ALOAD 3
     ATHROW
-   L6
-   L0
+   L7
+   L1
     ALOAD 0
     GETFIELD test/MyClass.target : Ltest/SomeTarget;
     ARETURN
+   L8
+    LOCALVARIABLE target Ltest/SomeTarget; L0 L8 1
 }
 """, bytecode);
 
@@ -394,11 +413,11 @@ class MyClass {
    private SomeTarget target;
 
    public Object interceptedTarget() {
-      SomeTarget var1 = this.target;
-      if (var1 == null) {
+      SomeTarget target = this.target;
+      if (target == null) {
          synchronized(this) {
-            var1 = this.target;
-            if (var1 == null) {
+            target = this.target;
+            if (target == null) {
                this.target = (SomeTarget)null;
                this.$beanResolutionContext = (BeanResolutionContext)null;
             }
@@ -426,10 +445,10 @@ class MyClass {
                 .build((aThis, methodParameters) -> {
                     VariableDef.Field myFieldAccess = aThis.field(myField);
                     return StatementDef.multi(
-                        myFieldAccess.isNull(
+                        myFieldAccess.ifNull(
                             ExpressionDef.constant(1).returning()
                         ),
-                        myFieldAccess.isNonNull(
+                        myFieldAccess.ifNonNull(
                             ExpressionDef.constant(2).returning()
                         ),
                         myFieldAccess.returning()
@@ -590,11 +609,13 @@ class test/MyClass {
 
   // access flags 0x1
   public swap(Ljava/lang/Object;)Ljava/lang/Object;
+   L0
     GETSTATIC java/lang/System.out : Ljava/io/PrintStream;
     LDC "Hello"
     INVOKEVIRTUAL java/io/PrintStream.println (Ljava/lang/String;)V
-    TRYCATCHBLOCK L0 L1 L2 null
-   L0
+    TRYCATCHBLOCK L1 L2 L3 null
+   L1
+   L4
     ALOAD 0
     GETFIELD test/MyClass.target : Ljava/lang/Object;
     ASTORE 2
@@ -608,17 +629,21 @@ class test/MyClass {
     INVOKEVIRTUAL java/io/PrintStream.println (Ljava/lang/String;)V
     ALOAD 3
     ARETURN
-   L1
-    GOTO L3
+   L5
+    LOCALVARIABLE target Ljava/lang/Object; L4 L5 2
    L2
+    GOTO L6
+   L3
     ASTORE 4
     GETSTATIC java/lang/System.out : Ljava/io/PrintStream;
     LDC "World"
     INVOKEVIRTUAL java/io/PrintStream.println (Ljava/lang/String;)V
     ALOAD 4
     ATHROW
-    GOTO L3
-   L3
+    GOTO L6
+   L6
+   L7
+    LOCALVARIABLE arg1 Ljava/lang/Object; L0 L7 1
 }
 """, bytecode);
 
@@ -628,14 +653,14 @@ package test;
 class MyClass {
    private final Object target;
 
-   public Object swap(Object var1) {
+   public Object swap(Object arg1) {
       System.out.println("Hello");
 
       try {
-         Object var2 = this.target;
-         this.target = var1;
+         Object target = this.target;
+         this.target = arg1;
          System.out.println("World");
-         return var2;
+         return target;
       } finally {
          System.out.println("World");
       }
@@ -690,28 +715,31 @@ class test/MyClass {
 
   // access flags 0x1
   public swap(I)I
+   L0
     ILOAD 1
     TABLESWITCH
-      1: L0
-      2: L1
-      3: L0
-      4: L0
-      5: L0
-      6: L0
-      7: L0
-      default: L2
-   L0
+      1: L1
+      2: L2
+      3: L1
+      4: L1
+      5: L1
+      6: L1
+      7: L1
+      default: L3
+   L1
     BIPUSH 123
     IRETURN
-    GOTO L3
-   L1
+    GOTO L4
+   L2
     BIPUSH 111
     IRETURN
-    GOTO L3
-   L2
+    GOTO L4
+   L3
     SIPUSH 444
     IRETURN
-   L3
+   L4
+   L5
+    LOCALVARIABLE arg1 I L0 L5 1
 }
 """, bytecode);
 
@@ -719,8 +747,8 @@ class test/MyClass {
 package test;
 
 class MyClass {
-   public int swap(int var1) {
-      switch (var1) {
+   public int swap(int arg1) {
+      switch (arg1) {
          case 1:
          case 3:
          case 4:
@@ -784,28 +812,31 @@ class test/MyClass {
 
   // access flags 0x1
   public swap(I)I
+   L0
     ILOAD 1
     LOOKUPSWITCH
-      1: L0
-      20: L1
-      30: L0
-      40: L0
-      50: L0
-      60: L0
-      70: L0
-      default: L2
-   L0
+      1: L1
+      20: L2
+      30: L1
+      40: L1
+      50: L1
+      60: L1
+      70: L1
+      default: L3
+   L1
     BIPUSH 123
     IRETURN
-    GOTO L3
-   L1
+    GOTO L4
+   L2
     BIPUSH 111
     IRETURN
-    GOTO L3
-   L2
+    GOTO L4
+   L3
     SIPUSH 444
     IRETURN
-   L3
+   L4
+   L5
+    LOCALVARIABLE arg1 I L0 L5 1
 }
 """, bytecode);
 
@@ -813,8 +844,8 @@ class test/MyClass {
 package test;
 
 class MyClass {
-   public int swap(int var1) {
-      switch (var1) {
+   public int swap(int arg1) {
+      switch (arg1) {
          case 1:
          case 30:
          case 40:
@@ -950,11 +981,15 @@ public final enum example/MyEnumWithInnerTypes extends java/lang/Enum {
 
   // access flags 0x2
   private <init>(Ljava/lang/String;I)V
+   L0
     ALOAD 0
     ALOAD 1
     ILOAD 2
     INVOKESPECIAL java/lang/Enum.<init> (Ljava/lang/String;I)V
     RETURN
+   L1
+    LOCALVARIABLE arg0 Ljava/lang/String; L0 L1 1
+    LOCALVARIABLE arg1 I L0 L1 2
 
   // access flags 0xA
   private static $values()[Lexample/MyEnumWithInnerTypes;
@@ -983,11 +1018,14 @@ public final enum example/MyEnumWithInnerTypes extends java/lang/Enum {
 
   // access flags 0x9
   public static valueOf(Ljava/lang/String;)Lexample/MyEnumWithInnerTypes;
+   L0
     LDC Lexample/MyEnumWithInnerTypes;.class
     ALOAD 0
     INVOKESTATIC java/lang/Enum.valueOf (Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Enum;
     CHECKCAST example/MyEnumWithInnerTypes
     ARETURN
+   L1
+    LOCALVARIABLE value Ljava/lang/String; L0 L1 1
 
   // access flags 0x1
   public myName()Ljava/lang/String;
@@ -1013,6 +1051,307 @@ public enum MyEnumWithInnerTypes {
 
    public String myName() {
       return this.toString();
+   }
+}
+""", decompileToJava(bytes));
+    }
+
+    @Test
+    void testLocalVariable() {
+        MethodDef method = MethodDef.builder("test").addParameter("myIn", String.class)
+            .returns(int.class)
+            .build((aThis, methodParameters) -> {
+                return methodParameters.get(0).invokeHashCode().newLocal("hc", hcVar -> {
+                    return hcVar.math("+", TypeDef.Primitive.INT.constant(4)).returning();
+                });
+            });
+        ClassDef classDef = ClassDef.builder("example.Test")
+            .addMethod(method)
+            .build();
+
+        StringWriter bytecodeWriter = new StringWriter();
+        byte[] bytes = generateFile(classDef, bytecodeWriter);
+        String bytecode = bytecodeWriter.toString();
+
+        Assertions.assertEquals("""
+// class version 61.0 (61)
+// access flags 0x0
+// signature Ljava/lang/Object;
+// declaration: example/Test
+class example/Test {
+
+
+  // access flags 0x0
+  <init>()V
+    ALOAD 0
+    INVOKESPECIAL java/lang/Object.<init> ()V
+    RETURN
+
+  // access flags 0x0
+  test(Ljava/lang/String;)I
+   L0
+   L1
+    ALOAD 1
+    IFNONNULL L2
+    ICONST_0
+    GOTO L3
+   L2
+    ALOAD 1
+    INVOKEVIRTUAL java/lang/String.hashCode ()I
+   L3
+    ISTORE 2
+    ILOAD 2
+    ICONST_4
+    IADD
+    IRETURN
+   L4
+    LOCALVARIABLE myIn Ljava/lang/String; L0 L4 1
+    LOCALVARIABLE hc I L1 L4 2
+}
+""", bytecode);
+
+        Assertions.assertEquals("""
+package example;
+
+class Test {
+   int test(String myIn) {
+      int hc = myIn == null ? 0 : myIn.hashCode();
+      return hc + 4;
+   }
+}
+""", decompileToJava(bytes));
+    }
+
+    @Test
+    void testMultipleCasts() {
+        MethodDef method = MethodDef.builder("test").addParameter("myIn", Object.class)
+            .returns(Integer.class)
+            .build((aThis, methodParameters) -> methodParameters.get(0).cast(TypeDef.Primitive.INT).cast(TypeDef.of(Integer.class)).returning());
+        ClassDef classDef = ClassDef.builder("example.Test")
+            .addMethod(method)
+            .build();
+
+        StringWriter bytecodeWriter = new StringWriter();
+        byte[] bytes = generateFile(classDef, bytecodeWriter);
+        String bytecode = bytecodeWriter.toString();
+
+        Assertions.assertEquals("""
+// class version 61.0 (61)
+// access flags 0x0
+// signature Ljava/lang/Object;
+// declaration: example/Test
+class example/Test {
+
+
+  // access flags 0x0
+  <init>()V
+    ALOAD 0
+    INVOKESPECIAL java/lang/Object.<init> ()V
+    RETURN
+
+  // access flags 0x0
+  test(Ljava/lang/Object;)Ljava/lang/Integer;
+   L0
+    ALOAD 1
+    CHECKCAST java/lang/Integer
+    ARETURN
+   L1
+    LOCALVARIABLE myIn Ljava/lang/Object; L0 L1 1
+}
+""", bytecode);
+
+        Assertions.assertEquals("""
+package example;
+
+class Test {
+   Integer test(Object myIn) {
+      return (Integer)myIn;
+   }
+}
+""", decompileToJava(bytes));
+    }
+
+    @Test
+    void testNullCast() {
+        MethodDef method = MethodDef.builder("test").addParameter("myIn", Object.class)
+            .returns(Integer.class)
+            .build((aThis, methodParameters) -> ExpressionDef.nullValue().cast(TypeDef.of(Integer.class)).returning());
+        ClassDef classDef = ClassDef.builder("example.Test")
+            .addMethod(method)
+            .build();
+
+        StringWriter bytecodeWriter = new StringWriter();
+        byte[] bytes = generateFile(classDef, bytecodeWriter);
+        String bytecode = bytecodeWriter.toString();
+
+        Assertions.assertEquals("""
+// class version 61.0 (61)
+// access flags 0x0
+// signature Ljava/lang/Object;
+// declaration: example/Test
+class example/Test {
+
+
+  // access flags 0x0
+  <init>()V
+    ALOAD 0
+    INVOKESPECIAL java/lang/Object.<init> ()V
+    RETURN
+
+  // access flags 0x0
+  test(Ljava/lang/Object;)Ljava/lang/Integer;
+   L0
+    ACONST_NULL
+    ARETURN
+   L1
+    LOCALVARIABLE myIn Ljava/lang/Object; L0 L1 1
+}
+""", bytecode);
+
+        Assertions.assertEquals("""
+package example;
+
+class Test {
+   Integer test(Object myIn) {
+      return null;
+   }
+}
+""", decompileToJava(bytes));
+    }
+
+    @Test
+    void testTrueFalseConditions() {
+        MethodDef method = MethodDef.builder("test")
+            .returns(boolean.class)
+            .build((aThis, methodParameters) ->
+                new ExpressionDef.Or(
+                    ExpressionDef.trueValue().isTrue().and(ExpressionDef.falseValue().isTrue()),
+                    ExpressionDef.trueValue().isTrue().or(ExpressionDef.falseValue().isTrue())
+                ).returning());
+        ClassDef classDef = ClassDef.builder("example.Test")
+            .addMethod(method)
+            .build();
+
+        StringWriter bytecodeWriter = new StringWriter();
+        byte[] bytes = generateFile(classDef, bytecodeWriter);
+        String bytecode = bytecodeWriter.toString();
+
+        Assertions.assertEquals("""
+// class version 61.0 (61)
+// access flags 0x0
+// signature Ljava/lang/Object;
+// declaration: example/Test
+class example/Test {
+
+
+  // access flags 0x0
+  <init>()V
+    ALOAD 0
+    INVOKESPECIAL java/lang/Object.<init> ()V
+    RETURN
+
+  // access flags 0x0
+  test()Z
+    ICONST_1
+    ICONST_1
+    IF_ICMPNE L0
+    ICONST_0
+    ICONST_1
+    IF_ICMPNE L0
+    GOTO L1
+   L0
+    ICONST_1
+    ICONST_1
+    IF_ICMPEQ L1
+    ICONST_0
+    ICONST_1
+    IF_ICMPEQ L1
+    GOTO L2
+   L1
+    ICONST_1
+    GOTO L3
+   L2
+    ICONST_0
+   L3
+    IRETURN
+}
+""", bytecode);
+
+        Assertions.assertEquals("""
+package example;
+
+class Test {
+   boolean test() {
+      return true && false || true || false;
+   }
+}
+""", decompileToJava(bytes));
+    }
+
+    @Test
+    void testTrueFalseConditions2() {
+        MethodDef method = MethodDef.builder("test")
+            .returns(boolean.class)
+            .build((aThis, methodParameters) ->
+                new ExpressionDef.And(
+                    ExpressionDef.trueValue().isTrue().or(ExpressionDef.falseValue().isTrue()),
+                    ExpressionDef.trueValue().isTrue().or(ExpressionDef.falseValue().isTrue())
+                ).returning());
+        ClassDef classDef = ClassDef.builder("example.Test")
+            .addMethod(method)
+            .build();
+
+        StringWriter bytecodeWriter = new StringWriter();
+        byte[] bytes = generateFile(classDef, bytecodeWriter);
+        String bytecode = bytecodeWriter.toString();
+
+        Assertions.assertEquals("""
+// class version 61.0 (61)
+// access flags 0x0
+// signature Ljava/lang/Object;
+// declaration: example/Test
+class example/Test {
+
+
+  // access flags 0x0
+  <init>()V
+    ALOAD 0
+    INVOKESPECIAL java/lang/Object.<init> ()V
+    RETURN
+
+  // access flags 0x0
+  test()Z
+    ICONST_1
+    ICONST_1
+    IF_ICMPEQ L0
+    ICONST_0
+    ICONST_1
+    IF_ICMPEQ L0
+    GOTO L1
+   L0
+    ICONST_1
+    ICONST_1
+    IF_ICMPEQ L2
+    ICONST_0
+    ICONST_1
+    IF_ICMPEQ L2
+    GOTO L1
+   L2
+    ICONST_1
+    GOTO L3
+   L1
+    ICONST_0
+   L3
+    IRETURN
+}
+""", bytecode);
+
+        Assertions.assertEquals("""
+package example;
+
+class Test {
+   boolean test() {
+      return (true || false) && (true || false);
    }
 }
 """, decompileToJava(bytes));

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertEquals;
 
 public class ExpressionWriteTest extends AbstractWriteTest {
 
-    private static final ClassTypeDef STRING = ClassTypeDef.of(String.class);
+    private static final ClassTypeDef STRING = ClassTypeDef.STRING;
 
     @Test
     public void returnConstantExpression() throws IOException {
@@ -102,19 +102,19 @@ public class ExpressionWriteTest extends AbstractWriteTest {
     @Test
     public void returnCastedVariable() throws IOException {
         ExpressionDef castedExpression = new Cast(
-            TypeDef.of(Object.class),
+            TypeDef.of(Integer.class),
             new VariableDef.Local("field", TypeDef.of(Object.class))
         );
         String result = writeMethodWithExpression(castedExpression);
 
-        assertEquals("(Object) field", result);
+        assertEquals("(Integer) field", result);
     }
 
     @Test
     public void returnAndCondition() throws IOException {
         ExpressionDef andExpression = new ExpressionDef.And(
-            ExpressionDef.trueValue(),
-            new VariableDef.Local("field", TypeDef.of(Object.class))
+            ExpressionDef.trueValue().isTrue(),
+            new VariableDef.Local("field", TypeDef.Primitive.BOOLEAN).isTrue()
         );
         String result = writeMethodWithExpression(andExpression);
 
@@ -122,10 +122,21 @@ public class ExpressionWriteTest extends AbstractWriteTest {
     }
 
     @Test
+    public void returnAndConditionFalse() throws IOException {
+        ExpressionDef andExpression = new ExpressionDef.And(
+            ExpressionDef.trueValue().isTrue(),
+            new VariableDef.Local("field", TypeDef.Primitive.BOOLEAN).isFalse()
+        );
+        String result = writeMethodWithExpression(andExpression);
+
+        assertEquals("true && !field", result);
+    }
+
+    @Test
     public void returnAndConditionWithParentheses() throws IOException {
         ExpressionDef andExpression = new ExpressionDef.And(
-            ExpressionDef.trueValue().asConditionOr(ExpressionDef.falseValue()),
-            ExpressionDef.trueValue().asConditionOr(ExpressionDef.falseValue())
+            ExpressionDef.trueValue().isTrue().or(ExpressionDef.falseValue().isTrue()),
+            ExpressionDef.trueValue().isTrue().or(ExpressionDef.falseValue().isTrue())
         );
         String result = writeMethodWithExpression(andExpression);
 
@@ -135,23 +146,23 @@ public class ExpressionWriteTest extends AbstractWriteTest {
     @Test
     public void returnOrCondition() throws IOException {
         ExpressionDef orExpression = new ExpressionDef.Or(
-            ExpressionDef.trueValue(),
-            new VariableDef.Local("field", TypeDef.of(Object.class))
+            ExpressionDef.trueValue().isTrue(),
+            new VariableDef.Local("field", TypeDef.Primitive.BOOLEAN).isTrue()
         );
         String result = writeMethodWithExpression(orExpression);
 
-        assertEquals("true || field", result);
+        assertEquals("(true || field)", result);
     }
 
     @Test
     public void returnOrConditionWithParentheses() throws IOException {
         ExpressionDef orExpression = new ExpressionDef.Or(
-            ExpressionDef.trueValue().asConditionAnd(ExpressionDef.falseValue()),
-            ExpressionDef.trueValue().asConditionOr(ExpressionDef.falseValue())
+            ExpressionDef.trueValue().isTrue().and(ExpressionDef.falseValue().isTrue()),
+            ExpressionDef.trueValue().isTrue().or(ExpressionDef.falseValue().isTrue())
         );
         String result = writeMethodWithExpression(orExpression);
 
-        assertEquals("true && false || (true || false)", result);
+        assertEquals("(true && false || (true || false))", result);
     }
 
     @Test

--- a/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
+++ b/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
@@ -32,8 +32,6 @@ import io.micronaut.sourcegen.model.ExpressionDef.*
 import io.micronaut.sourcegen.model.StatementDef.Assign
 import io.micronaut.sourcegen.model.StatementDef.DefineAndAssign
 import io.micronaut.sourcegen.model.StatementDef.PutField
-import io.micronaut.sourcegen.model.TypeDef
-import io.micronaut.sourcegen.model.VariableDef
 import java.io.IOException
 import java.io.Writer
 import java.lang.reflect.Array
@@ -950,6 +948,9 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 return codeBuilder.build()
             }
             if (expressionDef is Cast) {
+                if (expressionDef.type == expressionDef.expressionDef.type()) {
+                    return renderExpressionCode(objectDef, methodDef, expressionDef.expressionDef)
+                }
                 val codeBuilder = CodeBlock.builder()
                 codeBuilder.add(
                     renderExpressionCode(
@@ -1052,6 +1053,15 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 return CodeBlock.builder()
                     .add(renderExpressionCode(objectDef, methodDef, expressionDef.expression))
                     .add(" != null")
+                    .build()
+            }
+            if (expressionDef is IsTrue) {
+                return renderExpressionCode(objectDef, methodDef, expressionDef.expression)
+            }
+            if (expressionDef is IsFalse) {
+                return CodeBlock.builder()
+                    .add("!")
+                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.expression))
                     .build()
             }
             if (expressionDef is MathOp) {

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
@@ -192,7 +192,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                 parameter
                     .invoke("iterator", ClassTypeDef.of(Iterator.class))
                     .newLocal(parameter.name() + "Iterator", iteratorVar ->
-                        parameter.isNonNull().asConditionIf(
+                        parameter.ifNonNull(
                                 iteratorVar.invoke("hasNext", TypeDef.primitive(boolean.class))
                                     .whileLoop(
                                         arrayListVar.invoke("add", TypeDef.of(boolean.class), iteratorVar.invoke("next", ClassTypeDef.OBJECT))
@@ -284,12 +284,12 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(propertyName, TypeDef.parameterized(Collection.class, singularTypeDef))
                 .build((self, parameterDefs) -> StatementDef.multi(
-                    parameterDefs.get(0).isNull().asConditionIf(
+                    parameterDefs.get(0).isNull().doIf(
                         ClassTypeDef.of(NullPointerException.class)
                             .instantiate(ExpressionDef.constant(propertyName + " cannot be null"))
                             .doThrow()
                     ),
-                    self.field(field).isNull().asConditionIf(
+                    self.field(field).isNull().doIf(
                         self.field(field).assign(ClassTypeDef.of(ArrayList.class).instantiate())
                     ),
                     self.field(field).invoke("addAll", TypeDef.primitive(boolean.class), parameterDefs.get(0)),
@@ -299,7 +299,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(singularName, singularTypeDef)
                 .build((self, parameterDefs) -> StatementDef.multi(
-                    self.field(field).isNull().asConditionIf(
+                    self.field(field).isNull().doIf(
                         self.field(field).assign(ClassTypeDef.of(ArrayList.class).instantiate())
                     ),
                     self.field(field).invoke("add", TypeDef.of(boolean.class), parameterDefs.get(0)),
@@ -308,7 +308,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
             classBuilder.addMethod(MethodDef.builder("clear" + StringUtils.capitalize(propertyName))
                 .addModifiers(Modifier.PUBLIC)
                 .build((self, parameterDefs) -> StatementDef.multi(
-                    self.field(field).isNonNull().asConditionIf(
+                    self.field(field).isNonNull().doIf(
                         self.field(field).invoke("clear", TypeDef.VOID)
                     ),
                     returningExpressionProvider.apply(self)
@@ -328,12 +328,12 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(propertyName, TypeDef.parameterized(Map.class, keyType, valueType))
                 .build((self, parameterDefs) -> StatementDef.multi(
-                    parameterDefs.get(0).isNull().asConditionIf(
+                    parameterDefs.get(0).isNull().doIf(
                         ClassTypeDef.of(NullPointerException.class)
                             .instantiate(ExpressionDef.constant(propertyName + " cannot be null"))
                             .doThrow()
                     ),
-                    self.field(field).isNull().asConditionIf(
+                    self.field(field).isNull().doIf(
                         self.field(field).assign(fieldType.instantiate())
                     ),
                     self.field(field).invoke(
@@ -348,7 +348,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                 .addParameter("key", keyType)
                 .addParameter("value", valueType)
                 .build((self, parameterDefs) -> StatementDef.multi(
-                    self.field(field).isNull().asConditionIf(
+                    self.field(field).isNull().doIf(
                         self.field(field).assign(TypeDef.parameterized(ArrayList.class, TypeDef.parameterized(Map.Entry.class, keyType, valueType)).instantiate())
                     ),
                     self.field(field).invoke(
@@ -366,7 +366,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
             classBuilder.addMethod(MethodDef.builder("clear" + StringUtils.capitalize(propertyName))
                 .addModifiers(Modifier.PUBLIC)
                 .build((self, parameterDefs) -> StatementDef.multi(
-                    self.field(field).isNonNull().asConditionIf(
+                    self.field(field).isNonNull().doIf(
                         self.field(field).invoke("clear", TypeDef.VOID)
                     ),
                     returningExpressionProvider.apply(self)
@@ -416,7 +416,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                             TypeDef fieldType = propertyType.makeNullable();
                             if (fieldType.isNullable()) {
                                 statements.add(
-                                    self.field(propertyName, fieldType).isNonNull().asConditionIf(
+                                    self.field(propertyName, fieldType).isNonNull().doIf(
                                         instanceVar.invoke(
                                             writeMethod.get(),
                                             valueExpression(beanProperty, self.field(propertyName, fieldType))
@@ -454,7 +454,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
         String collectionType = propertyElement.getType().getName();
         ClassTypeDef elementType = propertyElement.getType().getFirstTypeArgument().map(ClassTypeDef::of).orElse(ClassTypeDef.OBJECT);
         TypeDef propertyType = TypeDef.of(propertyElement.getType());
-        ExpressionDef collectionSize = field.isNull().asConditionIfElse(
+        ExpressionDef collectionSize = field.ifNull(
             ExpressionDef.primitiveConstant(0),
             field.invoke("size", TypeDef.primitive(int.class))
         );

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassTypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassTypeDef.java
@@ -25,7 +25,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Matcher;
 
 /**
  * The class type definition.

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ExpressionDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ExpressionDef.java
@@ -85,7 +85,7 @@ public sealed interface ExpressionDef
      * @return The condition expression
      * @since 1.2
      */
-    default ExpressionDef asCondition(String op, ExpressionDef expression) {
+    default ConditionExpressionDef asCondition(String op, ExpressionDef expression) {
         return new ExpressionDef.Condition(op, this, expression);
     }
 
@@ -102,32 +102,10 @@ public sealed interface ExpressionDef
     }
 
     /**
-     * The and condition of this variable.
-     *
-     * @param expression The expression of this variable
-     * @return The "and" condition expression
-     * @since 1.3
-     */
-    default ExpressionDef asConditionAnd(ExpressionDef expression) {
-        return new ExpressionDef.And(this, expression);
-    }
-
-    /**
-     * The or condition of this variable.
-     *
-     * @param expression The expression of this variable
-     * @return The "or" condition expression
-     * @since 1.3
-     */
-    default ExpressionDef asConditionOr(ExpressionDef expression) {
-        return new ExpressionDef.Or(this, expression);
-    }
-
-    /**
      * @return Is non-null expression
      * @since 1.2
      */
-    default ExpressionDef isNonNull() {
+    default ConditionExpressionDef isNonNull() {
         return new ExpressionDef.IsNotNull(this);
     }
 
@@ -139,8 +117,8 @@ public sealed interface ExpressionDef
      * @return Is not null expression
      * @since 1.5
      */
-    default ExpressionDef isNonNull(ExpressionDef ifExpression, ExpressionDef elseExpression) {
-        return isNonNull().asConditionIfElse(ifExpression, elseExpression);
+    default ExpressionDef ifNonNull(ExpressionDef ifExpression, ExpressionDef elseExpression) {
+        return isNonNull().doIfElse(ifExpression, elseExpression);
     }
 
     /**
@@ -150,8 +128,8 @@ public sealed interface ExpressionDef
      * @return Is not null statement
      * @since 1.5
      */
-    default StatementDef isNonNull(StatementDef ifStatement) {
-        return isNonNull().asConditionIf(ifStatement);
+    default StatementDef ifNonNull(StatementDef ifStatement) {
+        return isNonNull().doIf(ifStatement);
     }
 
     /**
@@ -162,15 +140,15 @@ public sealed interface ExpressionDef
      * @return Is not null statement
      * @since 1.5
      */
-    default StatementDef isNonNull(StatementDef ifStatement, StatementDef elseStatement) {
-        return isNonNull().asConditionIfElse(ifStatement, elseStatement);
+    default StatementDef ifNonNull(StatementDef ifStatement, StatementDef elseStatement) {
+        return isNonNull().doIfElse(ifStatement, elseStatement);
     }
 
     /**
      * @return Is null expression
      * @since 1.2
      */
-    default ExpressionDef isNull() {
+    default ConditionExpressionDef isNull() {
         return new ExpressionDef.IsNull(this);
     }
 
@@ -182,8 +160,8 @@ public sealed interface ExpressionDef
      * @return Is null expression
      * @since 1.5
      */
-    default ExpressionDef isNull(ExpressionDef ifExpression, ExpressionDef elseExpression) {
-        return isNull().asConditionIfElse(ifExpression, elseExpression);
+    default ExpressionDef ifNull(ExpressionDef ifExpression, ExpressionDef elseExpression) {
+        return isNull().doIfElse(ifExpression, elseExpression);
     }
 
     /**
@@ -193,8 +171,8 @@ public sealed interface ExpressionDef
      * @return Is null statement
      * @since 1.5
      */
-    default StatementDef isNull(StatementDef ifStatement) {
-        return isNull().asConditionIf(ifStatement);
+    default StatementDef ifNull(StatementDef ifStatement) {
+        return isNull().doIf(ifStatement);
     }
 
     /**
@@ -205,8 +183,8 @@ public sealed interface ExpressionDef
      * @return Is null statement
      * @since 1.5
      */
-    default StatementDef isNull(StatementDef ifStatement, StatementDef elseStatement) {
-        return isNull().asConditionIfElse(ifStatement, elseStatement);
+    default StatementDef ifNull(StatementDef ifStatement, StatementDef elseStatement) {
+        return isNull().doIfElse(ifStatement, elseStatement);
     }
 
     /**
@@ -214,7 +192,42 @@ public sealed interface ExpressionDef
      * @since 1.5
      */
     default ExpressionDef.ConditionExpressionDef isTrue() {
-        return new ExpressionDef.Condition("==", trueValue(), this);
+        return new ExpressionDef.IsTrue(this.cast(TypeDef.Primitive.BOOLEAN));
+    }
+
+    /**
+     * Is true - if / else expression.
+     *
+     * @param ifExpression   If expression
+     * @param elseExpression Else expression
+     * @return Is true expression
+     * @since 1.5
+     */
+    default ExpressionDef ifTrue(ExpressionDef ifExpression, ExpressionDef elseExpression) {
+        return isTrue().doIfElse(ifExpression, elseExpression);
+    }
+
+    /**
+     * Is true - if statement.
+     *
+     * @param ifStatement If statement
+     * @return Is true statement
+     * @since 1.5
+     */
+    default StatementDef ifTrue(StatementDef ifStatement) {
+        return isTrue().doIf(ifStatement);
+    }
+
+    /**
+     * Is true - if / else statement.
+     *
+     * @param ifStatement   If statement
+     * @param elseStatement Else statement
+     * @return Is true statement
+     * @since 1.5
+     */
+    default StatementDef ifTrue(StatementDef ifStatement, StatementDef elseStatement) {
+        return isTrue().doIfElse(ifStatement, elseStatement);
     }
 
     /**
@@ -222,7 +235,42 @@ public sealed interface ExpressionDef
      * @since 1.5
      */
     default ExpressionDef.ConditionExpressionDef isFalse() {
-        return new ExpressionDef.Condition("==", falseValue(), this);
+        return new ExpressionDef.IsFalse(this.cast(TypeDef.Primitive.BOOLEAN));
+    }
+
+    /**
+     * Is false - if / else expression.
+     *
+     * @param ifExpression   If expression
+     * @param elseExpression Else expression
+     * @return Is false expression
+     * @since 1.5
+     */
+    default ExpressionDef ifFalse(ExpressionDef ifExpression, ExpressionDef elseExpression) {
+        return isFalse().doIfElse(ifExpression, elseExpression);
+    }
+
+    /**
+     * Is false - if statement.
+     *
+     * @param ifStatement If statement
+     * @return Is null statement
+     * @since 1.5
+     */
+    default StatementDef ifFalse(StatementDef ifStatement) {
+        return isFalse().doIf(ifStatement);
+    }
+
+    /**
+     * Is false - if / else statement.
+     *
+     * @param ifStatement   If statement
+     * @param elseStatement Else statement
+     * @return Is false statement
+     * @since 1.5
+     */
+    default StatementDef ifFalse(StatementDef ifStatement, StatementDef elseStatement) {
+        return isFalse().doIfElse(ifStatement, elseStatement);
     }
 
     /**
@@ -285,41 +333,6 @@ public sealed interface ExpressionDef
     }
 
     /**
-     * The conditional statement based on this expression.
-     *
-     * @param statement The statement
-     * @return The statement returning this expression
-     * @since 1.2
-     */
-    default StatementDef asConditionIf(StatementDef statement) {
-        return new StatementDef.If(this, statement);
-    }
-
-    /**
-     * The conditional statement based on this expression.
-     *
-     * @param statement     The statement
-     * @param elseStatement The else statement
-     * @return The statement returning this expression
-     * @since 1.2
-     */
-    default StatementDef asConditionIfElse(StatementDef statement, StatementDef elseStatement) {
-        return new StatementDef.IfElse(this, statement, elseStatement);
-    }
-
-    /**
-     * The conditional if else expression.
-     *
-     * @param expression     The expression
-     * @param elseExpression The else expression
-     * @return The statement returning this expression
-     * @since 1.2
-     */
-    default ExpressionDef asConditionIfElse(ExpressionDef expression, ExpressionDef elseExpression) {
-        return new ExpressionDef.IfElse(this, expression, elseExpression);
-    }
-
-    /**
      * Turn this expression into a new local variable.
      *
      * @param name The local name
@@ -339,10 +352,10 @@ public sealed interface ExpressionDef
      * @since 1.2
      */
     default StatementDef newLocal(String name, Function<VariableDef, StatementDef> fn) {
-        StatementDef.DefineAndAssign defineAndAssign = newLocal(name);
+        VariableDef.Local local = new VariableDef.Local(name, type());
         return StatementDef.multi(
-            defineAndAssign,
-            fn.apply(defineAndAssign.variable())
+            new StatementDef.DefineAndAssign(local, this),
+            fn.apply(local)
         );
     }
 
@@ -891,6 +904,12 @@ public sealed interface ExpressionDef
     record NewInstance(ClassTypeDef type,
                        List<TypeDef> parameterTypes,
                        List<? extends ExpressionDef> values) implements ExpressionDef {
+
+        public NewInstance {
+            if (parameterTypes.size() != values.size()) {
+                throw new IllegalStateException("Cannot create a new instance of " + type.getName() + " parameters: " + parameterTypes.size() + " doesn't match values provided: " + values.size());
+            }
+        }
     }
 
     /**
@@ -965,6 +984,13 @@ public sealed interface ExpressionDef
     record InvokeStaticMethod(ClassTypeDef classDef,
                               MethodDef method,
                               List<? extends ExpressionDef> values) implements ExpressionDef, StatementDef {
+
+        public InvokeStaticMethod {
+            if (method.getParameters().size() != values.size()) {
+                throw new IllegalStateException("Method " + classDef.getName() + "#" + method.getName() + " parameters: " + method.getParameters().size() + " doesn't match values provided: " + values.size());
+            }
+        }
+
         @Override
         public TypeDef type() {
             return method.getReturnType();
@@ -1024,6 +1050,26 @@ public sealed interface ExpressionDef
     }
 
     /**
+     * The IS TRUE condition.
+     *
+     * @param expression The expression
+     * @author Denis Stepanov
+     */
+    @Experimental
+    record IsTrue(ExpressionDef expression) implements ConditionExpressionDef {
+    }
+
+    /**
+     * The IS FALSE condition.
+     *
+     * @param expression The expression
+     * @author Denis Stepanov
+     */
+    @Experimental
+    record IsFalse(ExpressionDef expression) implements ConditionExpressionDef {
+    }
+
+    /**
      * The and condition. Puts parenthesis around itself when needed.
      *
      * @param left  The left expression
@@ -1032,7 +1078,7 @@ public sealed interface ExpressionDef
      * @since 1.3
      */
     @Experimental
-    record And(ExpressionDef left, ExpressionDef right) implements ConditionExpressionDef {
+    record And(ConditionExpressionDef left, ConditionExpressionDef right) implements ConditionExpressionDef {
     }
 
     /**
@@ -1044,7 +1090,7 @@ public sealed interface ExpressionDef
      * @since 1.3
      */
     @Experimental
-    record Or(ExpressionDef left, ExpressionDef right) implements ConditionExpressionDef {
+    record Or(ConditionExpressionDef left, ConditionExpressionDef right) implements ConditionExpressionDef {
     }
 
     /**
@@ -1244,6 +1290,63 @@ public sealed interface ExpressionDef
         @Override
         default TypeDef type() {
             return TypeDef.Primitive.BOOLEAN;
+        }
+
+        /**
+         * The conditional statement based on this expression.
+         *
+         * @param statement The statement
+         * @return The statement returning this expression
+         * @since 1.5
+         */
+        default StatementDef doIf(StatementDef statement) {
+            return new StatementDef.If(this, statement);
+        }
+
+        /**
+         * The conditional statement based on this expression.
+         *
+         * @param statement     The statement
+         * @param elseStatement The else statement
+         * @return The statement returning this expression
+         * @since 1.5
+         */
+        default StatementDef doIfElse(StatementDef statement, StatementDef elseStatement) {
+            return new StatementDef.IfElse(this, statement, elseStatement);
+        }
+
+        /**
+         * The conditional if else expression.
+         *
+         * @param expression     The expression
+         * @param elseExpression The else expression
+         * @return The statement returning this expression
+         * @since 1.5
+         */
+        default ExpressionDef doIfElse(ExpressionDef expression, ExpressionDef elseExpression) {
+            return new ExpressionDef.IfElse(this, expression, elseExpression);
+        }
+
+        /**
+         * The and condition of this variable.
+         *
+         * @param expression The expression of this variable
+         * @return The "and" condition expression
+         * @since 1.5
+         */
+        default ConditionExpressionDef and(ConditionExpressionDef expression) {
+            return new ExpressionDef.And(this, expression);
+        }
+
+        /**
+         * The or condition of this variable.
+         *
+         * @param expression The expression of this variable
+         * @return The "or" condition expression
+         * @since 1.5
+         */
+        default ConditionExpressionDef or(ConditionExpressionDef expression) {
+            return new ExpressionDef.Or(this, expression);
         }
 
     }

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/JavaIdioms.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/JavaIdioms.java
@@ -104,7 +104,7 @@ public final class JavaIdioms {
             return primitive.wrapperType()
                 .invokeStatic("hashCode", primitiveIntType, instance);
         }
-        return instance.isNull().asConditionIfElse(
+        return instance.ifNull(
             primitiveIntType.constant(0),
             instance.invoke(OBJECT_HASHCODE)
         );

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/VariableDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/VariableDef.java
@@ -58,7 +58,7 @@ public sealed interface VariableDef extends ExpressionDef permits VariableDef.Ex
     record Local(String name, TypeDef type) implements VariableDef {
 
         @Override
-        public StatementDef assign(ExpressionDef expression) {
+        public StatementDef.Assign assign(ExpressionDef expression) {
             return new StatementDef.Assign(this, expression);
         }
 

--- a/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateIfsPredicateVisitor.java
+++ b/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateIfsPredicateVisitor.java
@@ -61,7 +61,7 @@ public final class GenerateIfsPredicateVisitor implements TypeElementVisitor<Gen
                 .overrides()
                 .returns(boolean.class)
                 .build((aThis, methodParameters) -> StatementDef.multi(
-                    methodParameters.get(0).isNull().asConditionIf(TypeDef.Primitive.TRUE.returning()),
+                    methodParameters.get(0).isNull().doIf(TypeDef.Primitive.TRUE.returning()),
                     TypeDef.Primitive.FALSE.returning()
                 )))
             .build();
@@ -75,7 +75,7 @@ public final class GenerateIfsPredicateVisitor implements TypeElementVisitor<Gen
                 .overrides()
                 .returns(boolean.class)
                 .build((aThis, methodParameters) -> StatementDef.multi(
-                    methodParameters.get(0).isNonNull().asConditionIf(TypeDef.Primitive.TRUE.returning()),
+                    methodParameters.get(0).isNonNull().doIf(TypeDef.Primitive.TRUE.returning()),
                     TypeDef.Primitive.FALSE.returning()
                 )))
             .build();
@@ -89,7 +89,10 @@ public final class GenerateIfsPredicateVisitor implements TypeElementVisitor<Gen
                 .overrides()
                 .returns(boolean.class)
                 .build((aThis, methodParameters)
-                    -> methodParameters.get(0).isNull().asConditionIfElse(TypeDef.Primitive.TRUE.returning(), TypeDef.Primitive.FALSE.returning())))
+                    -> methodParameters.get(0).ifNull(
+                        TypeDef.Primitive.TRUE.returning(),
+                        TypeDef.Primitive.FALSE.returning()
+                )))
             .build();
 
         sourceGenerator.write(ifElsePredicateDef, context, element);
@@ -98,8 +101,8 @@ public final class GenerateIfsPredicateVisitor implements TypeElementVisitor<Gen
             .addMethod(MethodDef.builder("test").addParameter(PARAM, paramType)
                 .addModifiers(Modifier.PUBLIC)
                 .returns(int.class)
-                .build((aThis, methodParameters) -> methodParameters.get(0).isNull()
-                    .asConditionIfElse(
+                .build((aThis, methodParameters) -> methodParameters.get(0)
+                    .ifNull(
                         TypeDef.Primitive.INT.constant(1).returning(),
                         TypeDef.Primitive.INT.constant(2).returning()
                     )))
@@ -114,8 +117,7 @@ public final class GenerateIfsPredicateVisitor implements TypeElementVisitor<Gen
                 .overrides()
                 .addStatement(
                     new VariableDef.MethodParameter(PARAM, paramType)
-                        .isNull()
-                        .asConditionIfElse(
+                        .ifNull(
                             ExpressionDef.trueValue().returning(),
                             ExpressionDef.falseValue().returning()
                         )
@@ -130,7 +132,7 @@ public final class GenerateIfsPredicateVisitor implements TypeElementVisitor<Gen
             .addMethod(MethodDef.builder("test").addParameter(PARAM, paramType)
                 .addModifiers(Modifier.PUBLIC)
                 .returns(boolean.class)
-                .build((self, methodParameters) -> methodParameters.get(0).isNull().asConditionIfElse(
+                .build((self, methodParameters) -> methodParameters.get(0).ifNull(
                     ExpressionDef.trueValue(),
                     ExpressionDef.falseValue()
                 ).returning())
@@ -143,7 +145,7 @@ public final class GenerateIfsPredicateVisitor implements TypeElementVisitor<Gen
             .addMethod(MethodDef.builder("test").addParameter(PARAM, paramType)
                 .addModifiers(Modifier.PUBLIC)
                 .returns(int.class)
-                .build((self, methodParameters) -> methodParameters.get(0).isNull().asConditionIfElse(
+                .build((self, methodParameters) -> methodParameters.get(0).ifNull(
                     TypeDef.Primitive.INT.constant(1),
                     TypeDef.Primitive.INT.constant(2)
                 ).returning())
@@ -159,7 +161,7 @@ public final class GenerateIfsPredicateVisitor implements TypeElementVisitor<Gen
                 .overrides()
                 .returns(boolean.class)
                 .build((aThis, methodParameters) -> StatementDef.multi(
-                    methodParameters.get(0).isNull().asConditionIf(TypeDef.Primitive.TRUE.returning()),
+                    methodParameters.get(0).isNull().doIf(TypeDef.Primitive.TRUE.returning()),
                     TypeDef.Primitive.FALSE.returning()
                 )))
             .build();
@@ -176,7 +178,7 @@ public final class GenerateIfsPredicateVisitor implements TypeElementVisitor<Gen
                 .addModifiers(Modifier.PUBLIC)
                 .returns(boolean.class)
                 .build((aThis, methodParameters) -> StatementDef.multi(
-                    methodParameters.get(0).isNull().asConditionIf(TypeDef.Primitive.TRUE.returning()),
+                    methodParameters.get(0).isNull().doIf(TypeDef.Primitive.TRUE.returning()),
                     TypeDef.Primitive.FALSE.returning()
                 )))
             .build();


### PR DESCRIPTION
- Refactoring of conditions, `isXyz` syntax returns a conditional expression `ifXyz` allows to direct create an if/else statement/expression - make the syntax much better
- Moved main conditional methods to `ConditionExpressionDef` requiring `or`/`and` to use a condition
- Now it's required to convert blind expression to a condition by calling `isTrue`/`isFalse`/`IsNull` etc
- Fixes for bytecode generator + support for adding correct variables and parameters names for better reading decompiled classes
- Bytecode checker turn off by default