### PR TITLE
Handle Kotlin inner class names in source generator

### DIFF
--- a/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
+++ b/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
@@ -677,14 +677,22 @@ class KotlinPoetSourceGenerator : SourceGenerator {
         @OptIn(KotlinPoetJavaPoetPreview::class)
         private fun asClassName(classType: ClassTypeDef): ClassName {
             val result = if (classType.isInner) {
-                ClassName.bestGuess(classType.name.replace("$", "."))
-            } else {
-                val packageName = classType.packageName
-                var simpleName = classType.simpleName
-                if (classType.isEnum) {
-                    simpleName = simpleName.substringAfter("$")
+                // Build ClassName deterministically from the binary name split on '$',
+                // avoiding heuristics in ClassName.bestGuess() that rely on capitalisation.
+                val binaryName = classType.name
+                val dollarIndex = binaryName.indexOf('$')
+                if (dollarIndex != -1) {
+                    val outerFqn = binaryName.substring(0, dollarIndex)
+                    val dotIndex = outerFqn.lastIndexOf('.')
+                    val packageName = if (dotIndex == -1) "" else outerFqn.substring(0, dotIndex)
+                    val outerSimpleName = if (dotIndex == -1) outerFqn else outerFqn.substring(dotIndex + 1)
+                    val nestedNames = binaryName.substring(dollarIndex + 1).split('$').toTypedArray()
+                    ClassName(packageName, outerSimpleName, *nestedNames)
+                } else {
+                    com.squareup.javapoet.ClassName.get(classType.packageName, classType.simpleName).toKClassName()
                 }
-                com.squareup.javapoet.ClassName.get(packageName, simpleName).toKClassName()
+            } else {
+                com.squareup.javapoet.ClassName.get(classType.packageName, classType.simpleName).toKClassName()
             }
             if (result.isNullable) {
                 return asNullable(result) as ClassName

--- a/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
+++ b/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
@@ -676,12 +676,16 @@ class KotlinPoetSourceGenerator : SourceGenerator {
 
         @OptIn(KotlinPoetJavaPoetPreview::class)
         private fun asClassName(classType: ClassTypeDef): ClassName {
-            val packageName = classType.packageName
-            var simpleName = classType.simpleName
-            if (classType.isEnum) {
-                simpleName = simpleName.substringAfter("$")
+            val result = if (classType.isInner) {
+                ClassName.bestGuess(classType.name.replace("$", "."))
+            } else {
+                val packageName = classType.packageName
+                var simpleName = classType.simpleName
+                if (classType.isEnum) {
+                    simpleName = simpleName.substringAfter("$")
+                }
+                com.squareup.javapoet.ClassName.get(packageName, simpleName).toKClassName()
             }
-            val result: ClassName = com.squareup.javapoet.ClassName.get(packageName, simpleName).toKClassName()
             if (result.isNullable) {
                 return asNullable(result) as ClassName
             }


### PR DESCRIPTION
I had to to this fix, with the help of GPT-5, after upgrading the project to the latest versions. 

> The failure was caused by generated Kotlin builder code referencing nested records with JVM binary names like
  ClassWithInnerTypes$InnerRecord. Kotlin source needs nested type syntax: ClassWithInnerTypes.InnerRecord.

>  I changed sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt:678 so
  inner ClassTypeDefs are rendered from the binary name with $ converted to ., using ClassName.bestGuess(...).
  Top-level generated classes that intentionally contain $, like Trigger$MyRecord2, still render with backticks
  as before.