### PR TITLE
Fixing primitive types default values in builder generated classes

### DIFF
--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
@@ -507,10 +507,12 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                         beanProperties.remove(propertyElement);
                     }
                     // We need to convert it for the correct type in Kotlin
-                    TypeDef fieldType = TypeDef.of(parameter.getType()).makeNullable();
-                    VariableDef.Field field = self.field(parameter.getName(), fieldType);
-                    values.add(
-                        valueExpression(propertyElement, field).cast(TypeDef.of(parameter.getType()))
+                    TypeDef fieldType = TypeDef.of(parameter.getType());
+                    TypeDef nullableFieldType = fieldType.makeNullable();
+                    VariableDef.Field field = self.field(parameter.getName(), nullableFieldType);
+                    values.add(!fieldType.isPrimitive() ?
+                        valueExpression(propertyElement, field).cast(TypeDef.of(parameter.getType())) :
+                        field.ifNull(TypeDef.Primitive.defaultValue(parameter.getType().getName()), valueExpression(propertyElement, field))
                     );
                 }
                 if (beanProperties.isEmpty()) {
@@ -551,6 +553,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                 });
             });
     }
+
 
     private static ExpressionDef valueExpression(@Nullable PropertyElement propertyElement,
                                                  VariableDef.Field field) {

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
@@ -143,6 +143,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
 
     /**
      * Create a builder for the given arguments.
+     *
      * @param packageName            The package name
      * @param elementType            The element type
      * @param builderAnnotationValue The builder annotation value.
@@ -512,8 +513,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                     VariableDef.Field field = self.field(parameter.getName(), nullableFieldType);
                     values.add(!fieldType.isPrimitive() ?
                         valueExpression(propertyElement, field).cast(TypeDef.of(parameter.getType())) :
-                        field.ifNull(TypeDef.Primitive.defaultValue(parameter.getType().getName()), valueExpression(propertyElement, field))
-                    );
+                        field.ifNull(TypeDef.Primitive.defaultValue(parameter.getType().getName()), valueExpression(propertyElement, field)).cast(TypeDef.of(parameter.getType())));
                 }
                 if (beanProperties.isEmpty()) {
                     return buildType.instantiate(values).returning();
@@ -553,7 +553,6 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                 });
             });
     }
-
 
     private static ExpressionDef valueExpression(@Nullable PropertyElement propertyElement,
                                                  VariableDef.Field field) {

--- a/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/IncludeBuilderInSourceGenSpec.groovy
+++ b/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/IncludeBuilderInSourceGenSpec.groovy
@@ -22,6 +22,12 @@ interface Test {
     List<String> friends();
     Map<String, Object> metadata();
     int[] bytes();
+
+    boolean active();
+    long x();
+    float y();
+    char c();
+
     String[] stuff();
 
     Map<String, Stuff> moreStuff();
@@ -31,8 +37,16 @@ interface Stuff {}
 ''')
         expect:
         introspection != null
+
+        introspection.getBeanType().builder().build().x == 0
+        introspection.getBeanType().builder().build().c == '\u0000'
+        introspection.getBeanType().builder().y(1000).build().y == 1000
+        introspection.getBeanType().builder().active(true).build().active == true
+        introspection.getBeanType().builder().build().active == false
+        introspection.getBeanType().builder().active(true).build().active == true
+        introspection.getBeanType().builder().build().active == false
         introspection.getBeanType().builder().name("foo").age(30).build().name == 'foo'
-        introspection.getBeanType().builder().name("foo").build().age == 10
+        introspection.getBeanType().builder().name("foo").age(10).build().age == 10
         introspection.getBeanType().builder().name("foo").age(30).build().explicitlySet() == ["name", "age" ] as Set
         introspection.getBeanType().builder().name("foo").age(30).build().withName("bob").name == 'bob'
     }

--- a/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/TestRecordGenerator.java
+++ b/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/TestRecordGenerator.java
@@ -48,6 +48,7 @@ public class TestRecordGenerator implements TypeElementVisitor<TestAnn, Object> 
         for (MethodElement method : methods) {
             PropertyDef.PropertyDefBuilder propertyDefBuilder = PropertyDef.builder(method.getName()).ofType(TypeDef.of(method.getGenericReturnType()));
             ClassElement genericReturnType = method.getGenericReturnType();
+            //Turns every int field to 10 in the test
             if (genericReturnType.isPrimitive() &&
                  !genericReturnType.isArray() &&
                 genericReturnType.getName().equals(PrimitiveElement.INT.getName())) {

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
@@ -485,6 +485,19 @@ public sealed interface TypeDef permits ClassTypeDef, TypeDef.Annotated, TypeDef
             return typeDef;
         }
 
+        /**
+         * Default value for a primitive
+         * @param name of the primitive type
+         * @return ExpressionDef.constant with the default value for primitives
+         */
+        public static ExpressionDef.Constant defaultValue(String name) {
+            return switch (name) {
+                case "byte", "int", "short", "double", "float", "long", "char" -> ExpressionDef.constant(0);
+                case "boolean" -> FALSE;
+                default -> ExpressionDef.constant(null);
+            };
+        }
+
         public String name() {
             return clazz.getName();
         }

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
@@ -486,9 +486,9 @@ public sealed interface TypeDef permits ClassTypeDef, TypeDef.Annotated, TypeDef
         }
 
         /**
-         * Default value for a primitive
-         * @param name of the primitive type
-         * @return ExpressionDef.constant with the default value for primitives
+         * Default value for a primitive.
+         * @param name of the primitive type.
+         * @return ExpressionDef.constant with the default value for primitives.
          */
         public static ExpressionDef.Constant defaultValue(String name) {
             return switch (name) {


### PR DESCRIPTION
Hello, 
This pr fixes the bug mentioned in the issue #387 the problem was that it was using the default constructor and when building the object without initializing the primitive type it throws a null pointer exception cause you can't have null in primitive variables , the fix is adding inline if statement in the constructor parameters for the primitives types , and it wasn't catch by the tests cause it initialized every int variable to a value of 10 and there were no other primitive fields