### PR TITLE
Fix Builder & wither with types that declare generics

### DIFF
--- a/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
+++ b/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
@@ -409,6 +409,11 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
         if (!methodName.equals(MethodSpec.CONSTRUCTOR)) {
             methodBuilder.returns(asType(method.getReturnType(), objectDef, method));
         }
+        for (TypeDef.TypeVariable typeVariable : method.getTypeVariables()) {
+            methodBuilder.addTypeVariable(
+                asTypeVariable(typeVariable, null)
+            );
+        }
         method.getJavadoc().forEach(methodBuilder::addJavadoc);
         for (AnnotationDef annotation : method.getAnnotations()) {
             methodBuilder.addAnnotation(
@@ -497,7 +502,7 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
         if (typeDef instanceof ClassTypeDef.Parameterized parameterized) {
             return ParameterizedTypeName.get(
                 asClassType(parameterized.rawType()),
-                parameterized.typeArguments().stream().map(t -> asType(t, objectDef)).toArray(TypeName[]::new)
+                parameterized.typeArguments().stream().map(t -> asType(t, objectDef, methodDef)).toArray(TypeName[]::new)
             );
         }
         if (typeDef instanceof TypeDef.Primitive primitive) {
@@ -539,7 +544,7 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
             );
         }
         if (typeDef instanceof TypeDef.TypeVariable typeVariable) {
-            if (isVariablePartOfTheDefinition(typeVariable.name(), objectDef, null)) {
+            if (isVariablePartOfTheDefinition(typeVariable.name(), objectDef, methodDef)) {
                 return asTypeVariable(typeVariable, objectDef);
             }
             if (typeVariable.bounds().isEmpty()) {

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
@@ -110,7 +110,13 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
             AnnotationValue<Builder> builderAnnotationValue = element.getAnnotation(Builder.class);
             ClassTypeDef elementType = ClassTypeDef.of(element);
 
-            ClassDefBuilder builder = createBuilder(element.getPackageName(), elementType, builderAnnotationValue, properties, constructorParameters);
+            ClassDefBuilder builder = createBuilder(
+                element.getPackageName(),
+                elementType,
+                builderAnnotationValue,
+                properties,
+                constructorParameters
+            );
             ClassDef builderDef = builder.build();
 
             SourceGenerator sourceGenerator = SourceGenerators.findByLanguage(context.getLanguage()).orElse(null);
@@ -174,16 +180,36 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
         Function<BuilderGenerator.BuildContext, StatementDef> buildReturnStatement) {
         String simpleName = elementType.getSimpleName() + "Builder";
         String builderClassName = packageName + "." + simpleName;
-        ClassTypeDef builderType = ClassTypeDef.of(builderClassName);
+        List<TypeDef.TypeVariable> typeArguments = List.of();
+        if (elementType instanceof ClassTypeDef.Parameterized parameterizedType) {
+            typeArguments = parameterizedType.typeArguments()
+                .stream().filter(td -> td instanceof TypeDef.TypeVariable)
+                .map(TypeDef.TypeVariable.class::cast)
+                .toList();
+        }
+
+        ClassTypeDef builderType;
+
+        if (typeArguments.isEmpty()) {
+            builderType = ClassTypeDef.of(builderClassName);
+        } else {
+            builderType = TypeDef.parameterized(
+                ClassTypeDef.of(builderClassName),
+                typeArguments.toArray(TypeDef[]::new)
+            );
+        }
 
         ClassDefBuilder builder = ClassDef.builder(builderClassName)
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
+        for (TypeDef.TypeVariable typeArgument : typeArguments) {
+            builder.addTypeVariable(typeArgument);
+        }
         if (builderAnnotationValue != null) {
             addAnnotations(builder, builderAnnotationValue);
         }
 
         for (PropertyElement beanProperty : properties) {
-            createModifyPropertyMethod(builder, beanProperty, buildReturnStatement);
+            createModifyPropertyMethod(builder, builderType, beanProperty, buildReturnStatement);
         }
 
         builder.addMethod(MethodDef.constructor().build());
@@ -269,33 +295,74 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
     }
 
     private static MethodDef createBuilderMethod(ClassTypeDef builderType) {
-        return MethodDef.builder("builder")
+
+        ClassTypeDef erasure = ClassTypeDef.of(builderType.getCanonicalName());
+        MethodDef.MethodDefBuilder methodBuilder = MethodDef.builder("builder")
             .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-            .returns(builderType)
-            .addStatement(builderType.instantiate().returning())
+            .addStatement(erasure.instantiate().returning());
+        if (builderType instanceof ClassTypeDef.Parameterized parameterized) {
+            List<TypeDef> typeDefs = parameterized.typeArguments();
+            List<TypeDef> resolvedTypeDefs = new ArrayList<>();
+            int index = 1;
+            for (TypeDef typeDef : typeDefs) {
+                if (typeDef instanceof TypeDef.TypeVariable variable) {
+                    TypeDef.TypeVariable newTypeDef = new TypeDef.TypeVariable(
+                        variable.name() + "S",
+                        variable.bounds(),
+                        variable.nullable()
+                    );
+                    resolvedTypeDefs.add(newTypeDef);
+                    methodBuilder.addTypeVariable(
+                        newTypeDef
+                    );
+
+                    methodBuilder.addParameter(
+                        "t" + index++,
+                        TypeDef.parameterized(
+                            ClassTypeDef.of(Class.class),
+                            newTypeDef
+                        )
+                    );
+                }
+            }
+
+            methodBuilder.returns(
+                TypeDef.parameterized(
+                    parameterized.rawType(),
+                    resolvedTypeDefs.toArray(TypeDef[]::new)
+                )
+            );
+        } else {
+            methodBuilder.returns(builderType);
+        }
+        return methodBuilder
             .build();
     }
 
-    static void createModifyPropertyMethod(ClassDef.ClassDefBuilder classDefBuilder,
-                                           PropertyElement beanProperty,
+    static void createModifyPropertyMethod(ClassDefBuilder classDefBuilder,
+                                           ClassTypeDef builderType, PropertyElement beanProperty,
                                            Function<BuilderGenerator.BuildContext, StatementDef> returningExpressionProvider) {
         if (beanProperty.hasAnnotation(Singular.class)) {
             createSingularPropertyMethods(classDefBuilder, beanProperty, returningExpressionProvider);
         } else {
-            createDefaultModifyPropertyMethod(classDefBuilder, beanProperty, returningExpressionProvider);
+            createDefaultModifyPropertyMethod(classDefBuilder, builderType, beanProperty, returningExpressionProvider);
         }
     }
 
-    private static void createDefaultModifyPropertyMethod(ClassDef.ClassDefBuilder classDefBuilder,
-                                                          PropertyElement beanProperty,
+    private static void createDefaultModifyPropertyMethod(ClassDefBuilder classDefBuilder,
+                                                          ClassTypeDef builderType, PropertyElement beanProperty,
                                                           Function<BuilderGenerator.BuildContext, StatementDef> returningExpressionProvider) {
         TypeDef propertyTypeDef = TypeDef.of(beanProperty.getType());
         FieldDef field = createField(beanProperty, propertyTypeDef);
         classDefBuilder.addField(field);
         String propertyName = beanProperty.getSimpleName();
-        classDefBuilder.addMethod(MethodDef.builder(propertyName)
+        MethodDef.MethodDefBuilder methodDef = MethodDef.builder(propertyName)
             .addModifiers(Modifier.PUBLIC)
-            .addParameter(propertyName, propertyTypeDef)
+            .addParameter(propertyName, propertyTypeDef);
+        if (builderType instanceof ClassTypeDef.Parameterized) {
+            methodDef.returns(builderType);
+        }
+        classDefBuilder.addMethod(methodDef
             .build((self, parameterDefs) -> StatementDef.multi(
                 self.field(field).assign(parameterDefs.get(0)),
                 returningExpressionProvider.apply(new BuilderGenerator.BuildContext(self, field))
@@ -435,6 +502,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
     static MethodDef createBuildMethod(ClassTypeDef buildType, List<PropertyElement> properties, List<ParameterElement> constructorParameters) {
         return MethodDef.builder("build")
             .addModifiers(Modifier.PUBLIC)
+            .returns(buildType)
             .build((self, parameterDefs) -> {
                 List<PropertyElement> beanProperties = new ArrayList<>(properties);
                 List<ExpressionDef> values = new ArrayList<>();

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
@@ -315,14 +315,6 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                     methodBuilder.addTypeVariable(
                         newTypeDef
                     );
-
-                    methodBuilder.addParameter(
-                        "t" + index++,
-                        TypeDef.parameterized(
-                            ClassTypeDef.of(Class.class),
-                            newTypeDef
-                        )
-                    );
                 }
             }
 

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
@@ -303,7 +303,6 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
         if (builderType instanceof ClassTypeDef.Parameterized parameterized) {
             List<TypeDef> typeDefs = parameterized.typeArguments();
             List<TypeDef> resolvedTypeDefs = new ArrayList<>();
-            int index = 1;
             for (TypeDef typeDef : typeDefs) {
                 if (typeDef instanceof TypeDef.TypeVariable variable) {
                     TypeDef.TypeVariable newTypeDef = new TypeDef.TypeVariable(

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/SuperBuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/SuperBuilderAnnotationVisitor.java
@@ -99,7 +99,7 @@ public final class SuperBuilderAnnotationVisitor implements TypeElementVisitor<S
                 if (!beanProperty.getDeclaringType().equals(element)) {
                     continue;
                 }
-                createModifyPropertyMethod(abstractBuilder, beanProperty, buildContext -> buildContext.aThis().invoke("self", buildContext.aThis().type()).cast(selfType).returning());
+                createModifyPropertyMethod(abstractBuilder, abstractBuilderType, beanProperty, buildContext -> buildContext.aThis().invoke("self", buildContext.aThis().type()).cast(selfType).returning());
             }
 
             abstractBuilder.addMethod(MethodDef.builder("self").addModifiers(Modifier.ABSTRACT).returns(selfType).build());

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/WitherAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/WitherAnnotationVisitor.java
@@ -126,7 +126,16 @@ public final class WitherAnnotationVisitor implements TypeElementVisitor<Wither,
         String witherClassName = packageName + "." + simpleName;
         InterfaceDef.InterfaceDefBuilder wither = InterfaceDef.builder(witherClassName)
             .addModifiers(Modifier.PUBLIC);
-
+        if (recordType instanceof ClassTypeDef.Parameterized parameterized) {
+            List<TypeDef> typeDefs = parameterized.typeArguments();
+            for (TypeDef typeDef : typeDefs) {
+                if (typeDef instanceof TypeDef.TypeVariable variable) {
+                    wither.addTypeVariable(
+                        variable
+                    );
+                }
+            }
+        }
         weaveWithMethodsInternal(recordType, properties, parameters, hasBuilder, wither);
         return wither;
     }
@@ -165,7 +174,16 @@ public final class WitherAnnotationVisitor implements TypeElementVisitor<Wither,
         if (hasBuilder) {
             String builderSimpleName = recordType.getSimpleName() + "Builder";
             String builderClassName = recordType.getPackageName() + "." + builderSimpleName;
-            ClassTypeDef builderType = ClassTypeDef.of(builderClassName);
+            ClassTypeDef builderType;
+
+            if (recordType instanceof ClassTypeDef.Parameterized parameterized) {
+                builderType = TypeDef.parameterized(
+                    ClassTypeDef.of(builderClassName),
+                    parameterized.typeArguments()
+                );
+            } else {
+                builderType = ClassTypeDef.of(builderClassName);
+            }
 
             MethodDef withMethod = createWithMethod(wither, parameters, builderType, propertyAccessMethods);
             wither.addMethod(withMethod);

--- a/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitorSpec.groovy
+++ b/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitorSpec.groovy
@@ -47,4 +47,32 @@ class BuilderAnnotationVisitorSpec extends AbstractTypeElementSpec {
         walrus != null
     }
 
+    void "test builder with generics adds type arguments to builder method"() {
+        given:
+        var classLoader = buildClassLoader("test.Walrus", """
+        package test;
+        import io.micronaut.sourcegen.annotations.Builder;
+        import io.micronaut.sourcegen.annotations.Wither;
+
+        @Builder
+        @Wither
+        public record Walrus<I>(
+              I name,
+              int age,
+              byte[] chipInfo
+        ) implements WalrusWither<I> {
+        }
+        """)
+        var walrusBuilderClass = classLoader.loadClass("test.WalrusBuilder")
+
+        expect:
+        var walrusBuilder = walrusBuilderClass.builder(String.class)
+        walrusBuilderClass.getTypeParameters().size() == 1
+        walrusBuilderClass.getTypeParameters()[0].name == "I"
+        var walrus = walrusBuilder
+                .name("Ted the Walrus")
+                .age(1).build()
+        walrus.name == "Ted the Walrus"
+        walrus.age == 1
+    }
 }

--- a/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitorSpec.groovy
+++ b/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitorSpec.groovy
@@ -66,7 +66,7 @@ class BuilderAnnotationVisitorSpec extends AbstractTypeElementSpec {
         var walrusBuilderClass = classLoader.loadClass("test.WalrusBuilder")
 
         expect:
-        var walrusBuilder = walrusBuilderClass.builder(String.class)
+        var walrusBuilder = walrusBuilderClass.builder()
         walrusBuilderClass.getTypeParameters().size() == 1
         walrusBuilderClass.getTypeParameters()[0].name == "I"
         var walrus = walrusBuilder

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
@@ -608,6 +608,11 @@ public sealed interface TypeDef permits ClassTypeDef, TypeDef.Annotated, TypeDef
         public TypeDef makeNullable() {
             return new TypeVariable(name, bounds, true);
         }
+
+        @Override
+        public boolean isNullable() {
+            return nullable;
+        }
     }
 
     /**

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/Walrus3.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/Walrus3.java
@@ -25,6 +25,6 @@ public record Walrus3<I>(
     I name,
     int age,
     byte[] chipInfo
-)  {
+) implements Walrus3Wither<I> {
 }
 //end::clazz[]

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/Walrus3.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/Walrus3.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import io.micronaut.sourcegen.annotations.Builder;
+import io.micronaut.sourcegen.annotations.Wither;
+
+//tag::clazz[]
+@Wither
+@Builder
+public record Walrus3<I>(
+    I name,
+    int age,
+    byte[] chipInfo
+)  {
+}
+//end::clazz[]


### PR DESCRIPTION
* For `@Wither` if the target accepts generic arguments include the generic arguments in the generated wither interface
* For `@Builder` include the generic arguments in the builder and modify `builder()` method to accept arguments.