### PR TITLE
fallback to classelement and do not throw exception

### DIFF
--- a/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/IncludeBuilderInSourceGenSpec.groovy
+++ b/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/IncludeBuilderInSourceGenSpec.groovy
@@ -22,7 +22,11 @@ interface Test {
     Map<String, Object> metadata();
     int[] bytes();
     String[] stuff();
+
+    Map<String, Stuff> moreStuff();
 }
+
+interface Stuff {}
 ''')
         expect:
         introspection != null

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/RecordDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/RecordDef.java
@@ -184,13 +184,13 @@ public final class RecordDef extends ObjectDef {
             return cet.classElement();
         } else if (type instanceof ClassTypeDef.JavaClass javaClass) {
             return visitorContext.getClassElement(javaClass.getName())
-                .orElseThrow(() -> new IllegalStateException("Class missing from compilation path: " + javaClass.getName()));
+                .orElseGet(() -> ClassElement.of(javaClass.type()));
         } else if (type instanceof ClassTypeDef.ClassName javaClass) {
             return visitorContext.getClassElement(javaClass.getName())
-                .orElseThrow(() -> new IllegalStateException("Class missing from compilation path: " + javaClass.getName()));
+                .orElseGet(() -> ClassElement.of(javaClass.getName()));
         } else if (type instanceof ClassTypeDef.ClassDefType classDefType) {
             return visitorContext.getClassElement(classDefType.getName())
-                .orElseThrow(() -> new IllegalStateException("Class missing from compilation path: " + classDefType.getName()));
+                .orElseGet(() -> ClassElement.of(classDefType.getName()));
         } else if (type instanceof ClassTypeDef.Parameterized parameterized) {
             ClassTypeDef rawType = parameterized.rawType();
             if (rawType instanceof ClassTypeDef.ClassElementType cet) {


### PR DESCRIPTION
Currently an exception happens if the class element can't be resolved which is not always useful.