### PR TITLE
Render ExpressionDef.ArrayElement in the Java source writer

### DIFF
--- a/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
+++ b/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
@@ -837,6 +837,18 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
                     CodeBlock.of(")")
                 );
             }
+            case ExpressionDef.ArrayElement arrayElement -> {
+                CodeBlock array = renderExpression(objectDef, methodDef, remappedLocals, arrayElement.expression());
+                if (requiresMethodCallTargetParentheses(arrayElement.expression())) {
+                    array = addParentheses(array);
+                }
+                return CodeBlock.concat(
+                    array,
+                    CodeBlock.of("["),
+                    renderExpression(objectDef, methodDef, remappedLocals, arrayElement.indexExpression()),
+                    CodeBlock.of("]")
+                );
+            }
             case ExpressionDef.NewArrayOfSize newArray -> {
                 return CodeBlock.of("new $T[$L]", asType(newArray.type().componentType(), objectDef), newArray.size());
             }

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
@@ -1531,6 +1531,133 @@ class MyClass {
         assertEquals("\"Hello \" + 1 + \"Welcome!\"", result);
     }
 
+    @Test
+    public void arrayElementByConstantIndex() throws IOException {
+        ClassDef classDef = ClassDef.builder("test.MyClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("run")
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter("args", TypeDef.OBJECT.array())
+                .returns(TypeDef.OBJECT)
+                .build((aThis, methodParameters) -> methodParameters.get(0).arrayElement(0).returning())
+            )
+            .build();
+
+        String data = writeClass(classDef);
+
+        assertEquals("""
+package test;
+
+import java.lang.Object;
+
+public class MyClass {
+  public Object run(Object[] args) {
+    return args[0];
+  }
+}
+            """, data);
+    }
+
+    @Test
+    public void arrayElementByExpressionIndex() throws IOException {
+        TypeDef.Primitive intType = TypeDef.Primitive.INT;
+        ClassDef classDef = ClassDef.builder("test.MyClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("run")
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter("args", TypeDef.OBJECT.array())
+                .addParameter("i", intType)
+                .returns(TypeDef.OBJECT)
+                .build((aThis, methodParameters) -> methodParameters.get(0)
+                    .arrayElement(methodParameters.get(1).math(ADDITION, intType.constant(1)))
+                    .returning())
+            )
+            .build();
+
+        String data = writeClass(classDef);
+
+        assertEquals("""
+package test;
+
+import java.lang.Object;
+
+public class MyClass {
+  public Object run(Object[] args, int i) {
+    return args[i + 1];
+  }
+}
+            """, data);
+    }
+
+    @Test
+    public void arrayElementOfCast() throws IOException {
+        ClassDef classDef = ClassDef.builder("test.MyClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("run")
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter("o", TypeDef.OBJECT)
+                .returns(STRING)
+                .build((aThis, methodParameters) -> methodParameters.get(0)
+                    .cast(TypeDef.array(STRING))
+                    .arrayElement(0)
+                    .returning())
+            )
+            .build();
+
+        String data = writeClass(classDef);
+
+        assertEquals("""
+package test;
+
+import java.lang.Object;
+import java.lang.String;
+
+public class MyClass {
+  public String run(Object o) {
+    return ((String[]) o)[0];
+  }
+}
+            """, data);
+    }
+
+    @Test
+    public void arrayElementOfMethodCall() throws IOException {
+        ClassDef classDef = ClassDef.builder("test.MyClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("values")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(TypeDef.array(STRING))
+                .build((aThis, methodParameters) -> ExpressionDef.nullValue().returning())
+            )
+            .addMethod(MethodDef.builder("run")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(STRING)
+                .build((aThis, methodParameters) -> aThis
+                    .invoke("values", TypeDef.array(STRING))
+                    .arrayElement(0)
+                    .returning())
+            )
+            .build();
+
+        String data = writeClass(classDef);
+
+        assertEquals("""
+package test;
+
+import java.lang.String;
+
+public class MyClass {
+  public String[] values() {
+    return null;
+  }
+
+  public String run() {
+    return this.values()[0];
+  }
+}
+            """, data);
+    }
+
     private static ExpressionDef.SwitchYieldCase yieldWithConditionalBranch(TypeDef.Primitive intType,
                                                                             ExpressionDef conditionValue,
                                                                             int expectedValue,


### PR DESCRIPTION
## Problem

`JavaPoetSourceGenerator.renderExpression(...)` has no `case ExpressionDef.ArrayElement`, so any model containing an array access falls through to `case null, default -> throw new IllegalStateException("Unrecognized expression: " + expressionDef)`:

```
Unrecognized expression: ArrayElement[expression=MethodParameter[name=arguments,
  type=Array[componentType=JavaClass[type=class java.lang.Object, ...], dimensions=1, ...]],
  type=JavaClass[type=class java.lang.Object, ...], indexExpression=Constant[type=Primitive[clazz=int], value=0]]
```

The bytecode writer implements it (`ArrayElementExpressionWriter`, registered from `ExpressionWriter`), so today the two backends disagree about which models they accept. `ArrayElement` is also already recognised elsewhere in `JavaPoetSourceGenerator` — `requiresParentheses` lists it — which suggests the missing case is an oversight rather than a deliberate restriction.

Found while writing an annotation processor that generates Java source with the SourceGen model; it forced a workaround (a runtime helper taking `(array, index)` instead of an index expression).

## Fix

Add the case next to the `NewArrayOfSize` / `NewArrayInitialized` cases. The array operand is parenthesised with `requiresMethodCallTargetParentheses` — the predicate already used for a method call target — because array access has the same postfix precedence as `.method()`; the index is rendered plainly.

`GroovyPoetSourceGenerator` extends `JavaPoetSourceGenerator` and overrides only `getLanguage()`, so this covers Groovy too.

## Tests

Added to `ExpressionWriteTest`:

* a parameter indexed by a constant — `args[0]`
* a parameter indexed by an expression — `args[i + 1]`
* an indexed cast — `((String[]) o)[0]`, guarding the parenthesisation
* an indexed method result — `this.values()[0]`

## Note

Assignment *into* an array element is not covered: `StatementDef.Assign` takes a `VariableDef.Local`, so the model has no way to express it today. That needs an API addition and is left out of this change deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)