### PR TITLE
Fix the erasure method in TypeDef

### DIFF
--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
@@ -2,7 +2,9 @@ package io.micronaut.sourcegen.bytecode;
 
 import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.core.annotation.AnnotationClassValue;
+import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.reflect.ReflectionUtils;
+import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.sourcegen.custom.visitor.GenerateLambdaVisitor;
 import io.micronaut.sourcegen.custom.visitor.innerTypes.GenerateInnerTypeInEnumVisitor;
@@ -32,6 +34,7 @@ import java.lang.reflect.Constructor;
 import java.util.AbstractList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import static io.micronaut.sourcegen.bytecode.DecompilerUtils.decompileToJava;
 import static io.micronaut.sourcegen.model.ExpressionDef.ComparisonOperation.OpType.EQUAL_TO;
@@ -3513,6 +3516,64 @@ import java.io.IOException;
 class Test {
    void test() throws IOException {
       throw new IOException();
+   }
+}
+""", decompileToJava(bytes));
+    }
+
+    @Test
+    void testGenericInterface() {
+        ClassElement element = ClassElement.of(
+            Function.class,
+            AnnotationMetadata.EMPTY_METADATA,
+            Map.of(
+                "T", ClassElement.of(String.class),
+                "R", ClassElement.of(String.class)
+            )
+        );
+
+        ClassDef classDef = ClassDef.builder("example.Test")
+            .addSuperinterface(TypeDef.erasure(element))
+            .addMethod(MethodDef.builder("apply").returns(TypeDef.STRING)
+                .addParameter(TypeDef.STRING).build((t, params) -> params.get(0).returning()))
+            .build();
+
+        StringWriter bytecodeWriter = new StringWriter();
+        byte[] bytes = generateFile(classDef, bytecodeWriter);
+        String bytecode = bytecodeWriter.toString();
+
+        assertEquals("""
+// class version 61.0 (61)
+// access flags 0x0
+// signature Ljava/lang/Object;Ljava/util/function/Function<Ljava/lang/String;Ljava/lang/String;>;
+// declaration: example/Test implements java.util.function.Function<java.lang.String, java.lang.String>
+class example/Test implements java/util/function/Function {
+
+
+  // access flags 0x0
+  <init>()V
+    ALOAD 0
+    INVOKESPECIAL java/lang/Object.<init> ()V
+    RETURN
+
+  // access flags 0x0
+  apply(Ljava/lang/String;)Ljava/lang/String;
+   L0
+    ALOAD 1
+    ARETURN
+   L1
+    LOCALVARIABLE arg1 Ljava/lang/String; L0 L1 1
+}
+""", bytecode);
+
+        assertEquals("""
+package example;
+
+import java.util.function.Function;
+
+class Test implements Function {
+   String apply(String arg1) {
+      return arg1;
    }
 }
 """, decompileToJava(bytes));

--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
@@ -3522,7 +3522,7 @@ class Test {
     }
 
     @Test
-    void testGenericInterface() {
+    void testErasedInterface() {
         ClassElement element = ClassElement.of(
             Function.class,
             AnnotationMetadata.EMPTY_METADATA,
@@ -3534,8 +3534,8 @@ class Test {
 
         ClassDef classDef = ClassDef.builder("example.Test")
             .addSuperinterface(TypeDef.erasure(element))
-            .addMethod(MethodDef.builder("apply").returns(TypeDef.STRING)
-                .addParameter(TypeDef.STRING).build((t, params) -> params.get(0).returning()))
+            .addMethod(MethodDef.builder("apply").returns(TypeDef.OBJECT)
+                .addParameter(TypeDef.OBJECT).build((t, params) -> params.get(0).returning()))
             .build();
 
         StringWriter bytecodeWriter = new StringWriter();
@@ -3545,8 +3545,8 @@ class Test {
         assertEquals("""
 // class version 61.0 (61)
 // access flags 0x0
