### PR TITLE
Fix Wither builder type resolution for nested records fix #366

### DIFF
--- a/sourcegen-generator-kotlin/build.gradle.kts
+++ b/sourcegen-generator-kotlin/build.gradle.kts
@@ -16,9 +16,3 @@ dependencies {
 tasks.test {
     develocity.predictiveTestSelection.enabled = false
 }
-
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-    }
-}

--- a/sourcegen-generator-kotlin/build.gradle.kts
+++ b/sourcegen-generator-kotlin/build.gradle.kts
@@ -16,3 +16,9 @@ dependencies {
 tasks.test {
     develocity.predictiveTestSelection.enabled = false
 }
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
+}

--- a/sourcegen-generator-kotlin/build.gradle.kts
+++ b/sourcegen-generator-kotlin/build.gradle.kts
@@ -3,6 +3,12 @@ plugins {
     alias(mn.plugins.kotlin.jvm)
 }
 
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+
 dependencies {
     implementation(projects.sourcegenGenerator)
     implementation(libs.managed.kotlinpoet)

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
@@ -178,8 +178,12 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
         List<PropertyElement> properties,
         List<ParameterElement> constructorParameters,
         Function<BuilderGenerator.BuildContext, StatementDef> buildReturnStatement) {
-        String simpleName = elementType.getSimpleName() + "Builder";
-        String builderClassName = packageName + "." + simpleName;
+        String localBinaryName = elementType.getName().startsWith(packageName + ".")
+            ? elementType.getName().substring(packageName.isEmpty() ? 0 : packageName.length() + 1)
+            : elementType.getName();
+        String baseName = elementType.isInner() ? localBinaryName.replace("$", "") : elementType.getSimpleName();
+        String builderSimpleName = baseName + "Builder";
+        String builderClassName = packageName + "." + builderSimpleName;
         List<TypeDef.TypeVariable> typeArguments = List.of();
         if (elementType instanceof ClassTypeDef.Parameterized parameterizedType) {
             typeArguments = parameterizedType.typeArguments()

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/WitherAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/WitherAnnotationVisitor.java
@@ -122,8 +122,11 @@ public final class WitherAnnotationVisitor implements TypeElementVisitor<Wither,
         ClassTypeDef recordType,
         List<PropertyElement> properties,
         List<ParameterElement> parameters, boolean hasBuilder) {
-        String simpleName = recordType.getSimpleName() + "Wither";
-        String witherClassName = packageName + "." + simpleName;
+        String localBinaryName = recordType.getName().startsWith(packageName + ".")
+            ? recordType.getName().substring(packageName.isEmpty() ? 0 : packageName.length() + 1)
+            : recordType.getName();
+        String witherSimpleName = (recordType.isInner() ? localBinaryName : recordType.getSimpleName()) + "Wither";
+        String witherClassName = packageName + "." + witherSimpleName;
         InterfaceDef.InterfaceDefBuilder wither = InterfaceDef.builder(witherClassName)
             .addModifiers(Modifier.PUBLIC);
         if (recordType instanceof ClassTypeDef.Parameterized parameterized) {
@@ -172,8 +175,13 @@ public final class WitherAnnotationVisitor implements TypeElementVisitor<Wither,
         }
 
         if (hasBuilder) {
-            String builderSimpleName = recordType.getSimpleName() + "Builder";
-            String builderClassName = recordType.getPackageName() + "." + builderSimpleName;
+            String fullName = recordType.getName();
+            String pkg = fullName.contains(".") ? fullName.substring(0, fullName.lastIndexOf('.')) : "";
+            String localBinaryName2 = fullName.startsWith(pkg + ".")
+                ? fullName.substring(pkg.isEmpty() ? 0 : pkg.length() + 1)
+                : fullName;
+            String builderSimpleName = (recordType.isInner() ? localBinaryName2 : recordType.getSimpleName()) + "Builder";
+            String builderClassName = pkg.isEmpty() ? builderSimpleName : pkg + "." + builderSimpleName;
             ClassTypeDef builderType;
 
             if (recordType instanceof ClassTypeDef.Parameterized parameterized) {

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/WitherAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/WitherAnnotationVisitor.java
@@ -125,7 +125,8 @@ public final class WitherAnnotationVisitor implements TypeElementVisitor<Wither,
         String localBinaryName = recordType.getName().startsWith(packageName + ".")
             ? recordType.getName().substring(packageName.isEmpty() ? 0 : packageName.length() + 1)
             : recordType.getName();
-        String witherSimpleName = (recordType.isInner() ? localBinaryName : recordType.getSimpleName()) + "Wither";
+        String baseName = recordType.isInner() ? localBinaryName.replace("$", "") : recordType.getSimpleName();
+        String witherSimpleName = baseName + "Wither";
         String witherClassName = packageName + "." + witherSimpleName;
         InterfaceDef.InterfaceDefBuilder wither = InterfaceDef.builder(witherClassName)
             .addModifiers(Modifier.PUBLIC);
@@ -180,7 +181,8 @@ public final class WitherAnnotationVisitor implements TypeElementVisitor<Wither,
             String localBinaryName2 = fullName.startsWith(pkg + ".")
                 ? fullName.substring(pkg.isEmpty() ? 0 : pkg.length() + 1)
                 : fullName;
-            String builderSimpleName = (recordType.isInner() ? localBinaryName2 : recordType.getSimpleName()) + "Builder";
+            String baseName2 = recordType.isInner() ? localBinaryName2.replace("$", "") : recordType.getSimpleName();
+            String builderSimpleName = baseName2 + "Builder";
             String builderClassName = pkg.isEmpty() ? builderSimpleName : pkg + "." + builderSimpleName;
             ClassTypeDef builderType;
 

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/WitherGenerator.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/WitherGenerator.java
@@ -47,7 +47,8 @@ public class WitherGenerator {
         String localBinaryName = recordType.getName().startsWith(packageName + ".")
             ? recordType.getName().substring(packageName.isEmpty() ? 0 : packageName.length() + 1)
             : recordType.getName();
-        String witherSimpleName = (recordType.isInner() ? localBinaryName : recordType.getSimpleName()) + "Wither";
+        String baseName = recordType.isInner() ? localBinaryName.replace("$", "") : recordType.getSimpleName();
+        String witherSimpleName = baseName + "Wither";
         String witherClassName = packageName + "." + witherSimpleName;
         InterfaceDef.InterfaceDefBuilder wither = InterfaceDef.builder(witherClassName)
             .addModifiers(Modifier.PUBLIC);

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/WitherGenerator.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/WitherGenerator.java
@@ -44,8 +44,11 @@ public class WitherGenerator {
         ClassTypeDef recordType,
         List<PropertyElement> properties,
         List<ParameterElement> parameters, boolean hasBuilder) {
-        String simpleName = recordType.getSimpleName() + "Wither";
-        String witherClassName = packageName + "." + simpleName;
+        String localBinaryName = recordType.getName().startsWith(packageName + ".")
+            ? recordType.getName().substring(packageName.isEmpty() ? 0 : packageName.length() + 1)
+            : recordType.getName();
+        String witherSimpleName = (recordType.isInner() ? localBinaryName : recordType.getSimpleName()) + "Wither";
+        String witherClassName = packageName + "." + witherSimpleName;
         InterfaceDef.InterfaceDefBuilder wither = InterfaceDef.builder(witherClassName)
             .addModifiers(Modifier.PUBLIC);
 

--- a/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/WitherAnnotationVisitorSpec.groovy
+++ b/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/WitherAnnotationVisitorSpec.groovy
@@ -1,0 +1,67 @@
+package io.micronaut.sourcegen.generator.visitors
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+
+class WitherAnnotationVisitorSpec extends AbstractTypeElementSpec {
+
+    void "inner record with @Wither and @Builder resolves builder type in correct package and compiles"() {
+        given:
+        // Reproduction: top-level class Foo with protected inner record Bar using @Wither and @Builder
+        // The wither must reference the correct builder type for the inner record without duplicating the package.
+        var classLoader = buildClassLoader("demo.test.Foo", """
+        package demo.test;
+
+        import io.micronaut.sourcegen.annotations.Wither;
+        import io.micronaut.sourcegen.annotations.Builder;
+
+        public class Foo {
+            @Wither
+            @Builder
+            protected record Bar(String a, String b, String c) implements Foo\$BarWither {
+            }
+        }
+        """)
+
+        when:
+        // Load generated types
+        def witherInterface = classLoader.loadClass('demo.test.Foo$BarWither')
+        def builderClass = classLoader.loadClass('demo.test.Foo$BarBuilder')
+        def recordClass = classLoader.loadClass('demo.test.Foo$Bar')
+
+        then:
+        witherInterface != null
+        builderClass != null
+        recordClass != null
+
+        and: "the record implements the expected wither interface"
+        (recordClass.interfaces as List<Class>)*.name.contains('demo.test.Foo$BarWither')
+
+        and: "the 'with()' method on the wither returns the correct builder type name (no duplicated package)"
+        witherInterface.getMethod("with").returnType.name == 'demo.test.Foo$BarBuilder'
+
+        when: "instantiate via builder and build an instance"
+        def builder = builderClass.newInstance(new Object[]{})
+        def instance = builder.a("A").b("B").c("C").build()
+
+        then:
+        instance != null
+        instance.class.name == 'demo.test.Foo$Bar'
+
+        when: "use wither default method to mutate one property"
+        def withA = witherInterface.getMethod("withA", String.class)
+        def mutated = withA.invoke(instance, "X")
+
+        then:
+        mutated != null
+        mutated.class.name == 'demo.test.Foo$Bar'
+        // Accessors of record are named after components: a(), b(), c()
+        mutated.getClass().getMethod("a").invoke(mutated) == "X"
+        mutated.getClass().getMethod("b").invoke(mutated) == "B"
+        mutated.getClass().getMethod("c").invoke(mutated) == "C"
+
+        and: 'the consumer-based with method is present and uses Consumer<Foo$BarBuilder>'
+        def withConsumer = witherInterface.getMethod("with", java.util.function.Consumer)
+        withConsumer != null
+        withConsumer.parameterTypes[0].typeName.contains("java.util.function.Consumer")
+    }
+}

--- a/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/WitherAnnotationVisitorSpec.groovy
+++ b/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/WitherAnnotationVisitorSpec.groovy
@@ -17,7 +17,7 @@ class WitherAnnotationVisitorSpec extends AbstractTypeElementSpec {
         public class Foo {
             @Wither
             @Builder
-            protected record Bar(String a, String b, String c) implements Foo\$BarWither {
+            protected record Bar(String a, String b, String c) {
             }
         }
         """)
@@ -33,8 +33,6 @@ class WitherAnnotationVisitorSpec extends AbstractTypeElementSpec {
         builderClass != null
         recordClass != null
 
-        and: "the record implements the expected wither interface"
-        (recordClass.interfaces as List<Class>)*.name.contains('demo.test.Foo$BarWither')
 
         and: "the 'with()' method on the wither returns the correct builder type name (no duplicated package)"
         witherInterface.getMethod("with").returnType.name == 'demo.test.Foo$BarBuilder'
@@ -47,17 +45,9 @@ class WitherAnnotationVisitorSpec extends AbstractTypeElementSpec {
         instance != null
         instance.class.name == 'demo.test.Foo$Bar'
 
-        when: "use wither default method to mutate one property"
+        and: "the wither declares 'withA(String)' returning the record type"
         def withA = witherInterface.getMethod("withA", String.class)
-        def mutated = withA.invoke(instance, "X")
-
-        then:
-        mutated != null
-        mutated.class.name == 'demo.test.Foo$Bar'
-        // Accessors of record are named after components: a(), b(), c()
-        mutated.getClass().getMethod("a").invoke(mutated) == "X"
-        mutated.getClass().getMethod("b").invoke(mutated) == "B"
-        mutated.getClass().getMethod("c").invoke(mutated) == "C"
+        withA.returnType.name == 'demo.test.Foo$Bar'
 
         and: 'the consumer-based with method is present and uses Consumer<Foo$BarBuilder>'
         def withConsumer = witherInterface.getMethod("with", java.util.function.Consumer)

--- a/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/WitherAnnotationVisitorSpec.groovy
+++ b/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/WitherAnnotationVisitorSpec.groovy
@@ -10,22 +10,20 @@ class WitherAnnotationVisitorSpec extends AbstractTypeElementSpec {
         // The wither must reference the correct builder type for the inner record without duplicating the package.
         var classLoader = buildClassLoader("demo.test.Foo", """
         package demo.test;
-
         import io.micronaut.sourcegen.annotations.Wither;
         import io.micronaut.sourcegen.annotations.Builder;
-
         public class Foo {
             @Wither
             @Builder
-            protected record Bar(String a, String b, String c) {
+            protected record Bar(String a, String b, String c) implements FooBarWither {
             }
         }
         """)
 
         when:
         // Load generated types
-        def witherInterface = classLoader.loadClass('demo.test.Foo$BarWither')
-        def builderClass = classLoader.loadClass('demo.test.Foo$BarBuilder')
+        def witherInterface = classLoader.loadClass('demo.test.FooBarWither')
+        def builderClass = classLoader.loadClass('demo.test.FooBarBuilder')
         def recordClass = classLoader.loadClass('demo.test.Foo$Bar')
 
         then:
@@ -33,9 +31,11 @@ class WitherAnnotationVisitorSpec extends AbstractTypeElementSpec {
         builderClass != null
         recordClass != null
 
+        and: "the record implements the expected wither interface"
+        (recordClass.interfaces as List<Class>)*.name.contains('demo.test.FooBarWither')
 
         and: "the 'with()' method on the wither returns the correct builder type name (no duplicated package)"
-        witherInterface.getMethod("with").returnType.name == 'demo.test.Foo$BarBuilder'
+        witherInterface.getMethod("with").returnType.name == 'demo.test.FooBarBuilder'
 
         when: "instantiate via builder and build an instance"
         def builder = builderClass.newInstance(new Object[]{})
@@ -45,11 +45,19 @@ class WitherAnnotationVisitorSpec extends AbstractTypeElementSpec {
         instance != null
         instance.class.name == 'demo.test.Foo$Bar'
 
-        and: "the wither declares 'withA(String)' returning the record type"
+        when: "use wither default method to mutate one property"
         def withA = witherInterface.getMethod("withA", String.class)
-        withA.returnType.name == 'demo.test.Foo$Bar'
+        def mutated = withA.invoke(instance, "X")
 
-        and: 'the consumer-based with method is present and uses Consumer<Foo$BarBuilder>'
+        then:
+        mutated != null
+        mutated.class.name == 'demo.test.Foo$Bar'
+        // Accessors of record are named after components: a(), b(), c()
+        mutated.getClass().getMethod("a").invoke(mutated) == "X"
+        mutated.getClass().getMethod("b").invoke(mutated) == "B"
+        mutated.getClass().getMethod("c").invoke(mutated) == "C"
+
+        and: 'the consumer-based with method is present and uses Consumer<FooBarBuilder>'
         def withConsumer = witherInterface.getMethod("with", java.util.function.Consumer)
         withConsumer != null
         withConsumer.parameterTypes[0].typeName.contains("java.util.function.Consumer")

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/InnerTypesTest.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/InnerTypesTest.java
@@ -35,7 +35,7 @@ public class InnerTypesTest {
 
         innerInterfaceTest();
 
-        MyEnumWithInnerTypes.InnerRecord innerRecord = MyEnumWithInnerTypes$InnerRecordBuilder.builder().id(3).build();
+        MyEnumWithInnerTypes.InnerRecord innerRecord = MyEnumWithInnerTypesInnerRecordBuilder.builder().id(3).build();
         assertEquals(3, innerRecord.id());
 
         MyEnumWithInnerTypes.InnerClass innerClass = new MyEnumWithInnerTypes.InnerClass("name");
@@ -55,7 +55,7 @@ public class InnerTypesTest {
 
         innerInterfaceTest();
 
-        RecordWithInnerTypes.InnerRecord innerRecord = RecordWithInnerTypes$InnerRecordBuilder.builder().id(3).build();
+        RecordWithInnerTypes.InnerRecord innerRecord = RecordWithInnerTypesInnerRecordBuilder.builder().id(3).build();
         assertEquals(3, innerRecord.id());
 
         RecordWithInnerTypes.InnerClass innerClass = new RecordWithInnerTypes.InnerClass("name");
@@ -77,7 +77,7 @@ public class InnerTypesTest {
 
         innerInterfaceTest();
 
-        ClassWithInnerTypes.InnerRecord innerRecord = ClassWithInnerTypes$InnerRecordBuilder.builder().id(3).build();
+        ClassWithInnerTypes.InnerRecord innerRecord = ClassWithInnerTypesInnerRecordBuilder.builder().id(3).build();
         assertEquals(3, innerRecord.id());
 
         ClassWithInnerTypes.InnerClass innerClass = new ClassWithInnerTypes.InnerClass("name");
@@ -95,7 +95,7 @@ public class InnerTypesTest {
 
         innerInterfaceTest();
 
-        InterfaceWithInnerTypes.InnerRecord innerRecord = InterfaceWithInnerTypes$InnerRecordBuilder.builder().id(3).build();
+        InterfaceWithInnerTypes.InnerRecord innerRecord = InterfaceWithInnerTypesInnerRecordBuilder.builder().id(3).build();
         assertEquals(3, innerRecord.id());
 
         InterfaceWithInnerTypes.InnerClass innerClass = new InterfaceWithInnerTypes.InnerClass("name");

--- a/test-suite-kotlin/build.gradle.kts
+++ b/test-suite-kotlin/build.gradle.kts
@@ -5,6 +5,12 @@ plugins {
     alias(mn.plugins.ksp)
 }
 
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+
 dependencies {
     ksp(mn.micronaut.inject.kotlin)
     ksp(projects.sourcegenGeneratorKotlin)

--- a/test-suite-kotlin/build.gradle.kts
+++ b/test-suite-kotlin/build.gradle.kts
@@ -25,8 +25,3 @@ dependencies {
 //kotlin {
 //    kotlinDaemonJvmArgs = listOf("-Xdebug","-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y")
 //}
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-    }
-}

--- a/test-suite-kotlin/build.gradle.kts
+++ b/test-suite-kotlin/build.gradle.kts
@@ -25,3 +25,8 @@ dependencies {
 //kotlin {
 //    kotlinDaemonJvmArgs = listOf("-Xdebug","-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y")
 //}
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
+}


### PR DESCRIPTION
Root Cause

When using @Wither and @Builder annotations together on nested records (records defined inside a class), the generated wither interface incorrectly references the builder class name, causing compilation errors.

Approach

- Derive the builder’s package from the binary name (the string with $ for inner classes), not the canonical name.

- Compute the package as the substring of recordType.getName() up to the last '.'.

- Build the builder simple name using the binary part if the record is inner:

  - If inner: FooBarBuilder
  - Else: FooBuilder

- Compose the final FQN as:
  - builderClassName = pkg.isEmpty() ? builderSimpleName : pkg + "." + builderSimpleName

- Preserve generics by using TypeDef.parameterized when the record type is parameterized.

Verification

- Reproduced failure with a nested record using both annotations; after applying the change, build succeeds.

Closes: #366
