### PR TITLE
Support method invocations for unbound type variables

### DIFF
--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/SignatureWriterUtils.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/SignatureWriterUtils.java
@@ -115,7 +115,9 @@ final class SignatureWriterUtils {
             return null;
         }
         SignatureWriter signatureWriter = new SignatureWriter();
-        // TODO: method generic bounds
+        for (TypeDef.TypeVariable typeVariable : methodDef.getTypeVariables()) {
+            writeSignature(signatureWriter, objectDef, methodDef, typeVariable, true);
+        }
         for (ParameterDef parameter : methodDef.getParameters()) {
             writeSignature(signatureWriter.visitParameterType(), objectDef, methodDef, parameter.getType(), false);
         }

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/expression/InvokeInstanceMethodExpressionWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/expression/InvokeInstanceMethodExpressionWriter.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.sourcegen.bytecode.expression;
 
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.sourcegen.bytecode.MethodContext;
 import io.micronaut.sourcegen.bytecode.TypeUtils;
 import io.micronaut.sourcegen.model.ClassDef;
@@ -54,7 +55,11 @@ final class InvokeInstanceMethodExpressionWriter extends AbstractStatementAwareE
         MethodDef methodDef = invokeInstanceMethod.method();
         Method method = new Method(methodDef.getName(), TypeUtils.getMethodDescriptor(context.objectDef(), methodDef));
         if (instanceType instanceof TypeDef.TypeVariable typeVariable) {
-            instanceType = typeVariable.bounds().get(0);
+            if (CollectionUtils.isEmpty(typeVariable.bounds())) {
+                instanceType = TypeDef.OBJECT;
+            } else {
+                instanceType = typeVariable.bounds().get(0);
+            }
         }
         if (instanceType instanceof ClassTypeDef classTypeDef) {
             if (instance instanceof VariableDef.Super aSuper) {

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/expression/InvokeInstanceMethodExpressionWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/expression/InvokeInstanceMethodExpressionWriter.java
@@ -54,11 +54,13 @@ final class InvokeInstanceMethodExpressionWriter extends AbstractStatementAwareE
         Type methodOwnerType = TypeUtils.getType(instanceType, context.objectDef());
         MethodDef methodDef = invokeInstanceMethod.method();
         Method method = new Method(methodDef.getName(), TypeUtils.getMethodDescriptor(context.objectDef(), methodDef));
-        if (instanceType instanceof TypeDef.TypeVariable typeVariable) {
+        while (instanceType instanceof TypeDef.TypeVariable typeVariable) {
             if (CollectionUtils.isEmpty(typeVariable.bounds())) {
                 instanceType = TypeDef.OBJECT;
+                System.out.println(instanceType);
             } else {
                 instanceType = typeVariable.bounds().get(0);
+                System.out.println(instanceType);
             }
         }
         if (instanceType instanceof ClassTypeDef classTypeDef) {

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/expression/InvokeInstanceMethodExpressionWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/expression/InvokeInstanceMethodExpressionWriter.java
@@ -57,10 +57,8 @@ final class InvokeInstanceMethodExpressionWriter extends AbstractStatementAwareE
         while (instanceType instanceof TypeDef.TypeVariable typeVariable) {
             if (CollectionUtils.isEmpty(typeVariable.bounds())) {
                 instanceType = TypeDef.OBJECT;
-                System.out.println(instanceType);
             } else {
                 instanceType = typeVariable.bounds().get(0);
-                System.out.println(instanceType);
             }
         }
         if (instanceType instanceof ClassTypeDef classTypeDef) {

--- a/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/MethodInvokerTest.java
+++ b/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/MethodInvokerTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class MethodInvokerTest {
 
     MyRepository repository = new MyRepository() {
@@ -316,6 +318,13 @@ public class MethodInvokerTest {
         } catch (IllegalStateException e) {
             // Ignore
         }
+    }
+
+    @Test
+    public void testInvokeTypeVariable() {
+        MethodInvoker invoker = new MethodInvoker();
+        assertEquals("12", invoker.invokeTypeVariable(12));
+        assertEquals(5, invoker.invokeTypeVariableWithBounds("hello"));
     }
 
 }

--- a/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateMethodInvocationVisitor.java
+++ b/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateMethodInvocationVisitor.java
@@ -67,22 +67,17 @@ public final class GenerateMethodInvocationVisitor implements TypeElementVisitor
             return;
         }
 
-        try {
-            ClassElement myRepository = context.getRequiredClassElement("io.micronaut.sourcegen.example.MyRepository", context.getElementAnnotationMetadataFactory());
-            ClassTypeDef repositoryType = ClassTypeDef.of(myRepository);
+        ClassElement myRepository = context.getRequiredClassElement("io.micronaut.sourcegen.example.MyRepository", context.getElementAnnotationMetadataFactory());
+        ClassTypeDef repositoryType = ClassTypeDef.of(myRepository);
 
-            ClassDef methodInvoker = createMethodInvokerClass(repositoryType);
-            sourceGenerator.write(methodInvoker, context, element);
+        ClassDef methodInvoker = createMethodInvokerClass(repositoryType);
+        sourceGenerator.write(methodInvoker, context, element);
 
-            ClassDef interfaceSuperInvokerDef = createInterfaceSuperInvoker(myRepository);
-            sourceGenerator.write(interfaceSuperInvokerDef, context, element);
+        ClassDef interfaceSuperInvokerDef = createInterfaceSuperInvoker(myRepository);
+        sourceGenerator.write(interfaceSuperInvokerDef, context, element);
 
-            ClassDef swapper = createSwapper();
-            sourceGenerator.write(swapper, context, element);
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw e;
-        }
+        ClassDef swapper = createSwapper();
+        sourceGenerator.write(swapper, context, element);
     }
 
     private ClassDef createMethodInvokerClass(ClassTypeDef repositoryType) {

--- a/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateMethodInvocationVisitor.java
+++ b/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateMethodInvocationVisitor.java
@@ -33,9 +33,11 @@ import io.micronaut.sourcegen.model.JavaIdioms;
 import io.micronaut.sourcegen.model.MethodDef;
 import io.micronaut.sourcegen.model.StatementDef;
 import io.micronaut.sourcegen.model.TypeDef;
+import io.micronaut.sourcegen.model.TypeDef.TypeVariable;
 import io.micronaut.sourcegen.model.VariableDef;
 
 import javax.lang.model.element.Modifier;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -65,10 +67,26 @@ public final class GenerateMethodInvocationVisitor implements TypeElementVisitor
             return;
         }
 
-        ClassElement myRepository = context.getRequiredClassElement("io.micronaut.sourcegen.example.MyRepository", context.getElementAnnotationMetadataFactory());
+        try {
+            ClassElement myRepository = context.getRequiredClassElement("io.micronaut.sourcegen.example.MyRepository", context.getElementAnnotationMetadataFactory());
+            ClassTypeDef repositoryType = ClassTypeDef.of(myRepository);
 
-        ClassTypeDef repositoryType = ClassTypeDef.of(myRepository);
-        ClassDef classDef = ClassDef.builder("io.micronaut.sourcegen.example.MethodInvoker")
+            ClassDef methodInvoker = createMethodInvokerClass(repositoryType);
+            sourceGenerator.write(methodInvoker, context, element);
+
+            ClassDef interfaceSuperInvokerDef = createInterfaceSuperInvoker(myRepository);
+            sourceGenerator.write(interfaceSuperInvokerDef, context, element);
+
+            ClassDef swapper = createSwapper();
+            sourceGenerator.write(swapper, context, element);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+
+    private ClassDef createMethodInvokerClass(ClassTypeDef repositoryType) {
+        return ClassDef.builder("io.micronaut.sourcegen.example.MethodInvoker")
 
             .addMethod(MethodDef.builder("invokeDefaultMethod")
                 .addParameter(repositoryType)
@@ -170,13 +188,31 @@ public final class GenerateMethodInvocationVisitor implements TypeElementVisitor
                     .doFinally(methodParameters.get(0).invoke("getAndIncrement", TypeDef.Primitive.INT)))
             )
 
+            .addMethod(MethodDef.builder("invokeTypeVariable")
+                .addTypeVariable(new TypeVariable("T"))
+                .returns(TypeDef.STRING)
+                .addParameter("value", TypeDef.variable("T"))
+                .build((t, p) ->
+                    p.get(0).invoke("toString", TypeDef.STRING).returning()
+                )
+            )
+
+            .addMethod(MethodDef.builder("invokeTypeVariableWithBounds")
+                .addTypeVariable(new TypeVariable("T", List.of(TypeDef.of(CharSequence.class))))
+                .returns(TypeDef.Primitive.INT)
+                .addParameter("value", TypeDef.variable("T", List.of(TypeDef.of(CharSequence.class))))
+                .build((t, p) ->
+                    p.get(0).invoke("length", TypeDef.Primitive.INT).returning()
+                )
+            )
+
             .build();
+    }
 
-        sourceGenerator.write(classDef, context, element);
-
+    private ClassDef createInterfaceSuperInvoker(ClassElement myRepository) {
         ClassTypeDef myRepoType = ClassTypeDef.of(myRepository);
         MethodElement defaultMethod = myRepository.findMethod("defaultMethod").get();
-        ClassDef interfaceSuperInvokerDef = ClassDef.builder("io.micronaut.sourcegen.example.MethodRepositoryInvoker")
+        return ClassDef.builder("io.micronaut.sourcegen.example.MethodRepositoryInvoker")
             .addModifiers(Modifier.ABSTRACT)
             .addSuperinterface(myRepoType)
             .addMethod(MethodDef.override(defaultMethod)
@@ -187,9 +223,9 @@ public final class GenerateMethodInvocationVisitor implements TypeElementVisitor
                             .invoke(defaultMethod, methodParameters)
                     ).returning())
             ).build();
+    }
 
-        sourceGenerator.write(interfaceSuperInvokerDef, context, element);
-
+    private ClassDef createSwapper() {
         FieldDef targetField = FieldDef.builder("target", TypeDef.OBJECT).addModifiers(Modifier.PRIVATE).build();
         FieldDef lockField = FieldDef.builder("lock", ClassTypeDef.of(ReentrantReadWriteLock.class))
             .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
@@ -200,7 +236,7 @@ public final class GenerateMethodInvocationVisitor implements TypeElementVisitor
             .initializer(new VariableDef.This().field(lockField).invoke("writeLock", TypeDef.of(Lock.class)))
             .build();
 
-        ClassDef swapper = ClassDef.builder("io.micronaut.sourcegen.example.Swapper")
+        return ClassDef.builder("io.micronaut.sourcegen.example.Swapper")
             .addField(targetField)
             .addField(lockField)
             .addField(writeLockField)
@@ -291,8 +327,6 @@ public final class GenerateMethodInvocationVisitor implements TypeElementVisitor
                     )
                 )))
             .build();
-
-        sourceGenerator.write(swapper, context, element);
     }
 
 }

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/MethodInvokerTest.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/MethodInvokerTest.java
@@ -309,4 +309,11 @@ public class MethodInvokerTest {
         }
     }
 
+    @Test
+    public void testInvokeTypeVariable() {
+        MethodInvoker invoker = new MethodInvoker();
+        assertEquals("12", invoker.invokeTypeVariable(12));
+        assertEquals(5, invoker.invokeTypeVariableWithBounds("hello"));
+    }
+
 }


### PR DESCRIPTION
We currently support invoking type variables of form `T extends Other`, but this adds support for unbounded ones.

It also can extract a chain of bounds if for some reason those are type variables as well.