-// signature Ljava/lang/Object;Ljava/util/function/Function<Ljava/lang/String;Ljava/lang/String;>;
-// declaration: example/Test implements java.util.function.Function<java.lang.String, java.lang.String>
+// signature Ljava/lang/Object;Ljava/util/function/Function;
+// declaration: example/Test implements java.util.function.Function
 class example/Test implements java/util/function/Function {
 
 
@@ -3557,12 +3557,12 @@ class example/Test implements java/util/function/Function {
     RETURN
 
   // access flags 0x0
-  apply(Ljava/lang/String;)Ljava/lang/String;
+  apply(Ljava/lang/Object;)Ljava/lang/Object;
    L0
     ALOAD 1
     ARETURN
    L1
-    LOCALVARIABLE arg1 Ljava/lang/String; L0 L1 1
+    LOCALVARIABLE arg1 Ljava/lang/Object; L0 L1 1
 }
 """, bytecode);
 
@@ -3572,7 +3572,7 @@ package example;
 import java.util.function.Function;
 
 class Test implements Function {
-   String apply(String arg1) {
+   Object apply(Object arg1) {
       return arg1;
    }
 }

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassTypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassTypeDef.java
@@ -452,7 +452,7 @@ public sealed interface ClassTypeDef extends TypeDef {
      * @param classElement The class element
      * @return type definition
      */
-    static ClassTypeDef erasedOf(ClassElement classElement) {
+    static ClassTypeDef erasure(ClassElement classElement) {
         if (classElement.isPrimitive()) {
             throw new IllegalStateException("Primitive classes cannot be of type: " + ClassTypeDef.class.getName());
         }

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassTypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassTypeDef.java
@@ -446,6 +446,20 @@ public sealed interface ClassTypeDef extends TypeDef {
     }
 
     /**
+     * Create a new type definition that is an erasure.
+     * This means that no type arguments will be copied.
+     *
+     * @param classElement The class element
+     * @return type definition
+     */
+    static ClassTypeDef erasedOf(ClassElement classElement) {
+        if (classElement.isPrimitive()) {
+            throw new IllegalStateException("Primitive classes cannot be of type: " + ClassTypeDef.class.getName());
+        }
+        return new ClassElementType(classElement, classElement.isNullable());
+    }
+
+    /**
      * Create a new type definition.
      *
      * @param classElement The class element
@@ -458,9 +472,9 @@ public sealed interface ClassTypeDef extends TypeDef {
         if (!classElement.getTypeArguments().isEmpty()) {
             return new Parameterized(
                 new ClassElementType(classElement, classElement.isNullable()),
-                classElement.getTypeArguments().entrySet()
+                classElement.getTypeArguments().values()
                     .stream()
-                    .map(e -> TypeDef.erasure(e.getValue()))
+                    .map(TypeDef::of)
                     .toList()
             );
         }

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/MethodDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/MethodDef.java
@@ -110,10 +110,10 @@ public final class MethodDef extends AbstractElement {
     @NonNull
     public static MethodDef of(@NonNull MethodElement methodElement) {
         return MethodDef.builder(methodElement.getName())
-            .addParameters(Arrays.stream(methodElement.getSuspendParameters()).map(p -> ParameterDef.of(p.getName(), TypeDef.erasure(p.getType()))).toList())
+            .addParameters(Arrays.stream(methodElement.getSuspendParameters()).map(p -> ParameterDef.of(p.getName(), TypeDef.of(p.getType()))).toList())
             .addTypeVariables(methodElement.getTypeArguments().entrySet()
                 .stream()
-                .map(e -> TypeDef.variable(e.getKey(), TypeDef.erasure(e.getValue())))
+                .map(e -> TypeDef.variable(e.getKey(), TypeDef.of(e.getValue())))
                 .toList())
             .returns(methodElement.isSuspend() ? TypeDef.OBJECT : TypeDef.erasure(methodElement.getReturnType()))
             .build();

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
@@ -335,6 +335,13 @@ public sealed interface TypeDef permits ClassTypeDef, TypeDef.Annotated, TypeDef
             return primitive(typedElement.getName());
         }
         if (typedElement instanceof GenericPlaceholderElement placeholderElement) {
+            if (erasure) {
+                if (placeholderElement.getBounds().size() != 1) {
+                    return TypeDef.OBJECT;
+                } else {
+                    return TypeDef.of(placeholderElement.getBounds().get(0));
+                }
+            }
             return TypeDef.variable(
                 placeholderElement.getVariableName(),
                 placeholderElement.getBounds().stream().map(TypeDef::of).toList()

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
@@ -342,7 +342,7 @@ public sealed interface TypeDef permits ClassTypeDef, TypeDef.Annotated, TypeDef
         }
         if (typedElement instanceof WildcardElement wildcardElement) {
             if (erasure) {
-                return ClassTypeDef.erasedOf(wildcardElement);
+                return ClassTypeDef.erasure(wildcardElement);
             }
             return new Wildcard(
                 wildcardElement.getUpperBounds().stream().map(TypeDef::of).toList(),
@@ -350,7 +350,7 @@ public sealed interface TypeDef permits ClassTypeDef, TypeDef.Annotated, TypeDef
             );
         }
         if (typedElement instanceof ClassElement classElement) {
-            return erasure ? ClassTypeDef.erasedOf(classElement) : ClassTypeDef.of(classElement);
+            return erasure ? ClassTypeDef.erasure(classElement) : ClassTypeDef.of(classElement);
         }
         throw new IllegalStateException("Unknown typed element: " + typedElement);
     }

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
@@ -340,24 +340,17 @@ public sealed interface TypeDef permits ClassTypeDef, TypeDef.Annotated, TypeDef
                 placeholderElement.getBounds().stream().map(TypeDef::of).toList()
             );
         }
-        if (erasure && typedElement instanceof ClassElement classElement) {
-            return ClassTypeDef.of(classElement);
-        }
         if (typedElement instanceof WildcardElement wildcardElement) {
+            if (erasure) {
+                return ClassTypeDef.erasedOf(wildcardElement);
+            }
             return new Wildcard(
                 wildcardElement.getUpperBounds().stream().map(TypeDef::of).toList(),
                 wildcardElement.getLowerBounds().stream().map(TypeDef::of).toList()
             );
         }
         if (typedElement instanceof ClassElement classElement) {
-            Map<String, ClassElement> typeArguments = classElement.getTypeArguments();
-            if (typeArguments.isEmpty()) {
-                return ClassTypeDef.of(classElement);
-            }
-            return TypeDef.parameterized(
-                ClassTypeDef.of(classElement),
-                typeArguments.values().stream().map(TypeDef::of).toList()
-            );
+            return erasure ? ClassTypeDef.erasedOf(classElement) : ClassTypeDef.of(classElement);
         }
         throw new IllegalStateException("Unknown typed element: " + typedElement);
     }


### PR DESCRIPTION
The erasure method was broken because it assumed that `ClassTypeDef.of` would not add any type parameters.

It is fixed now by adding a `ClassTypeDef.erasure` method.