### PR TITLE
Improve array logic

### DIFF
--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
@@ -18,7 +18,6 @@ package io.micronaut.sourcegen.model;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.reflect.ReflectionUtils;
-import io.micronaut.inject.ast.ArrayableClassElement;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.GenericPlaceholderElement;
 import io.micronaut.inject.ast.TypedElement;

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
@@ -189,10 +189,13 @@ public sealed interface TypeDef permits ClassTypeDef, TypeDef.Annotated, TypeDef
     }
 
     static Array array(TypeDef componentType) {
-        return new Array(componentType, 1, false);
+        return array(componentType, 1);
     }
 
     static Array array(TypeDef componentType, int dimensions) {
+        if (componentType instanceof Array array) {
+            return new Array(array.componentType, array.dimensions + dimensions, false);
+        }
         return new Array(componentType, dimensions, false);
     }
 
@@ -359,7 +362,7 @@ public sealed interface TypeDef permits ClassTypeDef, TypeDef.Annotated, TypeDef
     static TypeDef of(TypedElement typedElement, Map<String, TypeDef> resolvedTypeVariables, boolean erasure) {
         int dimensions = 0;
         while (typedElement.isArray()) {
-            ArrayableClassElement arrayableClassElement = (ArrayableClassElement) typedElement;
+            ClassElement arrayableClassElement = (ClassElement) typedElement;
             typedElement = arrayableClassElement.fromArray();
             dimensions++;
         }

--- a/sourcegen-model/src/test/groovy/io/micronaut/sourcegen/model/TypeDefTest.java
+++ b/sourcegen-model/src/test/groovy/io/micronaut/sourcegen/model/TypeDefTest.java
@@ -1,0 +1,27 @@
+package io.micronaut.sourcegen.model;
+
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.sourcegen.model.TypeDef.Array;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TypeDefTest {
+
+    @Test
+    void arraysTest() {
+        TypeDef type = TypeDef.STRING;
+        TypeDef.Array array = type.array();
+
+        assertEquals(1, array.dimensions());
+        assertEquals(2, array.array().dimensions());
+        assertEquals(3, array.array(2).dimensions());
+
+        TypeDef array2 = TypeDef.of(ClassElement.of(int[][].class));
+        assertTrue(array2.isArray());
+        assertEquals(2, ((Array) array2).dimensions());
+
+    }
+
+}


### PR DESCRIPTION
This fixes https://github.com/micronaut-projects/micronaut-validation/pull/522.

Essentially it allows creating arrays with private `TypeDef.array` method even when component type is also an array.

The real issue is actually a bit more complicated. At some point there is an array of form `T[]` where `T` is resolvable and actually resolves into some other array. I couldn't reproduce such a complex test case, but I verified that this fixes the issue.

I found this out by printing logs of array creation:
```
Creating with component element: java.lang.Object, type: class io.micronaut.annotation.processing.visitor.JavaGenericPlaceholderElement
Creating with component: java.lang.Object, type: class io.micronaut.annotation.processing.visitor.JavaClassElement
Error creating ComponentType: Array[componentType=ClassElementType[classElement=java.lang.Object, nullable=false], dimensions=1, nullable=false] dimensions: 1
```
The first line is the top array, the second is the nested generic.