### PR TITLE
Update RecordDef.toClassElement to include more cases

### DIFF
--- a/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/TestRecordGenerator.java
+++ b/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/TestRecordGenerator.java
@@ -58,11 +58,6 @@ public class TestRecordGenerator implements TypeElementVisitor<TestAnn, Object> 
                 builder.addProperty(propertyDefBuilder.build());
             }
         }
-        builder.addProperty(PropertyDef.builder("listProperty")
-            .ofType(TypeDef.parameterized(ClassTypeDef.of(List.class), TypeDef.of(String.class)
-                .annotated(AnnotationDef.builder(Nonnull.class).build())
-            ))
-            .build());
 
         ClassTypeDef fieldType = TypeDef.parameterized(Set.class, String.class);
         builder.addProperty(PropertyDef.builder("explicitlySet").ofType(fieldType).build());

--- a/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/TestRecordGenerator.java
+++ b/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/TestRecordGenerator.java
@@ -24,6 +24,7 @@ import io.micronaut.sourcegen.model.RecordDef;
 import io.micronaut.sourcegen.model.StatementDef;
 import io.micronaut.sourcegen.model.TypeDef;
 import io.micronaut.sourcegen.model.VariableDef;
+import jakarta.annotation.Nonnull;
 
 import javax.lang.model.element.Modifier;
 import java.util.List;
@@ -57,6 +58,11 @@ public class TestRecordGenerator implements TypeElementVisitor<TestAnn, Object> 
                 builder.addProperty(propertyDefBuilder.build());
             }
         }
+        builder.addProperty(PropertyDef.builder("listProperty")
+            .ofType(TypeDef.parameterized(ClassTypeDef.of(List.class), TypeDef.of(String.class)
+                .annotated(AnnotationDef.builder(Nonnull.class).build())
+            ))
+            .build());
 
         ClassTypeDef fieldType = TypeDef.parameterized(Set.class, String.class);
         builder.addProperty(PropertyDef.builder("explicitlySet").ofType(fieldType).build());

--- a/sourcegen-model/build.gradle.kts
+++ b/sourcegen-model/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     compileOnly(mn.micronaut.core.processor)
 
+    testImplementation(mn.micronaut.inject.java)
     testImplementation(mn.micronaut.core.processor)
     testImplementation(mnTest.junit.jupiter.api)
 

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/AnnotationDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/AnnotationDef.java
@@ -16,6 +16,7 @@
 package io.micronaut.sourcegen.model;
 
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.AnnotationValueBuilder;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.FieldElement;
@@ -26,8 +27,11 @@ import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -100,6 +104,44 @@ public final class AnnotationDef {
                     .ifPresent(copiedValue -> builder.addMember(key, copiedValue))
         );
         return builder.build();
+    }
+
+    /**
+     * Convert to an annotation value.
+     * @return The annotation value
+     */
+    AnnotationValue<?> toAnnotationValue() {
+        AnnotationValueBuilder<?> builder = AnnotationValue.builder(getType().getName());
+        Map<CharSequence, Object> members = new HashMap<>();
+        for (Entry<String, Object> entry: getValues().entrySet()) {
+            members.put(entry.getKey(), toAnnotationValueMember(entry.getValue()));
+        }
+        return builder.members(members).build();
+    }
+
+    /**
+     * Convert a member that is defined in {@link #values} to a member
+     * that could be added to an {@link AnnotationValue}.
+     */
+    private static Object toAnnotationValueMember(Object member) {
+        if (member instanceof Collection<?> collection) {
+            Iterator<?> iterator = collection.iterator();
+            Object[] objects = new Object[collection.size()];
+            for (int i = 0; i < objects.length; i++) {
+                objects[i] = toAnnotationValueMember(iterator.next());
+            }
+            return objects;
+        } else if (member instanceof AnnotationDef annotationDef) {
+            return annotationDef.toAnnotationValue();
+        } else if (member instanceof ExpressionDef expressionDef) {
+            if (expressionDef instanceof ExpressionDef.Constant constant) {
+                return constant.value();
+            }
+            throw new IllegalArgumentException("Could not convert annotation that uses non-constant expressions to AnnotationValue");
+        } else if (member instanceof ClassTypeDef classTypeDef) {
+            return classTypeDef.toString();
+        }
+        return member;
     }
 
     /**

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/RecordDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/RecordDef.java
@@ -210,6 +210,18 @@ public final class RecordDef extends ObjectDef {
             if (componentType instanceof ArrayableClassElement arrayableClassElement) {
                 return arrayableClassElement.withArrayDimensions(array.dimensions());
             }
+        } else if (type instanceof TypeDef.AnnotatedTypeDef annotated) {
+            ClassElement element = toClassElement(annotated.typeDef(), visitorContext);
+            for (AnnotationDef annotation: annotated.annotations()) {
+                element.annotate(annotation.toAnnotationValue());
+            }
+            return element;
+        } else if (type instanceof ClassTypeDef.AnnotatedClassTypeDef annotated) {
+            ClassElement element = toClassElement(annotated.typeDef(), visitorContext);
+            for (AnnotationDef annotation: annotated.annotations()) {
+                element.annotate(annotation.toAnnotationValue());
+            }
+            return element;
         }
         throw new IllegalStateException("Only properties constructed from source elements are supported");
     }

--- a/sourcegen-model/src/test/groovy/io/micronaut/sourcegen/model/RecordDefTest.java
+++ b/sourcegen-model/src/test/groovy/io/micronaut/sourcegen/model/RecordDefTest.java
@@ -1,0 +1,34 @@
+package io.micronaut.sourcegen.model;
+
+import io.micronaut.annotation.processing.visitor.JavaVisitorContext;
+import io.micronaut.inject.ast.PropertyElement;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+
+class RecordDefTest {
+
+    @Test
+    public void testGetBeanProperties() {
+        RecordDef recordDef = RecordDef.builder("com.example.Test")
+            .addProperty(PropertyDef.builder("name").ofType(TypeDef.STRING)
+                .build())
+            .addProperty(PropertyDef.builder("list").ofType(
+                TypeDef.parameterized(
+                    ClassTypeDef.of(List.class),
+                    TypeDef.STRING
+                ))
+                .build()
+            )
+            .build();
+
+        List<PropertyElement> properties = recordDef.getBeanProperties(new JavaVisitorContext(
+            null, null, null, null, null, null, null, null, null
+        ));
+        Assertions.assertEquals(2, properties.size());
+        Assertions.assertEquals(String.class.getName(), properties.get(0).getType().getName());
+    }
+
+}


### PR DESCRIPTION
It includes `AnnotatedTypeDef` now, as I require this functionality.

Note that it still doesn't include `WildcardDef` and `TypeVariableDef`.