### PR TITLE
Fix instanceof in java source generator

### DIFF
--- a/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
+++ b/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
@@ -993,6 +993,13 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
                 renderExpressionWithParentheses(objectDef, methodDef, remappedLocals, comparisonOperation.right())
             );
         }
+        if (expressionDef instanceof ExpressionDef.InstanceOf instanceOf) {
+            return CodeBlock.concat(
+                renderExpression(objectDef, methodDef, remappedLocals, instanceOf.expression()),
+                CodeBlock.of(" instanceof "),
+                CodeBlock.of(instanceOf.instanceType().getCanonicalName())
+            );
+        }
         if (expressionDef instanceof ExpressionDef.And andExpressionDef) {
             return CodeBlock.concat(
                 renderCondition(objectDef, methodDef, remappedLocals, andExpressionDef.left()),

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
@@ -241,6 +241,17 @@ public class Example {
     }
 
     @Test
+    public void returnInstanceOfCondition() throws IOException {
+        ExpressionDef andExpression = new ExpressionDef.InstanceOf(
+            ExpressionDef.constant("test"),
+            ClassTypeDef.ClassDefType.STRING
+        );
+        String result = writeMethodWithExpression(andExpression);
+
+        assertEquals("\"test\" instanceof java.lang.String", result);
+    }
+
+    @Test
     public void returnAndConditionFalse() throws IOException {
         ExpressionDef andExpression = new ExpressionDef.And(
             ExpressionDef.trueValue().isTrue(),


### PR DESCRIPTION
Currently fails with:

```
 java.lang.IllegalStateException: Unrecognized condition: InstanceOf[expression=MethodParameter[name=from, type=ClassDefType[objectDef=io.micronaut.sourcegen.model.InterfaceDef@60a01cb, nullable=false]], instanceType=ClassName[name=test.ProfileADataModel, isInner=false, nullable=false]]
  ```