### PR TITLE
Fix sourcegen handling over annotation metadata for weaved builders

### DIFF
--- a/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/IncludeBuilderInSourceGenSpec.groovy
+++ b/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/IncludeBuilderInSourceGenSpec.groovy
@@ -10,6 +10,7 @@ class IncludeBuilderInSourceGenSpec extends AbstractTypeElementSpec {
         def introspection = buildBeanIntrospection("test.TestRecord", '''
 package test;
 
+import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.sourcegen.generator.visitors.TestAnn;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +32,7 @@ interface Stuff {}
         expect:
         introspection != null
         introspection.getBeanType().builder().name("foo").age(30).build().name == 'foo'
+        introspection.getBeanType().builder().name("foo").build().age == 10
         introspection.getBeanType().builder().name("foo").age(30).build().explicitlySet() == ["name", "age" ] as Set
         introspection.getBeanType().builder().name("foo").age(30).build().withName("bob").name == 'bob'
     }

--- a/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/TestRecordGenerator.java
+++ b/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/TestRecordGenerator.java
@@ -2,16 +2,19 @@ package io.micronaut.sourcegen.generator.visitors;
 
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.ElementQuery;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.ParameterElement;
+import io.micronaut.inject.ast.PrimitiveElement;
 import io.micronaut.inject.ast.PropertyElement;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.sourcegen.generator.SourceGenerator;
 import io.micronaut.sourcegen.generator.SourceGenerators;
+import io.micronaut.sourcegen.model.AnnotationDef;
 import io.micronaut.sourcegen.model.ClassDef;
 import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.ExpressionDef;
@@ -43,7 +46,16 @@ public class TestRecordGenerator implements TypeElementVisitor<TestAnn, Object> 
         RecordDef.RecordDefBuilder builder = RecordDef.builder(className)
             .addAnnotation(Introspected.class);
         for (MethodElement method : methods) {
-            builder.addProperty(PropertyDef.builder(method.getName()).ofType(TypeDef.of(method.getGenericReturnType())).build());
+            PropertyDef.PropertyDefBuilder propertyDefBuilder = PropertyDef.builder(method.getName()).ofType(TypeDef.of(method.getGenericReturnType()));
+            ClassElement genericReturnType = method.getGenericReturnType();
+            if (genericReturnType.isPrimitive() &&
+                 !genericReturnType.isArray() &&
+                genericReturnType.getName().equals(PrimitiveElement.INT.getName())) {
+                propertyDefBuilder.addAnnotation(AnnotationDef.builder(Bindable.class).addMember("defaultValue", "10").build());
+                builder.addProperty(propertyDefBuilder.build());
+            } else {
+                builder.addProperty(propertyDefBuilder.build());
+            }
         }
 
         ClassTypeDef fieldType = TypeDef.parameterized(Set.class, String.class);

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/RecordDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/RecordDef.java
@@ -78,11 +78,8 @@ public final class RecordDef extends ObjectDef {
      */
     public List<PropertyElement> getBeanProperties(VisitorContext visitorContext) {
         List<PropertyElement> propertyElements = new ArrayList<>(properties.size());
-        MutableAnnotationMetadata annotationMetadata = new MutableAnnotationMetadata();
-        for (AnnotationDef annotation : annotations) {
-            annotationMetadata.addDeclaredAnnotation(annotation.getType().getName(), new LinkedHashMap<>(annotation.getValues()));
-        }
         for (PropertyDef property : properties) {
+            MutableAnnotationMetadata annotationMetadata = toAnnotationMetadata(property);
             propertyElements.add(new PropertyElement() {
                 @Override
                 public @NonNull ClassElement getType() {
@@ -129,6 +126,14 @@ public final class RecordDef extends ObjectDef {
         return Collections.unmodifiableList(propertyElements);
     }
 
+    private static MutableAnnotationMetadata toAnnotationMetadata(PropertyDef property) {
+        MutableAnnotationMetadata annotationMetadata = new MutableAnnotationMetadata();
+        for (AnnotationDef annotation : property.annotations) {
+            annotationMetadata.addDeclaredAnnotation(annotation.getType().getName(), new LinkedHashMap<>(annotation.getValues()));
+        }
+        return annotationMetadata;
+    }
+
     /**
      * Turn the record components into constructor parameters.
      * @param visitorContext The visitor context.
@@ -136,11 +141,8 @@ public final class RecordDef extends ObjectDef {
      */
     public List<ParameterElement> getConstructorParameters(VisitorContext visitorContext) {
         List<ParameterElement> propertyElements = new ArrayList<>(properties.size());
-        MutableAnnotationMetadata annotationMetadata = new MutableAnnotationMetadata();
-        for (AnnotationDef annotation : annotations) {
-            annotationMetadata.addDeclaredAnnotation(annotation.getType().getName(), new LinkedHashMap<>(annotation.getValues()));
-        }
         for (PropertyDef property : properties) {
+            MutableAnnotationMetadata annotationMetadata = toAnnotationMetadata(property);
             propertyElements.add(new ParameterElement() {
                 @Override
                 public @NonNull ClassElement getType() {


### PR DESCRIPTION
The metadata of the type was being used instead of the property for the property elements. This fixes that.