### PR TITLE
Render a lambda with a block body

### DIFF
--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
@@ -37,6 +37,7 @@ import java.util.AbstractList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -4168,6 +4169,53 @@ public class MyClass {
 """, decompileToJava(bytes));
         // The captured parameter is the first argument of the synthetic method; the local variable names
         // the decompiler shows are shifted by one, which is a separate defect of the debug information
+    }
+
+    @Test
+    void testLambdaWithABlockBodyAsAnArgument() throws Exception {
+        // A Consumer whose body is an invocation statement, passed as the argument of another statement -
+        // the shape that the Java writer could not render at all
+        Method accept = Consumer.class.getMethod("accept", Object.class);
+        Method forEach = Iterable.class.getMethod("forEach", Consumer.class);
+        Method println = PrintStream.class.getMethod("println", Object.class);
+
+        ClassDef classDef = ClassDef.builder("example.MyClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("printAll")
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter("items", TypeDef.parameterized(List.class, String.class))
+                .build((t, params) -> params.get(0).invoke(forEach, new ExpressionDef.Lambda(
+                    ClassTypeDef.of(Consumer.class),
+                    MethodDef.of(accept),
+                    MethodDef.builder("accept")
+                        .addModifiers(Modifier.PUBLIC)
+                        .addParameter("item", TypeDef.OBJECT)
+                        .returns(TypeDef.VOID)
+                        .build((lt, lp) -> ClassTypeDef.of(System.class)
+                            .getStaticField("out", TypeDef.of(PrintStream.class))
+                            .invoke(println, lp.get(0)))
+                )))
+            )
+            .build();
+
+        StringWriter bytecodeWriter = new StringWriter();
+        byte[] bytes = generateFile(classDef, bytecodeWriter);
+
+        assertEquals("""
+package example;
+
+import java.util.List;
+
+public class MyClass {
+   public void printAll(List items) {
+      items.forEach(MyClass::lambda$printAll$0);
+   }
+
+   private static void lambda$printAll$0(Object var0) {
+      System.out.println(var0);
+   }
+}
+""", decompileToJava(bytes));
     }
 
     private String toBytecode(ObjectDef objectDef) {

--- a/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
+++ b/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
@@ -874,8 +874,12 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
     }
 
     private static boolean containsBlockBodyLambda(ExpressionDef expressionDef) {
-        return expressionDef instanceof Lambda lambda && singleExpressionBody(lambda) == null
-            || expressionDef.nestedExpressionsStream().anyMatch(JavaPoetSourceGenerator::containsBlockBodyLambda);
+        if (expressionDef instanceof Lambda lambda) {
+            // A lambda does not expose its body as nested expressions, so descend into it explicitly
+            return singleExpressionBody(lambda) == null
+                || lambda.implementation().getStatements().stream().anyMatch(JavaPoetSourceGenerator::containsBlockBodyLambda);
+        }
+        return expressionDef.nestedExpressionsStream().anyMatch(JavaPoetSourceGenerator::containsBlockBodyLambda);
     }
 
     private static boolean containsSwitchExpression(StatementDef statementDef) {

--- a/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
+++ b/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
@@ -863,8 +863,8 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
     @Nullable
     private static ExpressionDef singleExpressionBody(Lambda lambda) {
         List<StatementDef> statements = lambda.implementation().getStatements();
-        if (statements.size() == 1 && statements.get(0) instanceof StatementDef.Return returnStatement) {
-            return returnStatement.expression();
+        if (statements.size() == 1 && statements.get(0) instanceof StatementDef.Return(ExpressionDef expression)) {
+            return expression;
         }
         return null;
     }

--- a/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
+++ b/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
@@ -841,7 +841,9 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
             }
             case null, default -> {
                 CodeBlock statement = renderStatement(objectDef, methodDef, scope, statementDef);
-                if (statementDef != null && containsSwitchExpression(statementDef)) {
+                // Both render statements of their own, and JavaPoet rejects nesting its statement markers
+                if (statementDef != null
+                    && (containsSwitchExpression(statementDef) || containsBlockBodyLambda(statementDef))) {
                     return CodeBlock.builder()
                         .add(statement)
                         .add(";\n")
@@ -852,6 +854,28 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
                     .build();
             }
         }
+    }
+
+    /**
+     * @param lambda The lambda
+     * @return The expression of a single expression body, or {@code null} for a block body
+     */
+    @Nullable
+    private static ExpressionDef singleExpressionBody(Lambda lambda) {
+        List<StatementDef> statements = lambda.implementation().getStatements();
+        if (statements.size() == 1 && statements.get(0) instanceof StatementDef.Return returnStatement) {
+            return returnStatement.expression();
+        }
+        return null;
+    }
+
+    private static boolean containsBlockBodyLambda(StatementDef statementDef) {
+        return statementDef.nestedExpressionsStream().anyMatch(JavaPoetSourceGenerator::containsBlockBodyLambda);
+    }
+
+    private static boolean containsBlockBodyLambda(ExpressionDef expressionDef) {
+        return expressionDef instanceof Lambda lambda && singleExpressionBody(lambda) == null
+            || expressionDef.nestedExpressionsStream().anyMatch(JavaPoetSourceGenerator::containsBlockBodyLambda);
     }
 
     private static boolean containsSwitchExpression(StatementDef statementDef) {
@@ -1087,13 +1111,13 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
                 }
                 builder.add(") -> ");
                 List<StatementDef> statements = implementation.getStatements();
-                if (statements.size() == 1 && statements.get(0) instanceof StatementDef.Return returnStatement
-                    && returnStatement.expression() != null) {
-                    builder.add(renderExpression(objectDef, implementation, lambdaScope, returnStatement.expression()));
+                ExpressionDef body = singleExpressionBody(lambda);
+                if (body != null) {
+                    builder.add(renderExpression(objectDef, implementation, lambdaScope, body));
                 } else {
-                    builder.add("{").indent();
+                    builder.add("{\n").indent();
                     for (StatementDef statement : statements) {
-                        builder.addStatement(renderStatementCodeBlock(objectDef, implementation, lambdaScope, statement));
+                        builder.add(renderStatementCodeBlock(objectDef, implementation, lambdaScope, statement));
                     }
                     builder.unindent().add("}");
                 }

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/LambdaBlockBodyWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/LambdaBlockBodyWriteTest.java
@@ -86,6 +86,37 @@ public class MyClass {
     }
 
     @Test
+    public void singleExpressionLambdaIsUnchanged() throws IOException {
+        InterfaceDef functionDef = stringFunction();
+        ClassTypeDef lambdaType = functionDef.asTypeDef();
+
+        ClassDef classDef = ClassDef.builder("test.MyClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("evaluate")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(lambdaType)
+                .build((aThis, methodParameters) -> lambdaType.getLambda()
+                    .implement((t, params) -> params.get(0).invoke("trim", TypeDef.STRING).returning())
+                    .returning())
+            )
+            .build();
+
+        String data = writeClass(classDef);
+
+        assertEquals("""
+package test;
+
+public class MyClass {
+  public StringFunction evaluate() {
+    return (context) -> context.trim();
+  }
+}
+            """, data);
+
+        JavaCompileAssertions.assertCompiles(writeObject(functionDef), data);
+    }
+
+    @Test
     public void blockBodyLambdaInALocalVariable() throws IOException {
         InterfaceDef functionDef = stringFunction();
         ClassTypeDef lambdaType = functionDef.asTypeDef();

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/LambdaBlockBodyWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/LambdaBlockBodyWriteTest.java
@@ -205,6 +205,54 @@ public class MyClass {
     }
 
     @Test
+    public void blockBodyLambdaInsideASingleExpressionLambda() throws IOException {
+        ClassTypeDef nestedType = ClassTypeDef.of("test.Nested");
+        InterfaceDef nestedDef = InterfaceDef.builder("test.Nested")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("apply")
+                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                .addParameter("context", TypeDef.STRING)
+                .returns(nestedType)
+                .build())
+            .build();
+        ClassTypeDef lambdaType = nestedDef.asTypeDef();
+        VariableDef.Local tmp = new VariableDef.Local("tmp", TypeDef.STRING);
+
+        ExpressionDef.Lambda inner = lambdaType.getLambda().implement((aThis, params) -> StatementDef.multi(
+            tmp.defineAndAssign(params.get(0).invoke("trim", TypeDef.STRING)),
+            ExpressionDef.nullValue().returning()
+        ));
+        // The outer lambda is a single expression, so the block body is not visible as a nested expression
+        ExpressionDef.Lambda outer = lambdaType.getLambda().implement((aThis, params) -> inner.returning());
+
+        ClassDef classDef = ClassDef.builder("test.MyClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("evaluate")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(lambdaType)
+                .build((aThis, methodParameters) -> outer.returning())
+            )
+            .build();
+
+        String data = writeClass(classDef);
+
+        assertEquals("""
+package test;
+
+import java.lang.String;
+
+public class MyClass {
+  public Nested evaluate() {
+    return (context) -> (context) -> {
+      String tmp = context.trim();
+      return null;
+    };
+  }
+}
+            """, data);
+    }
+
+    @Test
     public void nestedBlockBodyLambdas() throws IOException {
         InterfaceDef functionDef = stringFunction();
         ClassTypeDef lambdaType = functionDef.asTypeDef();

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/LambdaBlockBodyWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/LambdaBlockBodyWriteTest.java
@@ -15,6 +15,10 @@ import org.junit.jupiter.api.Test;
 import javax.lang.model.element.Modifier;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -243,13 +247,64 @@ import java.lang.String;
 
 public class MyClass {
   public Nested evaluate() {
-    return (context) -> (context) -> {
-      String tmp = context.trim();
+    return (context) -> (context1) -> {
+      String tmp = context1.trim();
       return null;
     };
   }
 }
             """, data);
