### PR TITLE
Change equalsStructurally to support null values

### DIFF
--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
@@ -98,7 +98,7 @@ class test/IfPredicateGeneric implements java/util/function/Predicate {
     ALOAD 1
     ICONST_1
     INVOKESTATIC java/lang/Integer.valueOf (I)Ljava/lang/Integer;
-    INVOKEVIRTUAL java/lang/Object.equals (Ljava/lang/Object;)Z
+    INVOKESTATIC java/util/Objects.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
     ICONST_1
     IF_ICMPNE L1
     ICONST_1
@@ -115,11 +115,12 @@ class test/IfPredicateGeneric implements java/util/function/Predicate {
         Assertions.assertEquals("""
 package test;
 
+import java.util.Objects;
 import java.util.function.Predicate;
 
 class IfPredicateGeneric implements Predicate {
    boolean test(Object arg1) {
-      return arg1.equals(1);
+      return Objects.equals(arg1, 1);
    }
 }
 """, decompileToJava(bytes));
@@ -1280,7 +1281,7 @@ public class example/Example {
     ICONST_0
     ALOAD 1
     ALOAD 2
-    INVOKEVIRTUAL java/lang/Object.equals (Ljava/lang/Object;)Z
+    INVOKESTATIC java/util/Objects.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
     ICONST_1
     IF_ICMPNE L1
     ICONST_1
@@ -1294,7 +1295,7 @@ public class example/Example {
     ICONST_1
     ALOAD 1
     ALOAD 2
-    INVOKEVIRTUAL java/lang/Object.equals (Ljava/lang/Object;)Z
+    INVOKESTATIC java/util/Objects.equals (Ljava/lang/Object;Ljava/lang/Object;)Z
     ICONST_1
     IF_ICMPEQ L3
     ICONST_1
@@ -1338,9 +1339,11 @@ public class example/Example {
         Assertions.assertEquals("""
 package example;
 
+import java.util.Objects;
+
 public class Example {
    Object[] myMethod(Object arg1, Object arg2) {
-      return new Object[]{arg1.equals(arg2), !arg1.equals(arg2), arg1 == arg2, arg1 != arg2};
+      return new Object[]{Objects.equals(arg1, arg2), !Objects.equals(arg1, arg2), arg1 == arg2, arg1 != arg2};
    }
 }
 """, decompileToJava(bytes));

--- a/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
+++ b/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
@@ -251,7 +251,7 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
                 return CodeBlock.concat(CodeBlock.of("{"), values, CodeBlock.of("}"));
             }
         }
-        return renderExpression(def, null, Collections.emptyMap(),defaultValue);
+        return renderExpression(def, null, Collections.emptyMap(), defaultValue);
     }
 
     private void writeClass(Writer writer, ClassDef classDef) throws IOException {

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
@@ -129,11 +129,11 @@ public class Example {
 
         String equalsStructurally = writeMethodWithExpression(exp1.equalsStructurally(exp2));
 
-        assertEquals("\"hello\".equals(\"world\")", equalsStructurally);
+        assertEquals("Objects.equals(\"hello\", \"world\")", equalsStructurally);
 
         String notEqualsStructurally = writeMethodWithExpression(exp1.notEqualsStructurally(exp2));
 
-        assertEquals("(!\"hello\".equals(\"world\"))", notEqualsStructurally);
+        assertEquals("(!Objects.equals(\"hello\", \"world\"))", notEqualsStructurally);
     }
 
     @Test

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/JavaIdioms.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/JavaIdioms.java
@@ -25,6 +25,7 @@ import io.micronaut.inject.ast.PropertyElement;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -46,15 +47,16 @@ public final class JavaIdioms {
         .addParameter(TypeDef.OBJECT.array())
         .build();
 
-    private static final MethodDef OBJECT_EQUALS = MethodDef.builder("equals")
+    private static final MethodDef OBJECTS_EQUALS = MethodDef.builder("equals")
         .returns(boolean.class)
-        .addParameter(Object.class)
+        .addParameters(Object.class, Object.class)
         .build();
 
     private static final MethodDef OBJECT_HASHCODE = MethodDef.builder("hashCode")
         .returns(int.class)
         .build();
 
+    private static final ClassTypeDef OBJECTS_TYPE = ClassTypeDef.of(Objects.class);
     private static final ClassTypeDef ARRAYS_TYPE = ClassTypeDef.of(Arrays.class);
 
     private static final Method STRING_BUILDER_APPEND_STRING = ReflectionUtils.getRequiredMethod(StringBuilder.class, "append", String.class);
@@ -157,7 +159,7 @@ public final class JavaIdioms {
                     );
             }
         }
-        return left.invoke(OBJECT_EQUALS, right);
+        return OBJECTS_TYPE.invokeStatic(OBJECTS_EQUALS, left, right);
     }
 
     /**

--- a/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/Trigger.java
+++ b/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/Trigger.java
@@ -17,6 +17,7 @@ package io.micronaut.sourcegen.example;
 
 
 import io.micronaut.sourcegen.custom.example.GenerateArray;
+import io.micronaut.sourcegen.custom.example.GenerateExpressions;
 import io.micronaut.sourcegen.custom.example.GenerateIfsPredicate;
 import io.micronaut.sourcegen.custom.example.GenerateInnerTypes;
 import io.micronaut.sourcegen.custom.example.GenerateLambda;
@@ -47,5 +48,6 @@ import io.micronaut.sourcegen.custom.example.GenerateSwitch;
 @GenerateMethodInvocation
 @GenerateInnerTypes
 @GenerateLambda
+@GenerateExpressions
 public class Trigger {
 }

--- a/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/ExpressionsTest.java
+++ b/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/ExpressionsTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ExpressionsTest {
+
+    @Test
+    public void testEqualsStructurally() {
+        Expressions owner = new Expressions();
+        assertTrue(owner.equalsStructurally("hello", "hello"));
+        assertFalse(owner.equalsStructurally("hello", "hola"));
+        assertFalse(owner.equalsStructurally(null, "hola"));
+        assertFalse(owner.equalsStructurally("hello", null));
+        assertTrue(owner.equalsStructurally(null, null));
+    }
+
+}

--- a/test-suite-custom-annotations/src/main/java/io/micronaut/sourcegen/custom/example/GenerateExpressions.java
+++ b/test-suite-custom-annotations/src/main/java/io/micronaut/sourcegen/custom/example/GenerateExpressions.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.custom.example;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+public @interface GenerateExpressions {
+}

--- a/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateExpressionsVisitor.java
+++ b/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateExpressionsVisitor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.custom.visitor;
+
+// tag::class[]
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+import io.micronaut.sourcegen.custom.example.GenerateExpressions;
+import io.micronaut.sourcegen.generator.SourceGenerator;
+import io.micronaut.sourcegen.generator.SourceGenerators;
+import io.micronaut.sourcegen.model.ClassDef;
+import io.micronaut.sourcegen.model.MethodDef;
+
+import javax.lang.model.element.Modifier;
+
+@Internal
+public final class GenerateExpressionsVisitor implements TypeElementVisitor<GenerateExpressions, Object> { // <1>
+
+    @Override
+    public @NonNull VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    } // <2>
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        SourceGenerator sourceGenerator = SourceGenerators.findByLanguage(context.getLanguage()).orElse(null); // <3>
+        if (sourceGenerator == null) {
+            return;
+        }
+
+        String className = element.getPackageName() + ".Expressions";
+
+        ClassDef def = ClassDef.builder(className) // <4>
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("equalsStructurally")
+                .addModifiers(Modifier.PUBLIC)
+                .addParameters(String.class, String.class)
+                .returns(boolean.class)
+                .build((t, p) ->
+                    p.get(0).equalsStructurally(p.get(1)).returning()
+                )
+            )
+            .build();
+
+        sourceGenerator.write(def, context, element);
+    }
+}
+// end::class[]

--- a/test-suite-custom-generators/src/main/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/test-suite-custom-generators/src/main/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -21,3 +21,4 @@ io.micronaut.sourcegen.custom.visitor.GenerateAnnotatedTypeVisitor
 io.micronaut.sourcegen.custom.visitor.GenerateMyEnum2Visitor
 io.micronaut.sourcegen.custom.visitor.GenerateLambdaVisitor
 io.micronaut.sourcegen.custom.visitor.GenerateAnnotationClassVisitor
+io.micronaut.sourcegen.custom.visitor.GenerateExpressionsVisitor


### PR DESCRIPTION
Currently equals structurally is generated in the form `a.equals(b)`. 

This changes it to `Objects.equals(a, b)`, which additionally supports null, see implementation:
```java
   public static boolean equals(Object a, Object b) {
        return (a == b) || (a != null && a.equals(b));
    }
```

This seems like a better approach to avoid unwanted null-pointer exceptions.

I think the same might also need to be applied to the hashCode.