### PR TITLE
Feat: Support static initialization block generation in JavaPoetSourceGenerator

### DIFF
--- a/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
+++ b/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
@@ -285,6 +285,12 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
                 asMethodSpec(classDef, method)
             );
         }
+
+        StatementDef staticInitializer = classDef.getStaticInitializer();
+        if (staticInitializer != null) {
+            CodeBlock staticBlock = renderStatementCodeBlock(classDef, null, Map.of(), staticInitializer);
+            classBuilder.addStaticBlock(staticBlock);
+        }
         return classBuilder;
     }
 

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/StaticInitializationBlockTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/StaticInitializationBlockTest.java
@@ -1,0 +1,41 @@
+package io.micronaut.sourcegen.javapoet;
+
+import io.micronaut.sourcegen.javapoet.write.AbstractWriteTest;
+import io.micronaut.sourcegen.model.*;
+import org.junit.Test;
+
+import javax.lang.model.element.Modifier;
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class StaticInitializationBlockTest extends AbstractWriteTest {
+
+    @Test
+    public void testSimpleStaticInitializer() throws IOException {
+
+        StatementDef defineNewContext = new StatementDef.DefineAndAssign(new VariableDef.Local("var0", TypeDef.of(Context.class)), ClassTypeDef.of(Context.class).instantiate());
+        StatementDef staticBlock = StatementDef.multi(List.of(defineNewContext));
+
+        ClassDef classDef = ClassDef.builder("StaticInitializationBlockTest")
+            .addModifiers(Modifier.PUBLIC)
+            .addStaticInitializer(staticBlock)
+            .build();
+
+        String data = writeClass(classDef);
+
+        assertEquals("""
+public class StaticInitializationBlockTest {
+  static {
+    io.micronaut.sourcegen.javapoet.StaticInitializationBlockTest.Context var0 = new io.micronaut.sourcegen.javapoet.StaticInitializationBlockTest.Context();
+  }
+}
+""", data);
+    }
+
+    private static class Context {
+        public Context() {
+        }
+    }
+}


### PR DESCRIPTION
The JavaPoetSourceGenerator previously lacked support for generating static initialization blocks.
This PR introduces functionality to emit static {} blocks, enabling class-level initialization logic in generated code.