+    }
+
+    @Test
+    public void consumerWithAnInvocationBodyAsAMethodArgument() throws Exception {
+        // A void functional interface whose body is a statement, not a return - passed as an argument
+        Method accept = Consumer.class.getMethod("accept", Object.class);
+        Method forEach = Iterable.class.getMethod("forEach", Consumer.class);
+        VariableDef.Local sink = new VariableDef.Local("sink", TypeDef.parameterized(List.class, String.class));
+
+        ClassDef classDef = ClassDef.builder("test.MyClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("copy")
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter("items", TypeDef.parameterized(List.class, String.class))
+                .returns(TypeDef.parameterized(List.class, String.class))
+                .build((aThis, params) -> StatementDef.multi(
+                    sink.defineAndAssign(ClassTypeDef.of(ArrayList.class).instantiate()),
+                    params.get(0).invoke(forEach, new ExpressionDef.Lambda(
+                        ClassTypeDef.of(Consumer.class),
+                        MethodDef.of(accept),
+                        MethodDef.builder("accept")
+                            .addModifiers(Modifier.PUBLIC)
+                            .addParameter("t", TypeDef.OBJECT)
+                            .returns(TypeDef.VOID)
+                            .build((lt, lp) -> sink.invoke("add", TypeDef.Primitive.BOOLEAN, lp.get(0)))
+                    )),
+                    sink.returning()
+                ))
+            )
+            .build();
+
+        String data = writeClass(classDef);
+
+        assertEquals("""
+package test;
+
+import java.lang.String;
+import java.util.List;
+
+public class MyClass {
+  public List<String> copy(List<String> items) {
+    List<String> sink = new java.util.ArrayList();
+    items.forEach((t) -> {
+      sink.add(t);
+    });
+    return sink;
+  }
+}
+            """, data);
+
+        JavaCompileAssertions.assertCompiles(data);
     }
 
     @Test
