### PR TITLE
Broaden annotation capabilities in Kotlin

### DIFF
--- a/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
+++ b/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
@@ -1314,7 +1314,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             }
 
             is ClassTypeDef -> {
-                builder.addMember(memberName, "%L::class", value.getSimpleName())
+                builder.addMember("$memberName = %L::class", value.getSimpleName())
             }
 
             is Enum<*> -> {
@@ -1338,20 +1338,19 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             }
 
             is VariableDef -> {
-                builder.addMember(memberName, renderVariable(null, null, value))
+                builder.addMember("$memberName = %L", renderVariable(null, null, value))
             }
 
             is AnnotationDef -> {
-                // builder does not process AnnotationSpec as member
                 val spec = asAnnotationSpec(value)
-                builder.addMember(memberName, spec)
+                builder.addMember("$memberName = %L", spec)
             }
 
             is Collection<*> -> {
                 value.forEach(Consumer { v: Any? -> addAnnotationValue(builder, memberName, v!!) })
                 val listItems = builder.members.filter { it.isNotEmpty() && it.toString().contains(memberName) }
                 builder.members.removeAll(listItems)
-                val listStr: String = listItems.map { it.toString().substringAfter("= ") }.joinToString()
+                val listStr: String = listItems.map { it.toString().substringAfter("= ") }.joinToString(separator = ",\n")
                 builder.addMember("$memberName = listOf(%L)", listStr)
             }
 

