### PR TITLE
Allow naming the parameters of a lambda implementation

### DIFF
--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
@@ -6,6 +6,7 @@ import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.ExpressionDef;
 import io.micronaut.sourcegen.model.ExpressionDef.Cast;
 import io.micronaut.sourcegen.model.InterfaceDef;
+import io.micronaut.sourcegen.model.LambdaDef;
 import io.micronaut.sourcegen.model.MethodDef;
 import io.micronaut.sourcegen.model.StatementDef;
 import io.micronaut.sourcegen.model.TypeDef;
@@ -1710,10 +1711,11 @@ public class MyClass {
                 .build())
             .build();
 
+        LambdaDef lambda = functionDef.asTypeDef().getLambda();
+
         IllegalArgumentException e = Assertions.assertThrows(
             IllegalArgumentException.class,
-            () -> functionDef.asTypeDef().getLambda()
-                .implement(List.of("a", "b"), (aThis, params) -> params.get(0).returning())
+            () -> lambda.implement(List.of("a", "b"), (aThis, params) -> params.get(0).returning())
         );
 
         assertEquals("Lambda method apply has 1 parameter(s) but 2 name(s) were provided", e.getMessage());

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
@@ -5,6 +5,7 @@ import io.micronaut.sourcegen.model.ClassDef;
 import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.ExpressionDef;
 import io.micronaut.sourcegen.model.ExpressionDef.Cast;
+import io.micronaut.sourcegen.model.InterfaceDef;
 import io.micronaut.sourcegen.model.MethodDef;
 import io.micronaut.sourcegen.model.StatementDef;
 import io.micronaut.sourcegen.model.TypeDef;
