### PR TITLE
Exclude the test suites from the aggregate coverage report

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,4 +13,13 @@ afterEvaluate {
             it.name.startsWith("test-suite")
         }
     }
+    // The test suites generate the same example types with different generators - `test-suite-java`
+    // generates `io.micronaut.sourcegen.example.CrudRepository1` from source and `test-suite-bytecode`
+    // generates it as bytecode - so aggregating their classes fails the report with
+    // `Can't add different class with same name`. Their coverage is not meaningful anyway.
+    configurations.named("jacocoAggregation") {
+        dependencies.removeIf {
+            it.name.startsWith("test-suite")
+        }
+    }
 }


### PR DESCRIPTION
## Problem

`:testCodeCoverageReport` fails on **every** pull request in this repository — including ones that change nothing relevant, such as #462 (files sync) and #463 (renovate). It is a repo-wide CI break, not caused by any particular change.

```
Execution failed for task ':testCodeCoverageReport' (registered by plugin 'io.micronaut.build.internal.quality-reporting').
> A failure occurred while executing org.gradle.internal.jacoco.JacocoReportAction
   > Error while creating report
```

CI runs `./gradlew check jacocoReport --no-daemon --continue` without `--stacktrace`, so the actual cause never reaches the log. It is:

```
java.io.IOException: Error while analyzing
  test-suite-java/build/classes/java/main/io/micronaut/sourcegen/example/CrudRepository1.class
  with JaCoCo 0.8.14.
Caused by: java.lang.IllegalStateException: Can't add different class with same name:
  io/micronaut/sourcegen/example/CrudRepository1
```

`test-suite-java` and `test-suite-bytecode` generate the same example types with different generators — one from source, one as bytecode. The two class files therefore have the same name and different content, and JaCoCo's `CoverageBuilder` refuses to aggregate them.

Only the *aggregate* report fails; every per-project `jacocoTestReport` succeeds.

## Fix

Drop the test suites from `jacocoAggregation`, exactly the way they are already dropped from `javadocAggregatorBase` immediately above in the same `afterEvaluate` block. They are generated fixtures, so their coverage was not meaningful in the aggregate report anyway, and the per-project reports are unaffected.

## Reproducing

The JaCoCo agent is only attached when `CI` is set, which is why this does not show up in a normal local build:

```bash
CI=true ./gradlew check jacocoReport --continue
```

Fails on `2.2.x`, passes with this change, and `build/reports/jacoco/testCodeCoverageReport/` is populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)