### PR TITLE
Support lambdas for ClassTypeDef.of(Class)

### DIFF
--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
@@ -792,7 +792,7 @@ public class example/MyClassWithLambda {
     ARETURN
    L1
     LOCALVARIABLE constant Ljava/lang/String; L0 L1 1
-    LOCALVARIABLE arg1 Ljava/lang/String; L0 L1 2
+    LOCALVARIABLE arg0 Ljava/lang/String; L0 L1 2
 
   // access flags 0x1
   public callGenericLambda2(Ljava/lang/String;)Ljava/lang/String;

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassTypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassTypeDef.java
@@ -586,6 +586,87 @@ public sealed interface ClassTypeDef extends TypeDef {
     record JavaClass(Class<?> type, boolean nullable) implements ClassTypeDef {
 
         @Override
+        public LambdaDef getLambda(Function<String, @Nullable TypeDef> resolveVariableFn) {
+            List<Method> abstractMethods = Arrays.stream(type.getMethods())
+                .filter(JavaClass::isAbstractMethod)
+                .filter(m -> !isObjectMethod(m))
+                .toList();
+            if (abstractMethods.size() != 1) {
+                throw new IllegalArgumentException("Parent of a lambda should have exactly one " +
+                    "abstract method but has " + abstractMethods.size());
+            }
+            Method method = abstractMethods.get(0);
+            return new LambdaDef(
+                ClassTypeDef.of(type).resolveTypeVariables(resolveVariableFn),
+                MethodDef.of(method),
+                asImplementation(method, resolveVariableFn)
+            );
+        }
+
+        private static boolean isAbstractMethod(Method method) {
+            int modifiers = method.getModifiers();
+            return java.lang.reflect.Modifier.isAbstract(modifiers)
+                && !java.lang.reflect.Modifier.isStatic(modifiers)
+                && !method.isDefault()
+                && !method.isBridge()
+                && !method.isSynthetic();
+        }
+
+        /**
+         * An interface can redeclare a public method of {@link Object} as abstract - {@code Comparator}
+         * does with {@code equals} - without that making it a second abstract method for the purpose of
+         * being a functional interface.
+         *
+         * @param method The method
+         * @return True if the method is a public method of {@link Object}
+         */
+        private static boolean isObjectMethod(Method method) {
+            try {
+                Object.class.getMethod(method.getName(), method.getParameterTypes());
+                return true;
+            } catch (NoSuchMethodException e) {
+                return false;
+            }
+        }
+
+        private static MethodDef asImplementation(Method method, Function<String, @Nullable TypeDef> resolveVariableFn) {
+            MethodDef.MethodDefBuilder builder = MethodDef.builder(method.getName())
+                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                .returns(asTypeDef(method.getGenericReturnType(), method.getReturnType(), resolveVariableFn));
+            java.lang.reflect.Parameter[] parameters = method.getParameters();
+            java.lang.reflect.Type[] genericParameterTypes = method.getGenericParameterTypes();
+            for (int i = 0; i < parameters.length; i++) {
+                builder.addParameter(
+                    parameters[i].getName(),
+                    asTypeDef(genericParameterTypes[i], parameters[i].getType(), resolveVariableFn)
+                );
+            }
+            return builder.build();
+        }
+
+        /**
+         * Resolves a reflective type, substituting a type variable when the caller provided a value for
+         * it and falling back to the erasure otherwise, so that an unresolved variable never leaks into
+         * the model.
+         *
+         * @param genericType       The generic type
+         * @param erasure           The erasure of the generic type
+         * @param resolveVariableFn The resolve variable function
+         * @return The type definition
+         */
+        private static TypeDef asTypeDef(java.lang.reflect.Type genericType,
+                                         Class<?> erasure,
+                                         Function<String, @Nullable TypeDef> resolveVariableFn) {
+            if (genericType instanceof java.lang.reflect.TypeVariable<?> typeVariable) {
+                TypeDef resolved = resolveVariableFn.apply(typeVariable.getName());
+                if (resolved != null) {
+                    return resolved;
+                }
+            }
+            return TypeDef.of(erasure);
+        }
+
+        @Override
         public String getName() {
             return type.getName();
         }
@@ -654,6 +735,13 @@ public sealed interface ClassTypeDef extends TypeDef {
 
         public ClassName(String name, boolean isInner) {
             this(name, isInner, false);
+        }
+
+        @Override
+        public LambdaDef getLambda(Function<String, @Nullable TypeDef> resolveVariableFn) {
+            throw new UnsupportedOperationException("ClassTypeDef: " + name + " doesn't support lambdas" +
+                " because it is defined by name only and carries no member information." +
+                " Use ClassTypeDef.of(Class) or ClassTypeDef.of(ClassElement) instead.");
         }
 
         @Override

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassTypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassTypeDef.java
@@ -624,7 +624,7 @@ public sealed interface ClassTypeDef extends TypeDef {
             try {
                 Object.class.getMethod(method.getName(), method.getParameterTypes());
                 return true;
-            } catch (NoSuchMethodException e) {
+            } catch (NoSuchMethodException _) {
                 return false;
             }
         }

--- a/sourcegen-model/src/test/groovy/io/micronaut/sourcegen/model/JavaClassLambdaTest.java
+++ b/sourcegen-model/src/test/groovy/io/micronaut/sourcegen/model/JavaClassLambdaTest.java
@@ -1,0 +1,104 @@
+package io.micronaut.sourcegen.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests {@link ClassTypeDef.JavaClass#getLambda(java.util.function.Function)}, which resolves the
+ * single abstract method of a functional interface reflectively.
+ */
+class JavaClassLambdaTest {
+
+    @Test
+    void resolvesTheSingleAbstractMethod() {
+        LambdaDef lambda = ClassTypeDef.of(Function.class).getLambda();
+
+        assertEquals("apply", lambda.getMethod().getName());
+        assertEquals(ClassTypeDef.of(Function.class), lambda.getType());
+        assertEquals(1, lambda.getImplementation().getParameters().size());
+    }
+
+    @Test
+    void resolvesTypeVariables() {
+        LambdaDef lambda = ClassTypeDef.of(Function.class)
+            .getLambda(Map.of("T", TypeDef.STRING, "R", TypeDef.of(Integer.class)));
+
+        MethodDef implementation = lambda.getImplementation();
+        assertEquals(TypeDef.STRING, implementation.getParameters().get(0).getType());
+        assertEquals(TypeDef.of(Integer.class), implementation.getReturnType());
+    }
+
+    @Test
+    void unresolvedTypeVariablesFallBackToTheErasure() {
+        MethodDef implementation = ClassTypeDef.of(Function.class).getLambda().getImplementation();
+
+        assertEquals(TypeDef.OBJECT, implementation.getParameters().get(0).getType());
+        assertEquals(TypeDef.OBJECT, implementation.getReturnType());
+    }
+
+    @Test
+    void ignoresDefaultAndStaticMethods() {
+        LambdaDef lambda = ClassTypeDef.of(WithDefaultAndStaticMethods.class).getLambda();
+
+        assertEquals("run", lambda.getMethod().getName());
+    }
+
+    @Test
+    void ignoresRedeclaredObjectMethods() {
+        // Comparator redeclares Object#equals as abstract
+        LambdaDef lambda = ClassTypeDef.of(Comparator.class).getLambda();
+
+        assertEquals("compare", lambda.getMethod().getName());
+    }
+
+    @Test
+    void failsForMoreThanOneAbstractMethod() {
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> ClassTypeDef.of(TwoAbstractMethods.class).getLambda()
+        );
+
+        assertEquals("Parent of a lambda should have exactly one abstract method but has 2", e.getMessage());
+    }
+
+    @Test
+    void failsForANameOnlyClassTypeDefWithAHelpfulMessage() {
+        UnsupportedOperationException e = assertThrows(
+            UnsupportedOperationException.class,
+            () -> ClassTypeDef.of("com.example.Foo").getLambda()
+        );
+
+        assertTrue(e.getMessage().contains("com.example.Foo"), e.getMessage());
+        assertTrue(e.getMessage().contains("ClassTypeDef.of(Class)"), e.getMessage());
+        assertTrue(e.getMessage().contains("ClassTypeDef.of(ClassElement)"), e.getMessage());
+    }
+
+    @FunctionalInterface
+    interface WithDefaultAndStaticMethods {
+
+        String run(String value);
+
+        default String runTwice(String value) {
+            return run(run(value));
+        }
+
+        static WithDefaultAndStaticMethods identity() {
+            return value -> value;
+        }
+    }
+
+    interface TwoAbstractMethods {
+
+        String first();
+
+        String second();
+    }
+
+}

--- a/sourcegen-model/src/test/groovy/io/micronaut/sourcegen/model/JavaClassLambdaTest.java
+++ b/sourcegen-model/src/test/groovy/io/micronaut/sourcegen/model/JavaClassLambdaTest.java
@@ -60,20 +60,18 @@ class JavaClassLambdaTest {
 
     @Test
     void failsForMoreThanOneAbstractMethod() {
-        IllegalArgumentException e = assertThrows(
-            IllegalArgumentException.class,
-            () -> ClassTypeDef.of(TwoAbstractMethods.class).getLambda()
-        );
+        ClassTypeDef typeDef = ClassTypeDef.of(TwoAbstractMethods.class);
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, typeDef::getLambda);
 
         assertEquals("Parent of a lambda should have exactly one abstract method but has 2", e.getMessage());
     }
 
     @Test
     void failsForANameOnlyClassTypeDefWithAHelpfulMessage() {
-        UnsupportedOperationException e = assertThrows(
-            UnsupportedOperationException.class,
-            () -> ClassTypeDef.of("com.example.Foo").getLambda()
-        );
+        ClassTypeDef typeDef = ClassTypeDef.of("com.example.Foo");
+
+        UnsupportedOperationException e = assertThrows(UnsupportedOperationException.class, typeDef::getLambda);
 
         assertTrue(e.getMessage().contains("com.example.Foo"), e.getMessage());
         assertTrue(e.getMessage().contains("ClassTypeDef.of(Class)"), e.getMessage());

--- a/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateLambdaVisitor.java
+++ b/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateLambdaVisitor.java
@@ -179,23 +179,12 @@ public final class GenerateLambdaVisitor implements TypeElementVisitor<GenerateL
         Local constant = new Local("constant", TypeDef.STRING);
         Local function = new Local("function", TypeDef.parameterized(Function.class, String.class, String.class));
 
-        MethodDef target = MethodDef.builder("apply")
-            .addParameters(TypeDef.OBJECT)
-            .returns(TypeDef.OBJECT)
-            .addModifiers(Modifier.ABSTRACT)
-            .build();
-        Lambda lambda = new Lambda(
-            ClassTypeDef.of(Function.class),
-            target,
-            MethodDef.builder("apply")
-                .addParameters(TypeDef.STRING)
-                .returns(TypeDef.STRING)
-                .addModifiers(Modifier.ABSTRACT)
-                .build((t, params) -> JavaIdioms.concatStrings(
-                    constant,
-                    params.get(0).invoke("substring", TypeDef.STRING, ExpressionDef.constant(1))
-                ).returning())
-        );
+        Lambda lambda = ClassTypeDef.of(Function.class)
+            .getLambda(Map.of("T", TypeDef.STRING, "R", TypeDef.STRING))
+            .implement((t, params) -> JavaIdioms.concatStrings(
+                constant,
+                params.get(0).invoke("substring", TypeDef.STRING, ExpressionDef.constant(1))
+            ).returning());
 
         return MethodDef.builder("callGenericLambda")
             .addModifiers(Modifier.PUBLIC)


### PR DESCRIPTION
## Problem

`ClassTypeDef.getLambda(...)` is a default method that throws `UnsupportedOperationException`. Only `ClassElementType` overrode it, by querying `ElementQuery.of(MethodElement.class).onlyAbstract()`. `JavaClass` — what `ClassTypeDef.of(Class)` returns — did not, even though the same information is available reflectively:

```
ClassTypeDef: io.micronaut.el.runtime.ELLambdaBody doesn't support lambdas
```

This bites whenever a processor's target functional interface is a compiled class on the processor's own classpath, which is the common case for a runtime SPI.

The repository itself works around it: `GenerateLambdaVisitor.createGenericLambda` hand-builds an `ExpressionDef.Lambda` over `java.util.function.Function` with a hand-written target and implementation `MethodDef`, because `ClassTypeDef.of(Function.class).getLambda(...)` was not available.

## Fix

`JavaClass.getLambda` collects the public abstract, non-`default`, non-`static`, non-bridge methods of the class and requires exactly one — the same rule and the same message as the `ClassElement` path. Methods that merely redeclare a public method of `Object` are excluded, since an interface may declare one without that making it a second abstract method for functional-interface purposes (`Comparator` declares `equals`).

The implementation `MethodDef` is built from the method's **generic** signature, so `getLambda(Map.of("T", ..., "R", ...))` resolves the interface's type variables the way the `ClassElement` path does. A variable the caller did not resolve falls back to its erasure, so an unresolved `TypeDef.TypeVariable` never leaks into the model and callers of the no-arg `getLambda()` keep getting the erased signature.

`ClassTypeDef.ClassName` (`ClassTypeDef.of(String)`) still throws — a name carries no member information — but the message now says why and points at `ClassTypeDef.of(Class)` / `of(ClassElement)`.

I did not require `@FunctionalInterface`: the annotation is optional in Java, and the single-abstract-method check is the real rule.

## Tests

New `JavaClassLambdaTest`:

* `ClassTypeDef.of(Function.class).getLambda()` resolves `apply`
* type variables resolve when supplied, and fall back to the erasure when not
* an interface with a single abstract method plus `default` and `static` methods resolves the abstract one
* `Comparator`, which redeclares `Object#equals` as abstract, resolves `compare`
* an interface with two abstract methods fails with a clear message
* `ClassTypeDef.of("com.example.Foo").getLambda()` fails with the improved message

`GenerateLambdaVisitor.createGenericLambda` now uses `getLambda(...).implement(...)` instead of the hand-built `Lambda`, which puts the reflective path under end-to-end coverage: the generated `callGenericLambda` is compiled and executed by `test-suite-java` and `test-suite-bytecode`, and its bytecode is asserted by `ByteCodeWriterTest`.

The only change in the generated output is one lambda parameter name (`arg1` → `arg0`), which now comes from reflection; `ByteCodeWriterTest`'s golden output is updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)