### PR TITLE
Fix null value casting

### DIFF
--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
@@ -52,7 +52,9 @@ public class ExpressionWriteTest extends AbstractWriteTest {
                             methodParameters.get(0).compare(GREATER_THAN, methodParameters.get(1)),
                             methodParameters.get(0).compare(LESS_THAN, methodParameters.get(1)),
                             methodParameters.get(0).compare(GREATER_THAN_OR_EQUAL, methodParameters.get(1)),
-                            methodParameters.get(0).compare(LESS_THAN_OR_EQUAL, methodParameters.get(1))
+                            methodParameters.get(0).compare(LESS_THAN_OR_EQUAL, methodParameters.get(1)),
+                            methodParameters.get(0).isNull(),
+                            methodParameters.get(0).isNonNull()
                         ).returning()))
                 .build()
         );
@@ -64,7 +66,7 @@ import java.lang.Object;
 
 public class Example {
   Object[] myMethod(int arg1, int arg2) {
-    return new Object[]{arg1 == arg2,arg1 != arg2,arg1 > arg2,arg1 < arg2,arg1 >= arg2,arg1 <= arg2};
+    return new Object[]{arg1 == arg2,arg1 != arg2,arg1 > arg2,arg1 < arg2,arg1 >= arg2,arg1 <= arg2,arg1 == null,arg1 != null};
   }
 }
 """, data);

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ExpressionDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ExpressionDef.java
@@ -1081,7 +1081,7 @@ public sealed interface ExpressionDef
                 }
             }
             this.opType = opType;
-            this.right = right.cast(left.type());
+            this.right = right.equals(ExpressionDef.nullValue()) ? right : right.cast(left.type());
             this.left = left;
         }
 

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ExpressionDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ExpressionDef.java
@@ -1081,7 +1081,7 @@ public sealed interface ExpressionDef
                 }
             }
             this.opType = opType;
-            this.right = right.equals(ExpressionDef.nullValue()) ? right : right.cast(left.type());
+            this.right = isNull(right) ? right : right.cast(left.type());
             this.left = left;
         }
 


### PR DESCRIPTION
Do not cast null values in EQUAL_TO and NOT_EQUAL_TO comparisons.
From: `arg1 == (int) (null)` to `arg1 == null`.