--- a/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/AnnotationTest.kt
+++ b/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/AnnotationTest.kt
@@ -1,0 +1,131 @@
+package io.micronaut.sourcegen
+
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.sourcegen.model.*
+import org.junit.Assert
+import org.junit.Test
+import java.io.IOException
+import java.io.StringWriter
+
+class AnnotationTest {
+    private val PATTERN_ANN: String = "jakarta.validation.constraints.Pattern"
+    private val JSON_SUB_TYPES_ANN: String = "com.fasterxml.jackson.annotation.JsonSubTypes"
+    private val JSON_SUB_TYPES_TYPE_ANN: String = "$JSON_SUB_TYPES_ANN.Type"
+
+    @Test
+    @Throws(IOException::class)
+    fun writeSimpleAnnotation() {
+        val classDef = ClassDef.builder("SimpleClass").addAnnotation(Introspected::class.java).build()
+        val result = writeClass(classDef)
+
+        val expected = """
+        @Introspected
+        public class SimpleClass
+        """.trimIndent()
+        Assert.assertEquals(expected.trim(), result.trim())
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun writeAnnotationWithVariable() {
+        val annDef = AnnotationDef.builder(ClassTypeDef.of(PATTERN_ANN))
+            .addMember("regex", "hii")
+            .build()
+        val classDef = ClassDef.builder("SimpleClass")
+            .addAnnotation(Introspected::class.java)
+            .addField(FieldDef.builder("str").ofType(TypeDef.STRING).addAnnotation(annDef).build())
+            .build()
+        val result = writeClass(classDef)
+
+        val expected = """
+        @Introspected
+        public class SimpleClass {
+          @Pattern(regex = "hii")
+          public var str: String
+        }
+        """.trimIndent()
+        Assert.assertEquals(expected.trim(), result.trim())
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun writeAnnotationWithListVariable() {
+        val simpleAnn = getSimpleAnn()
+        val classDef = ClassDef.builder("SimpleClass")
+            .addAnnotation(simpleAnn)
+            .build()
+        val result = writeClass(classDef)
+
+        val expected = """
+        @Simple(value = listOf(1, 2, 3))
+        public class SimpleClass
+        """.trimIndent()
+        Assert.assertEquals(expected.trim(), result.trim())
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun writeAnnotationWithAnnListVariable() {
+        val annDef = getJsonSubTypesAnn()
+        val classDef = ClassDef.builder("SimpleClass")
+            .addAnnotation(annDef)
+            .build()
+        val result = writeClass(classDef)
+
+        val expected = """
+        @JsonSubTypes(
+        value = listOf(
+                @JsonSubTypes.Type(
+                    value = String.class,
+                    name = "Cat"
+                ),
+                @JsonSubTypes.Type(
+                    value = String.class,
+                    name = "Dog"
+                ),
+                @JsonSubTypes.Type(
+                    value = String.class,
+                    name = "Fish"
+                )
+            )
+        )
+        public class SimpleClass
+        """.trimIndent()
+        Assert.assertEquals(expected.trim(), result.trim())
+    }
+
+    private fun getSimpleAnn(): AnnotationDef {
+        val numbers = listOf(1,2,3)
+        return AnnotationDef.builder(ClassTypeDef.of("Simple"))
+            .addMember("value", numbers)
+            .build()
+    }
+
+    private fun getJsonSubTypesAnn(): AnnotationDef {
+        val mapping = mapOf("Cat" to String::class, "Dog" to String::class, "Fish" to String::class)
+        val subTypeList = mapping.entries
+            .map { entry: Map.Entry<String, Any> ->
+                AnnotationDef
+                    .builder(ClassTypeDef.of(JSON_SUB_TYPES_TYPE_ANN))
+                    .addMember("value", entry.value)
+                    .addMember("name", entry.key)
+                    .build()
+            }
+            .toList()
+        return AnnotationDef.builder(ClassTypeDef.of(JSON_SUB_TYPES_ANN))
+            .addMember("value", subTypeList)
+            .build()
+    }
+
+    @Throws(IOException::class)
+    private fun writeClass(classDef: ClassDef): String {
+        val generator: KotlinPoetSourceGenerator = KotlinPoetSourceGenerator()
+        var result: String
+        StringWriter().use { writer ->
+            generator.write(classDef, writer)
+            result = writer.toString()
+        }
+
+        return result.substring(result.indexOf("@"), result.length)
+    }
+}

--- a/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/AnnotationTest.kt
+++ b/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/AnnotationTest.kt
@@ -57,7 +57,9 @@ class AnnotationTest {
         val result = writeClass(classDef)
 
         val expected = """
-        @Simple(value = listOf(1, 2, 3))
+        @Simple(value = listOf(1,
+        2,
+        3))
         public class SimpleClass
         """.trimIndent()
         Assert.assertEquals(expected.trim(), result.trim())
@@ -73,22 +75,9 @@ class AnnotationTest {
         val result = writeClass(classDef)
 
         val expected = """
-        @JsonSubTypes(
-        value = listOf(
-                @JsonSubTypes.Type(
-                    value = String.class,
-                    name = "Cat"
-                ),
-                @JsonSubTypes.Type(
-                    value = String.class,
-                    name = "Dog"
-                ),
-                @JsonSubTypes.Type(
-                    value = String.class,
-                    name = "Fish"
-                )
-            )
-        )
+        @JsonSubTypes(value = listOf(@com.fasterxml.jackson.`annotation`.JsonSubTypes.Type(value = String::class, name = "Cat"),
+        @com.fasterxml.jackson.`annotation`.JsonSubTypes.Type(value = String::class, name = "Dog"),
+        @com.fasterxml.jackson.`annotation`.JsonSubTypes.Type(value = String::class, name = "Fish")))
         public class SimpleClass
         """.trimIndent()
         Assert.assertEquals(expected.trim(), result.trim())
@@ -102,7 +91,7 @@ class AnnotationTest {
     }
 
     private fun getJsonSubTypesAnn(): AnnotationDef {
-        val mapping = mapOf("Cat" to String::class, "Dog" to String::class, "Fish" to String::class)
+        val mapping = mapOf("Cat" to TypeDef.STRING, "Dog" to TypeDef.STRING, "Fish" to TypeDef.STRING)
         val subTypeList = mapping.entries
             .map { entry: Map.Entry<String, Any> ->
                 AnnotationDef


### PR DESCRIPTION
Added functionalities to annotations in Kotlin:

- Add AnnotationDef, VariableDef, ClassTypeDef and Collections to be used as annotation values
- Allow usage of inner annotations (ex: @Heron.Simple)