@@ -282,8 +337,8 @@ import java.lang.String;
 public class MyClass {
   public StringFunction evaluate() {
     return (context) -> {
-      StringFunction inner = (context) -> {
-        String tmp = context.trim();
+      StringFunction inner = (context1) -> {
+        String tmp = context1.trim();
         return tmp;
       };
       return inner.apply("a");
@@ -291,8 +346,6 @@ public class MyClass {
   }
 }
             """, data);
-        // Not compiled: both lambdas declare `context`, which Java rejects. That is a separate defect -
-        // the writer emits the interface's parameter name for every lambda over the same interface.
     }
 
 }

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/LambdaBlockBodyWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/LambdaBlockBodyWriteTest.java
@@ -1,0 +1,219 @@
+package io.micronaut.sourcegen.javapoet.write;
+
+import io.micronaut.sourcegen.JavaPoetSourceGenerator;
+import io.micronaut.sourcegen.model.ClassDef;
+import io.micronaut.sourcegen.model.ClassTypeDef;
+import io.micronaut.sourcegen.model.ExpressionDef;
+import io.micronaut.sourcegen.model.InterfaceDef;
+import io.micronaut.sourcegen.model.MethodDef;
+import io.micronaut.sourcegen.model.ObjectDef;
+import io.micronaut.sourcegen.model.StatementDef;
+import io.micronaut.sourcegen.model.TypeDef;
+import io.micronaut.sourcegen.model.VariableDef;
+import org.junit.jupiter.api.Test;
+
+import javax.lang.model.element.Modifier;
+import java.io.IOException;
+import java.io.StringWriter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests a lambda whose body is a block rather than a single expression. Such a body renders its own
+ * statements, and JavaPoet rejects nesting its statement markers, so the enclosing statement must not
+ * be wrapped again.
+ */
+public class LambdaBlockBodyWriteTest extends AbstractWriteTest {
+
+    private static InterfaceDef stringFunction() {
+        return InterfaceDef.builder("test.StringFunction")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("apply")
+                .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                .addParameter("context", TypeDef.STRING)
+                .returns(TypeDef.STRING)
+                .build())
+            .build();
+    }
+
+    private static ExpressionDef.Lambda blockBodyLambda(ClassTypeDef lambdaType) {
+        VariableDef.Local tmp = new VariableDef.Local("tmp", TypeDef.STRING);
+        return lambdaType.getLambda().implement((aThis, params) -> StatementDef.multi(
+            tmp.defineAndAssign(params.get(0).invoke("trim", TypeDef.STRING)),
+            tmp.returning()
+        ));
+    }
+
+    private static String writeObject(ObjectDef objectDef) throws IOException {
+        try (StringWriter writer = new StringWriter()) {
+            new JavaPoetSourceGenerator().write(objectDef, writer);
+            return writer.toString();
+        }
+    }
+
+    @Test
+    public void blockBodyLambdaInAReturn() throws IOException {
+        InterfaceDef functionDef = stringFunction();
+        ClassTypeDef lambdaType = functionDef.asTypeDef();
+
+        ClassDef classDef = ClassDef.builder("test.MyClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("evaluate")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(lambdaType)
+                .build((aThis, methodParameters) -> blockBodyLambda(lambdaType).returning())
+            )
+            .build();
+
+        String data = writeClass(classDef);
+
+        assertEquals("""
+package test;
+
+import java.lang.String;
+
+public class MyClass {
+  public StringFunction evaluate() {
+    return (context) -> {
+      String tmp = context.trim();
+      return tmp;
+    };
+  }
+}
+            """, data);
+
+        JavaCompileAssertions.assertCompiles(writeObject(functionDef), data);
+    }
+
+    @Test
+    public void blockBodyLambdaInALocalVariable() throws IOException {
+        InterfaceDef functionDef = stringFunction();
+        ClassTypeDef lambdaType = functionDef.asTypeDef();
+        VariableDef.Local function = new VariableDef.Local("function", lambdaType);
+
+        ClassDef classDef = ClassDef.builder("test.MyClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("evaluate")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(TypeDef.STRING)
+                .build((aThis, methodParameters) -> StatementDef.multi(
+                    function.defineAndAssign(blockBodyLambda(lambdaType)),
+                    function.invoke("apply", TypeDef.STRING, ExpressionDef.constant(" a ")).returning()
+                ))
+            )
+            .build();
+
+        String data = writeClass(classDef);
+
+        assertEquals("""
+package test;
+
+import java.lang.String;
+
+public class MyClass {
+  public String evaluate() {
+    StringFunction function = (context) -> {
+      String tmp = context.trim();
+      return tmp;
+    };
+    return function.apply(" a ");
+  }
+}
+            """, data);
+
+        JavaCompileAssertions.assertCompiles(writeObject(functionDef), data);
+    }
+
+    @Test
+    public void blockBodyLambdaAsAMethodArgument() throws IOException {
+        InterfaceDef functionDef = stringFunction();
+        ClassTypeDef lambdaType = functionDef.asTypeDef();
+
+        MethodDef callDef = MethodDef.builder("call")
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter("function", lambdaType)
+            .returns(TypeDef.STRING)
+            .build((aThis, methodParameters) -> methodParameters.get(0)
+                .invoke("apply", TypeDef.STRING, ExpressionDef.constant(" a "))
+                .returning());
+
+        ClassDef classDef = ClassDef.builder("test.MyClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(callDef)
+            .addMethod(MethodDef.builder("evaluate")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(TypeDef.STRING)
+                .build((aThis, methodParameters) -> aThis
+                    .invoke(callDef, blockBodyLambda(lambdaType))
+                    .returning())
+            )
+            .build();
+
+        String data = writeClass(classDef);
+
+        assertEquals("""
+package test;
+
+import java.lang.String;
+
+public class MyClass {
+  public String call(StringFunction function) {
+    return function.apply(" a ");
+  }
+
+  public String evaluate() {
+    return this.call((context) -> {
+      String tmp = context.trim();
+      return tmp;
+    });
+  }
+}
+            """, data);
+
+        JavaCompileAssertions.assertCompiles(writeObject(functionDef), data);
+    }
+
+    @Test
+    public void nestedBlockBodyLambdas() throws IOException {
+        InterfaceDef functionDef = stringFunction();
+        ClassTypeDef lambdaType = functionDef.asTypeDef();
+        VariableDef.Local inner = new VariableDef.Local("inner", lambdaType);
+
+        ExpressionDef.Lambda outer = lambdaType.getLambda().implement((aThis, params) -> StatementDef.multi(
+            inner.defineAndAssign(blockBodyLambda(lambdaType)),
+            inner.invoke("apply", TypeDef.STRING, ExpressionDef.constant("a")).returning()
+        ));
+
+        ClassDef classDef = ClassDef.builder("test.MyClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("evaluate")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(lambdaType)
+                .build((aThis, methodParameters) -> outer.returning())
+            )
+            .build();
+
+        String data = writeClass(classDef);
+
+        assertEquals("""
+package test;
+
+import java.lang.String;
+
+public class MyClass {
+  public StringFunction evaluate() {
+    return (context) -> {
+      StringFunction inner = (context) -> {
+        String tmp = context.trim();
+        return tmp;
+      };
+      return inner.apply("a");
+    };
+  }
+}
+            """, data);
+        // Not compiled: both lambdas declare `context`, which Java rejects. That is a separate defect -
+        // the writer emits the interface's parameter name for every lambda over the same interface.
+    }
+
+}


### PR DESCRIPTION
## Problem

A lambda whose body has more than one statement cannot be rendered at all — not in a `return`, not in a local variable, not as a method argument:

```
java.lang.IllegalStateException: statement enter $[ followed by statement enter $[
  at io.micronaut.sourcegen.javapoet.Util.checkState(Util.java:62)
  at io.micronaut.sourcegen.javapoet.CodeWriter.emit(CodeWriter.java:279)
  at io.micronaut.sourcegen.JavaPoetSourceGenerator.writeClass(JavaPoetSourceGenerator.java:257)
```

Reproduces on `2.2.x` with any block-bodied lambda, e.g.

```java
ExpressionDef.Lambda lambda = lambdaType.getLambda().implement((aThis, params) -> StatementDef.multi(
    tmp.defineAndAssign(params.get(0).invoke("trim", TypeDef.STRING)),
    tmp.returning()
));
```

Found while writing tests for #467; unrelated to it.

## Root cause

Two layers of statement wrapping.

`case Lambda lambda` rendered a block body with `builder.addStatement(renderStatementCodeBlock(...))`. But `renderStatementCodeBlock` *already* returns a complete statement — its default branch ends in `CodeBlock.builder().addStatement(statement)` — so the `$[`/`$]` markers were applied twice. On top of that, the resulting lambda block was embedded in the enclosing statement (`return <lambda>;`), which `addStatement`-wraps it a third time.

## Fix

`renderStatementCodeBlock` already has a mechanism for exactly this: a statement containing a switch expression is emitted with an explicit `;\n` instead of `addStatement`, because a switch expression renders statements of its own. A lambda with a block body has the same shape, so `containsBlockBodyLambda` joins `containsSwitchExpression` on that path, and the block body now `add`s its already-complete statements instead of wrapping them again.

The markers only control the indentation of continuation lines, so nothing else about the output changes. Unlike flattening the block to a string — the approach `ExpressionDef.SwitchYieldCase` takes with `CodeBlock.ofWithoutFormat` — this keeps `$T` references resolving against the file's imports, so a block body emits `String tmp` rather than `java.lang.String tmp`.

`GroovyPoetSourceGenerator` extends `JavaPoetSourceGenerator` and overrides only `getLanguage()`, so this covers Groovy too.

## Tests

New `LambdaBlockBodyWriteTest` — a block-bodied lambda in a `return`, in a local variable, and as a method argument, each asserted and **compiled** in memory; plus nested block bodies.

```java
public StringFunction evaluate() {
  return (context) -> {
    String tmp = context.trim();
    return tmp;
  };
}
```

All four fail on `2.2.x` with the exception above.

The tests add `JavaCompileAssertions`, an in-memory `javax.tools.JavaCompiler` helper. #465 and #468 add the same file with identical content, so they merge cleanly in any order.

## Note for reviewers

The nested case is deliberately not compiled: both lambdas declare `context`, which Java rejects. That is the separate defect #468 fixes — the writer emits the interface's parameter name for every lambda over the same interface. #468 also rewrites this same `case Lambda` block, so whichever merges second needs a small conflict resolution there; the two changes are independent and compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review pass

A self-review found a blind spot (second commit): `Lambda.nestedExpressionsStream()` is empty, so a block-body lambda nested inside a **single-expression** lambda — `return (a) -> (b) -> { ... };` — was not detected and the writer still crashed. `containsBlockBodyLambda` now descends into a lambda's body explicitly. Covered by `blockBodyLambdaInsideASingleExpressionLambda`.


Fixes #474.