@@ -1656,6 +1657,66 @@ public class MyClass {
   }
 }
             """, data);
+    }
+
+    @Test
+    public void nestedLambdasCanBeGivenDistinctParameterNames() throws IOException {
+        ClassTypeDef nestedType = ClassTypeDef.of("test.Nested");
+        InterfaceDef nestedDef = InterfaceDef.builder("test.Nested")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("apply")
+                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                .addParameter("context", TypeDef.STRING)
+                .returns(nestedType)
+                .build())
+            .build();
+        ClassTypeDef lambdaType = nestedDef.asTypeDef();
+
+        ExpressionDef.Lambda inner = lambdaType.getLambda()
+            .implement(List.of("innerContext"), (aThis, params) -> ExpressionDef.nullValue().returning());
+        ExpressionDef.Lambda outer = lambdaType.getLambda()
+            .implement(List.of("outerContext"), (aThis, params) -> inner.returning());
+
+        ClassDef classDef = ClassDef.builder("test.MyClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("evaluate")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(lambdaType)
+                .build((aThis, methodParameters) -> outer.returning())
+            )
+            .build();
+
+        String data = writeClass(classDef);
+
+        assertEquals("""
+package test;
+
+public class MyClass {
+  public Nested evaluate() {
+    return (outerContext) -> (innerContext) -> null;
+  }
+}
+            """, data);
+    }
+
+    @Test
+    public void lambdaParameterNamesAreValidatedAgainstTheArity() {
+        InterfaceDef functionDef = InterfaceDef.builder("test.StringFunction")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("apply")
+                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                .addParameter("context", TypeDef.STRING)
+                .returns(TypeDef.STRING)
+                .build())
+            .build();
+
+        IllegalArgumentException e = Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> functionDef.asTypeDef().getLambda()
+                .implement(List.of("a", "b"), (aThis, params) -> params.get(0).returning())
+        );
+
+        assertEquals("Lambda method apply has 1 parameter(s) but 2 name(s) were provided", e.getMessage());
     }
 
     private static ExpressionDef.SwitchYieldCase yieldWithConditionalBranch(TypeDef.Primitive intType,

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/LambdaDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/LambdaDef.java
@@ -17,6 +17,9 @@ package io.micronaut.sourcegen.model;
 
 import io.micronaut.core.annotation.Experimental;
 
+import java.util.List;
+import java.util.Objects;
+
 /**
  * Definition holding information about a lambda interface that can be implemented.
  * Use {@link ClassTypeDef#getLambda()} to create an instance from an existing type definition.
@@ -51,6 +54,48 @@ public final class LambdaDef {
             method,
             MethodDef.override(implementation).build(lambdaBuilder)
         );
+    }
+
+    /**
+     * Implement lambda by providing the parameter names and the method body.
+     *
+     * <p>The implementation carries the parameter names of the functional interface's own method, so
+     * every lambda over the same interface declares the same names. Java forbids a lambda parameter
+     * from shadowing a name that is already in scope, which makes nested lambdas over one interface
+     * fail to compile; naming the parameters explicitly avoids the collision.
+     *
+     * @param parameterNames The lambda parameter names
+     * @param lambdaBuilder  The lambda builder
+     * @return the lambda expression
+     * @since 2.2
+     */
+    public ExpressionDef.Lambda implement(List<String> parameterNames, MethodDef.MethodBodyBuilder lambdaBuilder) {
+        Objects.requireNonNull(parameterNames, "Parameter names cannot be null");
+        List<ParameterDef> parameters = implementation.getParameters();
+        if (parameterNames.size() != parameters.size()) {
+            throw new IllegalArgumentException("Lambda method " + implementation.getName() + " has "
+                + parameters.size() + " parameter(s) but " + parameterNames.size() + " name(s) were provided");
+        }
+        MethodDef.MethodDefBuilder builder = MethodDef.builder(implementation.getName())
+            .addModifiers(implementation.getModifiers())
+            .returns(implementation.getReturnType())
+            .overrides();
+        for (int i = 0; i < parameters.size(); i++) {
+            builder.addParameter(parameters.get(i).withName(parameterNames.get(i)));
+        }
+        return new ExpressionDef.Lambda(type, method, builder.build(lambdaBuilder));
+    }
+
+    /**
+     * Implement lambda by providing the parameter names and the method body.
+     *
+     * @param parameterNames The lambda parameter names
+     * @param lambdaBuilder  The lambda builder
+     * @return the lambda expression
+     * @since 2.2
+     */
+    public ExpressionDef.Lambda implement(String[] parameterNames, MethodDef.MethodBodyBuilder lambdaBuilder) {
+        return implement(List.of(parameterNames), lambdaBuilder);
     }
 
     /**

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ParameterDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ParameterDef.java
@@ -81,6 +81,25 @@ public final class ParameterDef extends AbstractElement {
             .build();
     }
 
+    /**
+     * Creates a copy of this parameter with a different name.
+     *
+     * @param name The new name
+     * @return The renamed parameter
+     * @since 2.2
+     */
+    public ParameterDef withName(String name) {
+        if (this.name.equals(name)) {
+            return this;
+        }
+        return ParameterDef.builder(name, type)
+            .addAnnotations(annotations)
+            .addModifiers(modifiers)
+            .addJavadoc(javadoc)
+            .synthetic(synthetic)
+            .build();
+    }
+
     public TypeDef getType() {
         return type;
     }


### PR DESCRIPTION
## Problem

`LambdaDef.implement(MethodDef.MethodBodyBuilder)` builds the implementation with `MethodDef.override(implementation).build(lambdaBuilder)`, and `implementation` comes from the functional interface's own method — so it carries the *interface's* parameter names. Every lambda over the same interface therefore declares the same parameter name, and `JavaPoetSourceGenerator`'s `case Lambda lambda` emits `lambda.implementation().getParameters()` verbatim:

```java
return (context) -> (context) -> null;
```

Java forbids a lambda parameter from shadowing a name already in scope, so the source is emitted successfully and *then* fails to compile:

```
error: variable context is already defined in method evaluate(ELContext)
```

The bytecode writer is unaffected, because names are not significant there.

Found while writing an annotation processor that nests lambdas over one functional interface; the workaround was constructing `ExpressionDef.Lambda` directly with a hand-built `MethodDef` whose parameter name carries a counter suffix.

## Fix

Add an overload that lets the caller name the parameters:

```java
public ExpressionDef.Lambda implement(List<String> parameterNames, MethodDef.MethodBodyBuilder lambdaBuilder)
public ExpressionDef.Lambda implement(String[] parameterNames, MethodDef.MethodBodyBuilder lambdaBuilder)
```

It builds the implementation `MethodDef` from the existing one with the given names substituted, validating the arity. `ParameterDef.withName` does the substitution while preserving the parameter's annotations, modifiers and javadoc.

This is purely additive and unblocks callers immediately; it is the sanctioned form of the workaround they are already writing by hand.

## Follow-up

Making the writer allocate non-colliding names so callers don't have to think about it is a larger change — it needs scope awareness in the renderer, and the existing `Map<String, String> remappedLocals` threaded through it is not sufficient (it is keyed only by name, not by the owning method). That is worth doing separately, since it is the only one of these changes that can churn existing golden output.

## Tests

In `ExpressionWriteTest`:

* two nested lambdas over the same functional interface — the emitted parameter names differ: `(outerContext) -> (innerContext) -> null`. Without the overload the same model renders `(context) -> (context) -> null`, which does not compile.
* the parameter names are validated against the arity, with a message naming the method and both counts.

## Unrelated defect noticed

While writing these tests I hit a separate writer bug: a lambda with a **multi-statement** body in a `return` position throws `IllegalStateException: statement enter $[ followed by statement enter $[` from JavaPoet's `CodeWriter`. It reproduces on `2.2.x` without any of this change and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)