### PR TITLE
Resolve the invoked signature instead of inferring it from the arguments

### DIFF
--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
@@ -1972,7 +1972,8 @@ public class example/Example {
     ALOAD 2
     INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/Object;)Ljava/lang/StringBuilder;
     ALOAD 3
-    INVOKESTATIC java/util/Arrays.toString ([Ljava/lang/String;)Ljava/lang/String;
+    CHECKCAST [Ljava/lang/Object;
+    INVOKESTATIC java/util/Arrays.toString ([Ljava/lang/Object;)Ljava/lang/String;
     INVOKEVIRTUAL java/lang/StringBuilder.append (Ljava/lang/String;)Ljava/lang/StringBuilder;
     INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
     ARETURN
@@ -1990,7 +1991,7 @@ import java.util.Arrays;
 
 public class Example {
    String myMethod(String arg1, Object arg2, String[] arg3) {
-      return arg1 + arg2 + Arrays.toString(arg3);
+      return arg1 + arg2 + Arrays.toString((Object[])arg3);
    }
 }
 """, decompileToJava(bytes));

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
@@ -297,7 +297,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                                                         VariableDef.MethodParameter parameter) {
         return propertyField.put(
             ClassTypeDef.of(ArrayList.class).instantiate(
-                parameter.invoke("entrySet", ClassTypeDef.of(Map.Entry.class))
+                parameter.invoke("entrySet", ClassTypeDef.of(Set.class))
             )
         );
     }

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassTypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassTypeDef.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * The class type definition.
@@ -142,6 +143,42 @@ public sealed interface ClassTypeDef extends TypeDef {
     }
 
     /**
+     * Find the methods this type declares that a call with the given name and number of arguments could
+     * target, variable arity included.
+     *
+     * <p>Used by the convenience overloads that would otherwise build the invoked signature from the
+     * static types of the arguments, which names a method that does not exist whenever an argument is
+     * statically narrower than the declared parameter.
+     *
+     * <p>Bridge methods are included, because their descriptors are real: a covariant override such as
+     * {@code ReentrantReadWriteLock.readLock()} leaves a bridge returning the supertype, and a call
+     * declaring that return type does resolve.
+     *
+     * <p>Only implementations that carry member information return anything - {@link #of(Class)},
+     * {@link #of(ClassElement)} and a definition being generated. {@link #of(String)} has nothing to
+     * resolve against and returns an empty list, which leaves the signature inferred as before.
+     *
+     * @param name          The method name, or {@link MethodDef#CONSTRUCTOR}
+     * @param argumentCount The number of arguments at the call site
+     * @return The candidate methods, or an empty list when they cannot be resolved
+     * @since 2.2
+     */
+    default List<MethodDef> findDeclaredMethods(String name, int argumentCount) {
+        return List.of();
+    }
+
+    /**
+     * @param parameterCount The number of declared parameters
+     * @param varArgs        True if the declaration has variable arity
+     * @param argumentCount  The number of arguments at the call site
+     * @return True if a call with that many arguments can target the declaration
+     * @since 2.2
+     */
+    private static boolean matchesArity(int parameterCount, boolean varArgs, int argumentCount) {
+        return varArgs ? argumentCount >= parameterCount - 1 : argumentCount == parameterCount;
+    }
+
+    /**
      * Find the method that can be represented as a lambda.
      *
      * @param resolvedTypeVariables The resolved type variables
@@ -187,11 +224,20 @@ public sealed interface ClassTypeDef extends TypeDef {
     /**
      * The new instance expression.
      *
+     * <p>The constructor is resolved with {@link #findDeclaredMethods(String, int)} when this type carries
+     * member information. When it does not, the signature is inferred from the static types of the
+     * values, which names a constructor that does not exist if any of them is narrower than the declared
+     * parameter - use {@link #instantiate(List, List)} or {@link #instantiate(Constructor, List)} then.
+     *
      * @param values The constructor values
      * @return The new instance
      */
     @Experimental
     default ExpressionDef.NewInstance instantiate(List<? extends ExpressionDef> values) {
+        Invocations.Resolved resolved = Invocations.resolve(this, MethodDef.CONSTRUCTOR, null, values);
+        if (resolved != null) {
+            return instantiate(resolved.parameterTypes(), resolved.values());
+        }
         return instantiate(values.stream().map(ExpressionDef::type).toList(), values);
     }
 
@@ -293,6 +339,12 @@ public sealed interface ClassTypeDef extends TypeDef {
     /**
      * Invoke static method.
      *
+     * <p>The method is resolved with {@link #findDeclaredMethods(String, int)} when this type carries member
+     * information. When it does not, the signature is inferred from the static types of the values, which
+     * names a method that does not exist if any of them is narrower than the declared parameter - use
+     * {@link #invokeStatic(String, List, TypeDef, List)}, {@link #invokeStatic(Method, List)} or
+     * {@link #invokeStatic(MethodElement, List)} then.
+     *
      * @param name          The method name
      * @param returningType The return type
      * @param values        The values
@@ -302,6 +354,10 @@ public sealed interface ClassTypeDef extends TypeDef {
     default ExpressionDef.InvokeStaticMethod invokeStatic(String name,
                                                           TypeDef returningType,
                                                           List<? extends ExpressionDef> values) {
+        Invocations.Resolved resolved = Invocations.resolve(this, name, returningType, values);
+        if (resolved != null) {
+            return invokeStatic(name, resolved.parameterTypes(), returningType, resolved.values());
+        }
         return invokeStatic(name, values.stream().map(ExpressionDef::type).toList(), returningType, values);
     }
 
@@ -664,6 +720,22 @@ public sealed interface ClassTypeDef extends TypeDef {
                 }
             }
             return TypeDef.of(erasure);
+        public List<MethodDef> findDeclaredMethods(String name, int argumentCount) {
+            if (MethodDef.CONSTRUCTOR.equals(name)) {
+                return Arrays.stream(type.getDeclaredConstructors())
+                    .filter(c -> !c.isSynthetic())
+                    .filter(c -> matchesArity(c.getParameterCount(), c.isVarArgs(), argumentCount))
+                    .<MethodDef>map(c -> MethodDef.builder(c).build())
+                    .toList();
+            }
+            // getMethods() covers the inherited public methods, getDeclaredMethods() the non-public ones
+            return Stream.concat(Arrays.stream(type.getMethods()), Arrays.stream(type.getDeclaredMethods()))
+                .distinct()
+                // A bridge method is synthetic but its descriptor is real, so a call declaring it resolves
+                .filter(m -> m.getName().equals(name) && (!m.isSynthetic() || m.isBridge()))
+                .filter(m -> matchesArity(m.getParameterCount(), m.isVarArgs(), argumentCount))
+                .map(MethodDef::of)
+                .toList();
         }
 
         @Override
@@ -787,6 +859,20 @@ public sealed interface ClassTypeDef extends TypeDef {
     record ClassElementType(ClassElement classElement, boolean nullable) implements ClassTypeDef {
 
         @Override
+        public List<MethodDef> findDeclaredMethods(String name, int argumentCount) {
+            List<MethodElement> methods;
+            if (MethodDef.CONSTRUCTOR.equals(name)) {
+                methods = List.copyOf(classElement.getEnclosedElements(ElementQuery.CONSTRUCTORS));
+            } else {
+                methods = classElement.getEnclosedElements(ElementQuery.ALL_METHODS.named(name));
+            }
+            return methods.stream()
+                .filter(m -> matchesArity(m.getParameters().length, m.isVarArgs(), argumentCount))
+                .map(MethodDef::of)
+                .toList();
+        }
+
+        @Override
         public LambdaDef getLambda(Function<String, @Nullable TypeDef> resolveVariableFn) {
             List<MethodElement> abstractMethods = classElement.getEnclosedElements(
                 ElementQuery.of(MethodElement.class).onlyAbstract());
@@ -864,6 +950,15 @@ public sealed interface ClassTypeDef extends TypeDef {
      */
     @Experimental
     record ClassDefType(ObjectDef objectDef, boolean nullable) implements ClassTypeDef {
+
+        @Override
+        public List<MethodDef> findDeclaredMethods(String name, int argumentCount) {
+            return objectDef.getMethods()
+                .stream()
+                .filter(m -> m.getName().equals(name))
+                .filter(m -> matchesArity(m.getParameters().size(), false, argumentCount))
+                .toList();
+        }
 
         @Override
         public LambdaDef getLambda(Function<String, @Nullable TypeDef> resolveVariableFn) {
@@ -946,6 +1041,11 @@ public sealed interface ClassTypeDef extends TypeDef {
                 lambda.getMethod(),
                 lambda.getImplementation()
             );
+        }
+
+        @Override
+        public List<MethodDef> findDeclaredMethods(String name, int argumentCount) {
+            return rawType.findDeclaredMethods(name, argumentCount);
         }
 
         @Override

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassTypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassTypeDef.java
@@ -720,6 +720,9 @@ public sealed interface ClassTypeDef extends TypeDef {
                 }
             }
             return TypeDef.of(erasure);
+        }
+
+        @Override
         public List<MethodDef> findDeclaredMethods(String name, int argumentCount) {
             if (MethodDef.CONSTRUCTOR.equals(name)) {
                 return Arrays.stream(type.getDeclaredConstructors())

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ExpressionDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ExpressionDef.java
@@ -714,7 +714,7 @@ public sealed interface ExpressionDef
     /**
      * The call the instance method expression.
      *
-     * <p>The method is resolved with {@link ClassTypeDef#findDeclaredMethod(String, int)} when the type of
+     * <p>The method is resolved with {@link ClassTypeDef#findDeclaredMethods(String, int)} when the type of
      * this expression carries member information. When it does not, the signature is inferred from the
      * static types of the values, which names a method that does not exist if any of them is narrower than
      * the declared parameter - use {@link #invoke(String, List, TypeDef, List)},

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ExpressionDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ExpressionDef.java
@@ -546,6 +546,11 @@ public sealed interface ExpressionDef
      */
     @Deprecated(since = "2.0", forRemoval = true)
     default InvokeInstanceMethod invokeConstructor(List<? extends ExpressionDef> values) {
+        ClassTypeDef owner = type() instanceof ClassTypeDef classTypeDef ? classTypeDef : null;
+        Invocations.Resolved resolved = Invocations.resolve(owner, MethodDef.CONSTRUCTOR, null, values);
+        if (resolved != null) {
+            return invokeConstructor(resolved.parameterTypes(), resolved.values());
+        }
         return invokeConstructor(values.stream().map(ExpressionDef::type).toList(), values);
     }
 
@@ -709,6 +714,12 @@ public sealed interface ExpressionDef
     /**
      * The call the instance method expression.
      *
+     * <p>The method is resolved with {@link ClassTypeDef#findDeclaredMethod(String, int)} when the type of
+     * this expression carries member information. When it does not, the signature is inferred from the
+     * static types of the values, which names a method that does not exist if any of them is narrower than
+     * the declared parameter - use {@link #invoke(String, List, TypeDef, List)},
+     * {@link #invoke(Method, List)} or {@link #invoke(MethodElement, List)} then.
+     *
      * @param name      The method name
      * @param returning The returning
      * @param values    The values
@@ -716,6 +727,11 @@ public sealed interface ExpressionDef
      * @since 1.2
      */
     default InvokeInstanceMethod invoke(String name, TypeDef returning, List<? extends ExpressionDef> values) {
+        ClassTypeDef owner = type() instanceof ClassTypeDef classTypeDef ? classTypeDef : null;
+        Invocations.Resolved resolved = Invocations.resolve(owner, name, returning, values);
+        if (resolved != null) {
+            return invoke(name, resolved.parameterTypes(), returning, resolved.values());
+        }
         return invoke(
             name,
             values.stream().map(ExpressionDef::type).toList(),

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/Invocations.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/Invocations.java
@@ -106,21 +106,19 @@ final class Invocations {
         // With variable arity only the fixed prefix can be checked; the tail is packed into the array later
         int fixed = parameters.size() == values.size() ? parameters.size() : parameters.size() - 1;
         for (int i = 0; i < fixed && i < values.size(); i++) {
-            TypeDef parameter = parameters.get(i).getType();
-            TypeDef argument = values.get(i).type();
-            if (maybeAssignable(parameter, argument)) {
-                continue;
-            }
             // The model does not record variable arity, so the last argument of an exact-count call to an
             // array parameter may also be a single element of it
             boolean lastOfExactCount = i == parameters.size() - 1 && parameters.size() == values.size();
-            if (lastOfExactCount && erase(parameter) instanceof TypeDef.Array array
-                && maybeAssignable(array.componentType(), argument)) {
-                continue;
+            if (!canAccept(parameters.get(i).getType(), values.get(i).type(), lastOfExactCount)) {
+                return false;
             }
-            return false;
         }
         return true;
+    }
+
+    private static boolean canAccept(TypeDef parameter, TypeDef argument, boolean orElement) {
+        return maybeAssignable(parameter, argument)
+            || orElement && erase(parameter) instanceof TypeDef.Array array && maybeAssignable(array.componentType(), argument);
     }
 
     private static boolean maybeAssignable(TypeDef parameterType, TypeDef argumentType) {
@@ -207,7 +205,6 @@ final class Invocations {
     private static Class<?> rawClass(TypeDef typeDef) {
         return switch (erase(typeDef)) {
             case ClassTypeDef.JavaClass javaClass -> javaClass.type();
-            case TypeDef.Primitive primitive -> primitive.clazz();
             default -> null;
         };
     }
@@ -275,9 +272,6 @@ final class Invocations {
         int fixed = parameterTypes.size() - 1;
         if (values.size() == parameterTypes.size() && values.getLast().type() instanceof TypeDef.Array) {
             // The caller already passed the array
-            return values;
-        }
-        if (values.size() < fixed) {
             return values;
         }
         List<ExpressionDef> adapted = new ArrayList<>(parameterTypes.size());

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/Invocations.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/Invocations.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.model;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.List;
+
+/**
+ * Support for building an invocation from the signature the target actually declares, instead of from
+ * the static types of the arguments.
+ *
+ * <p>A descriptor built from the argument types names a method that does not exist whenever an argument
+ * is statically narrower than the declared parameter. The Java writer hides this, because javac resolves
+ * the overload from the rendered call; the bytecode writer emits the descriptor verbatim and the mismatch
+ * surfaces at run time as a {@link NoSuchMethodError}.
+ *
+ * @author Denis Stepanov
+ * @since 2.2
+ */
+final class Invocations {
+
+    private static final Map<Class<?>, Class<?>> WRAPPERS = Map.of(
+        boolean.class, Boolean.class,
+        byte.class, Byte.class,
+        char.class, Character.class,
+        short.class, Short.class,
+        int.class, Integer.class,
+        long.class, Long.class,
+        float.class, Float.class,
+        double.class, Double.class
+    );
+
+    private Invocations() {
+    }
+
+    /**
+     * Resolves the method a call resolves to and adapts the arguments to it.
+     *
+     * @param owner         The type declaring the method, if it is known
+     * @param name          The method name, or {@link MethodDef#CONSTRUCTOR}
+     * @param returningType The return type the caller expects, or {@code null} for a constructor
+     * @param values        The argument expressions
+     * @return The resolved call, or {@code null} when the declaration cannot be resolved
+     */
+    @Nullable
+    static Resolved resolve(@Nullable ClassTypeDef owner,
+                            String name,
+                            @Nullable TypeDef returningType,
+                            List<? extends ExpressionDef> values) {
+        if (owner == null) {
+            return null;
+        }
+        List<MethodDef> candidates = owner.findDeclaredMethods(name, values.size());
+        if (candidates.isEmpty()) {
+            return null;
+        }
+        if (returningType == null) {
+            List<MethodDef> possible = narrowByArguments(candidates, values);
+            return possible.size() == 1 ? resolved(possible.get(0), values) : null;
+        }
+        List<MethodDef> matching = narrowByArguments(candidates.stream()
+            .filter(m -> sameErasure(m.getReturnType(), returningType))
+            .toList(), values);
+        // A requested return type that matches none of the declarations is left alone: it is legal for the
+        // Java writer, which lets javac resolve the call, and the bytecode writer reports it instead
+        return matching.size() == 1 ? resolved(matching.get(0), values) : null;
+    }
+
+    /**
+     * Packs the trailing arguments of a variable arity call into an array, so that the number of arguments
+     * matches the declared parameters.
+     *
+     * @param parameterTypes The declared parameter types
+     * @param values         The argument expressions
+     * @return The adapted arguments
+     */
+    /**
+     * Drops the candidates an argument provably cannot be passed to, so that overloads of the same arity -
+     * {@code ArrayList(int)} against {@code ArrayList(Collection)} - can still be told apart. A candidate is
+     * kept whenever compatibility cannot be decided from the model alone.
+     *
+     * @param candidates The candidates
+     * @param values     The argument expressions
+     * @return The candidates that are not provably incompatible
+     */
+    private static List<MethodDef> narrowByArguments(List<MethodDef> candidates,
+                                                     List<? extends ExpressionDef> values) {
+        if (candidates.size() < 2) {
+            return candidates;
+        }
+        List<MethodDef> possible = candidates.stream()
+            .filter(m -> canAccept(m.getParameters(), values))
+            .toList();
+        return possible.isEmpty() ? candidates : possible;
+    }
+
+    private static boolean canAccept(List<ParameterDef> parameters, List<? extends ExpressionDef> values) {
+        // With variable arity only the fixed prefix can be checked; the tail is packed into the array later
+        int fixed = parameters.size() == values.size() ? parameters.size() : parameters.size() - 1;
+        for (int i = 0; i < fixed && i < values.size(); i++) {
+            if (!maybeAssignable(parameters.get(i).getType(), values.get(i).type())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean maybeAssignable(TypeDef parameterType, TypeDef argumentType) {
+        if (sameErasure(parameterType, argumentType)) {
+            return true;
+        }
+        TypeDef parameter = erase(parameterType);
+        TypeDef argument = erase(argumentType);
+        if (parameter instanceof TypeDef.Primitive != argument instanceof TypeDef.Primitive) {
+            // Only boxing crosses the divide between a primitive and a reference type
+            return boxes(parameter, argument);
+        }
+        Class<?> parameterClass = rawClass(parameter);
+        Class<?> argumentClass = rawClass(argument);
+        if (parameterClass == null || argumentClass == null) {
+            // Not resolvable from the model - assume it could match
+            return true;
+        }
+        return parameterClass.isAssignableFrom(argumentClass);
+    }
+
+    private static boolean boxes(TypeDef left, TypeDef right) {
+        TypeDef.Primitive primitive = left instanceof TypeDef.Primitive p ? p : (TypeDef.Primitive) right;
+        TypeDef reference = left instanceof TypeDef.Primitive ? right : left;
+        if (!(reference instanceof ClassTypeDef classTypeDef)) {
+            return false;
+        }
+        Class<?> wrapper = WRAPPERS.get(primitive.clazz());
+        if (wrapper == null) {
+            return false;
+        }
+        // A boxed primitive widens to its wrapper's supertypes, up to Object
+        return isSuperTypeName(wrapper, classTypeDef.getName());
+    }
+
+    private static boolean isSuperTypeName(Class<?> wrapper, String name) {
+        for (Class<?> c = wrapper; c != null; c = c.getSuperclass()) {
+            if (c.getName().equals(name)) {
+                return true;
+            }
+            for (Class<?> i : c.getInterfaces()) {
+                if (i.getName().equals(name)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Nullable
+    private static Class<?> rawClass(TypeDef typeDef) {
+        return switch (erase(typeDef)) {
+            case ClassTypeDef.JavaClass javaClass -> javaClass.type();
+            case TypeDef.Primitive primitive -> primitive.clazz();
+            default -> null;
+        };
+    }
+
+    /**
+     * Erases a type the way a descriptor does: a parameterized type to its raw type, a type variable to its
+     * first bound, and an annotated type to the type it annotates.
+     *
+     * @param typeDef The type
+     * @return The erasure
+     */
+    private static TypeDef erase(TypeDef typeDef) {
+        return switch (typeDef) {
+            case ClassTypeDef.Parameterized parameterized -> erase(parameterized.rawType());
+            case ClassTypeDef.AnnotatedClassTypeDef annotated -> erase(annotated.typeDef());
+            case TypeDef.AnnotatedTypeDef annotated -> erase(annotated.typeDef());
+            case TypeDef.TypeVariable variable -> variable.bounds().isEmpty()
+                ? ClassTypeDef.OBJECT
+                : erase(variable.bounds().get(0));
+            default -> typeDef;
+        };
+    }
+
+    /**
+     * Compares two types the way a descriptor does: by erasure, ignoring nullability.
+     *
+     * @param left  The left type
+     * @param right The right type
+     * @return True if the two erase to the same descriptor
+     */
+    private static boolean sameErasure(TypeDef left, TypeDef right) {
+        return descriptorName(left).equals(descriptorName(right));
+    }
+
+    private static String descriptorName(TypeDef typeDef) {
+        return switch (erase(typeDef)) {
+            case TypeDef.Array array -> descriptorName(array.componentType()) + "[]".repeat(array.dimensions());
+            case TypeDef.Primitive primitive -> primitive.name();
+            case ClassTypeDef classTypeDef -> classTypeDef.getName();
+            case TypeDef other -> other.toString();
+        };
+    }
+
+    private static Resolved resolved(MethodDef method, List<? extends ExpressionDef> values) {
+        List<TypeDef> parameterTypes = method.getParameters().stream().map(ParameterDef::getType).toList();
+        return new Resolved(parameterTypes, adaptToVarArgs(parameterTypes, values));
+    }
+
+    private static List<? extends ExpressionDef> adaptToVarArgs(List<TypeDef> parameterTypes,
+                                                                List<? extends ExpressionDef> values) {
+        if (parameterTypes.isEmpty()) {
+            return values;
+        }
+        if (!(parameterTypes.getLast() instanceof TypeDef.Array array)) {
+            return values;
+        }
+        int fixed = parameterTypes.size() - 1;
+        if (values.size() == parameterTypes.size() && values.getLast().type() instanceof TypeDef.Array) {
+            // The caller already passed the array
+            return values;
+        }
+        if (values.size() < fixed) {
+            return values;
+        }
+        List<ExpressionDef> adapted = new ArrayList<>(parameterTypes.size());
+        adapted.addAll(values.subList(0, fixed));
+        adapted.add(new ExpressionDef.NewArrayInitialized(array, List.copyOf(values.subList(fixed, values.size()))));
+        return adapted;
+    }
+
+    /**
+     * A call resolved against the declaration of its target.
+     *
+     * @param parameterTypes The declared parameter types
+     * @param values         The arguments, with a variable arity tail packed into an array
+     */
+    record Resolved(List<TypeDef> parameterTypes, List<? extends ExpressionDef> values) {
+    }
+
+}

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/Invocations.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/Invocations.java
@@ -83,14 +83,6 @@ final class Invocations {
     }
 
     /**
-     * Packs the trailing arguments of a variable arity call into an array, so that the number of arguments
-     * matches the declared parameters.
-     *
-     * @param parameterTypes The declared parameter types
-     * @param values         The argument expressions
-     * @return The adapted arguments
-     */
-    /**
      * Drops the candidates an argument provably cannot be passed to, so that overloads of the same arity -
      * {@code ArrayList(int)} against {@code ArrayList(Collection)} - can still be told apart. A candidate is
      * kept whenever compatibility cannot be decided from the model alone.
@@ -114,9 +106,19 @@ final class Invocations {
         // With variable arity only the fixed prefix can be checked; the tail is packed into the array later
         int fixed = parameters.size() == values.size() ? parameters.size() : parameters.size() - 1;
         for (int i = 0; i < fixed && i < values.size(); i++) {
-            if (!maybeAssignable(parameters.get(i).getType(), values.get(i).type())) {
-                return false;
+            TypeDef parameter = parameters.get(i).getType();
+            TypeDef argument = values.get(i).type();
+            if (maybeAssignable(parameter, argument)) {
+                continue;
             }
+            // The model does not record variable arity, so the last argument of an exact-count call to an
+            // array parameter may also be a single element of it
+            boolean lastOfExactCount = i == parameters.size() - 1 && parameters.size() == values.size();
+            if (lastOfExactCount && erase(parameter) instanceof TypeDef.Array array
+                && maybeAssignable(array.componentType(), argument)) {
+                continue;
+            }
+            return false;
         }
         return true;
     }
@@ -127,45 +129,78 @@ final class Invocations {
         }
         TypeDef parameter = erase(parameterType);
         TypeDef argument = erase(argumentType);
-        if (parameter instanceof TypeDef.Primitive != argument instanceof TypeDef.Primitive) {
-            // Only boxing crosses the divide between a primitive and a reference type
-            return boxes(parameter, argument);
+        if (parameter instanceof TypeDef.Primitive primitive) {
+            // Only the exact wrapper unboxes to a primitive; a wider reference type does not
+            return argument instanceof ClassTypeDef classTypeDef
+                && isWrapperOf(primitive, classTypeDef.getName());
         }
-        Class<?> parameterClass = rawClass(parameter);
+        if (argument instanceof TypeDef.Primitive primitive) {
+            // A primitive boxes, and the box widens to any supertype of the wrapper
+            Class<?> wrapper = WRAPPERS.get(primitive.clazz());
+            return wrapper != null && parameter instanceof ClassTypeDef classTypeDef
+                && isSuperTypeName(wrapper, classTypeDef.getName());
+        }
+        if (argument instanceof TypeDef.Array argumentArray) {
+            if (parameter instanceof TypeDef.Array parameterArray) {
+                return parameterArray.dimensions() == argumentArray.dimensions()
+                    && maybeAssignable(parameterArray.componentType(), argumentArray.componentType());
+            }
+            return parameter instanceof ClassTypeDef classTypeDef && isArraySuperTypeName(classTypeDef.getName());
+        }
+        if (parameter instanceof TypeDef.Array) {
+            return false;
+        }
+        if (parameter instanceof ClassTypeDef parameterClass && argument instanceof ClassTypeDef argumentClass) {
+            return maybeAssignable(parameterClass, argumentClass);
+        }
+        // Not resolvable from the model - assume it could match
+        return true;
+    }
+
+    private static boolean maybeAssignable(ClassTypeDef parameter, ClassTypeDef argument) {
+        if (argument instanceof ClassTypeDef.ClassElementType argumentElement) {
+            Class<?> parameterClass = rawClass(parameter);
+            return parameterClass != null
+                ? argumentElement.classElement().isAssignable(parameterClass)
+                : argumentElement.classElement().isAssignable(parameter.getName());
+        }
         Class<?> argumentClass = rawClass(argument);
-        if (parameterClass == null || argumentClass == null) {
-            // Not resolvable from the model - assume it could match
+        if (argumentClass == null) {
             return true;
         }
-        return parameterClass.isAssignableFrom(argumentClass);
+        Class<?> parameterClass = rawClass(parameter);
+        if (parameterClass != null) {
+            return parameterClass.isAssignableFrom(argumentClass);
+        }
+        return isSuperTypeName(argumentClass, parameter.getName());
     }
 
-    private static boolean boxes(TypeDef left, TypeDef right) {
-        TypeDef.Primitive primitive = left instanceof TypeDef.Primitive p ? p : (TypeDef.Primitive) right;
-        TypeDef reference = left instanceof TypeDef.Primitive ? right : left;
-        if (!(reference instanceof ClassTypeDef classTypeDef)) {
-            return false;
-        }
+    private static boolean isWrapperOf(TypeDef.Primitive primitive, String name) {
         Class<?> wrapper = WRAPPERS.get(primitive.clazz());
-        if (wrapper == null) {
-            return false;
-        }
-        // A boxed primitive widens to its wrapper's supertypes, up to Object
-        return isSuperTypeName(wrapper, classTypeDef.getName());
+        return wrapper != null && wrapper.getName().equals(name);
     }
 
-    private static boolean isSuperTypeName(Class<?> wrapper, String name) {
-        for (Class<?> c = wrapper; c != null; c = c.getSuperclass()) {
-            if (c.getName().equals(name)) {
+    private static boolean isArraySuperTypeName(String name) {
+        return name.equals(Object.class.getName())
+            || name.equals(Cloneable.class.getName())
+            || name.equals(java.io.Serializable.class.getName());
+    }
+
+    /**
+     * @param type The type
+     * @param name The binary name of a candidate supertype
+     * @return True if the type is, extends or implements the named type
+     */
+    private static boolean isSuperTypeName(Class<?> type, String name) {
+        if (type.getName().equals(name)) {
+            return true;
+        }
+        for (Class<?> i : type.getInterfaces()) {
+            if (isSuperTypeName(i, name)) {
                 return true;
             }
-            for (Class<?> i : c.getInterfaces()) {
-                if (i.getName().equals(name)) {
-                    return true;
-                }
-            }
         }
-        return false;
+        return type.getSuperclass() != null && isSuperTypeName(type.getSuperclass(), name);
     }
 
     @Nullable
@@ -221,6 +256,14 @@ final class Invocations {
         return new Resolved(parameterTypes, adaptToVarArgs(parameterTypes, values));
     }
 
+    /**
+     * Packs the trailing arguments of a variable arity call into an array, so that the number of arguments
+     * matches the declared parameters.
+     *
+     * @param parameterTypes The declared parameter types
+     * @param values         The argument expressions
+     * @return The adapted arguments
+     */
     private static List<? extends ExpressionDef> adaptToVarArgs(List<TypeDef> parameterTypes,
                                                                 List<? extends ExpressionDef> values) {
         if (parameterTypes.isEmpty()) {

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/VariableDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/VariableDef.java
@@ -206,11 +206,22 @@ public sealed interface VariableDef extends ExpressionDef permits VariableDef.Ex
         /**
          * Invoke super constructor statement.
          *
+         * <p>The constructor is resolved with {@link ClassTypeDef#findDeclaredMethod(String, int)} when the
+         * super type carries member information. When it does not, the signature is inferred from the static
+         * types of the values, which names a constructor that does not exist if any of them is narrower than
+         * the declared parameter - use {@link #invokeSuperConstructor(List, List)} or
+         * {@link #invokeSuperConstructor(Constructor, List)} then.
+         *
          * @param values The values
          * @return The call to the instance method
          * @since 1.5
          */
         public StatementDef.InvokeSuperConstructor invokeSuperConstructor(List<? extends ExpressionDef> values) {
+            ClassTypeDef owner = type() instanceof ClassTypeDef classTypeDef ? classTypeDef : null;
+            Invocations.Resolved resolved = Invocations.resolve(owner, MethodDef.CONSTRUCTOR, null, values);
+            if (resolved != null) {
+                return invokeSuperConstructor(resolved.parameterTypes(), resolved.values());
+            }
             return invokeSuperConstructor(values.stream().map(ExpressionDef::type).toList(), values);
         }
 

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/VariableDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/VariableDef.java
@@ -206,7 +206,7 @@ public sealed interface VariableDef extends ExpressionDef permits VariableDef.Ex
         /**
          * Invoke super constructor statement.
          *
-         * <p>The constructor is resolved with {@link ClassTypeDef#findDeclaredMethod(String, int)} when the
+         * <p>The constructor is resolved with {@link ClassTypeDef#findDeclaredMethods(String, int)} when the
          * super type carries member information. When it does not, the signature is inferred from the static
          * types of the values, which names a constructor that does not exist if any of them is narrower than
          * the declared parameter - use {@link #invokeSuperConstructor(List, List)} or

--- a/sourcegen-model/src/test/groovy/io/micronaut/sourcegen/model/InvocationResolutionTest.java
+++ b/sourcegen-model/src/test/groovy/io/micronaut/sourcegen/model/InvocationResolutionTest.java
@@ -54,6 +54,43 @@ class InvocationResolutionTest {
     }
 
     @Test
+    void variableArityOverloadsAreResolvedWithASingleTrailingArgument() {
+        // String.format(String, Object...) and format(Locale, String, Object...) both accept two arguments
+        ExpressionDef.InvokeStaticMethod call = ClassTypeDef.of(String.class)
+            .invokeStatic("format", TypeDef.STRING, A_STRING, B_STRING);
+
+        assertEquals(List.of(TypeDef.STRING, TypeDef.OBJECT.array()), parameterTypes(call.method()));
+        assertEquals(2, call.values().size());
+        assertEquals(TypeDef.OBJECT.array(), call.values().get(1).type());
+    }
+
+    @Test
+    void aReferenceArgumentDoesNotUnboxToAPrimitiveParameter() {
+        // Neither pick(int) nor pick(String) accepts an Object, so the signature stays inferred
+        ExpressionDef object = new VariableDef.Local("value", TypeDef.OBJECT);
+
+        ExpressionDef.InvokeStaticMethod call = SUPPORT.invokeStatic("pick", TypeDef.STRING, object);
+
+        assertEquals(List.of(TypeDef.OBJECT), parameterTypes(call.method()));
+    }
+
+    @Test
+    void aPrimitiveArgumentBoxesToAWiderParameter() {
+        ExpressionDef.InvokeStaticMethod call = SUPPORT.invokeStatic("describe", TypeDef.STRING, ExpressionDef.constant(1));
+
+        assertEquals(List.of(TypeDef.of(Number.class)), parameterTypes(call.method()));
+    }
+
+    @Test
+    void arrayOverloadsAreToldApartByTheComponentType() {
+        ExpressionDef strings = new VariableDef.Local("values", TypeDef.STRING.array());
+
+        ExpressionDef.InvokeStaticMethod call = SUPPORT.invokeStatic("first", TypeDef.STRING, strings);
+
+        assertEquals(List.of(TypeDef.STRING.array()), parameterTypes(call.method()));
+    }
+
+    @Test
     void anArrayAlreadyPassedForAVariableArityParameterIsLeftAlone() {
         ExpressionDef array = new ExpressionDef.NewArrayInitialized(TypeDef.OBJECT.array(), List.of(A_STRING));
 
@@ -123,6 +160,30 @@ class InvocationResolutionTest {
 
         static String ambiguous(Object value) {
             return String.valueOf(value);
+        }
+
+        static String pick(int value) {
+            return String.valueOf(value);
+        }
+
+        static String pick(String value) {
+            return value;
+        }
+
+        static String first(String[] values) {
+            return values[0];
+        }
+
+        static String first(Integer[] values) {
+            return String.valueOf(values[0]);
+        }
+
+        static String describe(Number value) {
+            return String.valueOf(value);
+        }
+
+        static String describe(String value) {
+            return value;
         }
 
         String join(Object left, Object right) {

--- a/sourcegen-model/src/test/groovy/io/micronaut/sourcegen/model/InvocationResolutionTest.java
+++ b/sourcegen-model/src/test/groovy/io/micronaut/sourcegen/model/InvocationResolutionTest.java
@@ -1,6 +1,9 @@
 package io.micronaut.sourcegen.model;
 
+import io.micronaut.inject.ast.ClassElement;
 import org.junit.jupiter.api.Test;
+
+import javax.lang.model.element.Modifier;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -88,6 +91,71 @@ class InvocationResolutionTest {
         ExpressionDef.InvokeStaticMethod call = SUPPORT.invokeStatic("first", TypeDef.STRING, strings);
 
         assertEquals(List.of(TypeDef.STRING.array()), parameterTypes(call.method()));
+    }
+
+    @Test
+    void anAstArgumentIsCheckedAgainstAReflectiveParameter() {
+        ExpressionDef integer = new VariableDef.Local("value", ClassTypeDef.of(ClassElement.of(Integer.class)));
+
+        ExpressionDef.InvokeStaticMethod call = SUPPORT.invokeStatic("describe", TypeDef.STRING, integer);
+
+        assertEquals(List.of(TypeDef.of(Number.class)), parameterTypes(call.method()));
+    }
+
+    @Test
+    void aReflectiveArgumentIsCheckedAgainstAParameterKnownByName() {
+        // A definition being generated can declare its parameters by name only; Comparable is reached
+        // through Integer's interfaces
+        ClassTypeDef owner = ClassDef.builder("test.Generated")
+            .addMethod(MethodDef.builder("describe").addModifiers(Modifier.STATIC)
+                .addParameter("value", ClassTypeDef.of("java.lang.Comparable")).returns(TypeDef.STRING).build())
+            .addMethod(MethodDef.builder("describe").addModifiers(Modifier.STATIC)
+                .addParameter("value", ClassTypeDef.of("java.lang.String")).returns(TypeDef.STRING).build())
+            .build()
+            .asTypeDef();
+
+        ExpressionDef.InvokeStaticMethod call = owner.invokeStatic("describe", TypeDef.STRING, ExpressionDef.constant(1));
+
+        assertEquals(List.of(ClassTypeDef.of("java.lang.Comparable")), parameterTypes(call.method()));
+    }
+
+    @Test
+    void anArgumentKnownByNameOnlyCannotNarrowOverloads() {
+        ExpressionDef unknown = new VariableDef.Local("value", ClassTypeDef.of("com.example.Unknown"));
+
+        ExpressionDef.InvokeStaticMethod call = SUPPORT.invokeStatic("describe", TypeDef.STRING, unknown);
+
+        assertEquals(List.of(ClassTypeDef.of("com.example.Unknown")), parameterTypes(call.method()));
+    }
+
+    @Test
+    void anUnboundedTypeVariableErasesToObject() {
+        ExpressionDef variable = new VariableDef.Local("value", TypeDef.variable("T"));
+
+        ExpressionDef.InvokeStaticMethod call = SUPPORT.invokeStatic("describe", TypeDef.STRING, variable);
+
+        assertEquals(List.of(TypeDef.variable("T")), parameterTypes(call.method()));
+    }
+
+    @Test
+    void annotatedTypesAreComparedByTheTypeTheyAnnotate() {
+        AnnotationDef deprecated = AnnotationDef.builder(ClassTypeDef.of(Deprecated.class)).build();
+        ExpressionDef annotatedClass = new VariableDef.Local("value", ClassTypeDef.of(Integer.class).annotated(deprecated));
+        ExpressionDef annotatedPrimitive = new VariableDef.Local("other", TypeDef.Primitive.INT.annotated(deprecated));
+
+        assertEquals(List.of(TypeDef.of(Number.class)),
+            parameterTypes(SUPPORT.invokeStatic("describe", TypeDef.STRING, annotatedClass).method()));
+        assertEquals(List.of(TypeDef.of(Number.class)),
+            parameterTypes(SUPPORT.invokeStatic("describe", TypeDef.STRING, annotatedPrimitive).method()));
+    }
+
+    @Test
+    void aWildcardArgumentCannotNarrowOverloads() {
+        ExpressionDef wildcard = new VariableDef.Local("value", TypeDef.wildcard());
+
+        ExpressionDef.InvokeStaticMethod call = SUPPORT.invokeStatic("describe", TypeDef.STRING, wildcard);
+
+        assertEquals(List.of(TypeDef.wildcard()), parameterTypes(call.method()));
     }
 
     @Test

--- a/sourcegen-model/src/test/groovy/io/micronaut/sourcegen/model/InvocationResolutionTest.java
+++ b/sourcegen-model/src/test/groovy/io/micronaut/sourcegen/model/InvocationResolutionTest.java
@@ -1,0 +1,133 @@
+package io.micronaut.sourcegen.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests that an invocation built from the arguments alone takes its signature from the declaration when
+ * the declaring type is resolvable, instead of from the static types of the arguments - which names a
+ * method that does not exist whenever an argument is narrower than the declared parameter.
+ */
+class InvocationResolutionTest {
+
+    private static final ClassTypeDef SUPPORT = ClassTypeDef.of(Support.class);
+    private static final ExpressionDef A_STRING = ExpressionDef.constant("a");
+    private static final ExpressionDef B_STRING = ExpressionDef.constant("b");
+
+    private static List<TypeDef> parameterTypes(MethodDef methodDef) {
+        return methodDef.getParameters().stream().map(ParameterDef::getType).toList();
+    }
+
+    @Test
+    void staticCallUsesTheDeclaredParameterTypes() {
+        ExpressionDef.InvokeStaticMethod call = SUPPORT.invokeStatic("concat", TypeDef.STRING, A_STRING, B_STRING);
+
+        assertEquals(List.of(TypeDef.OBJECT, TypeDef.OBJECT), parameterTypes(call.method()));
+        assertEquals(2, call.values().size());
+    }
+
+    @Test
+    void instanceCallUsesTheDeclaredParameterTypes() {
+        ExpressionDef instance = new VariableDef.Local("support", SUPPORT);
+
+        ExpressionDef.InvokeInstanceMethod call = instance.invoke("join", TypeDef.STRING, A_STRING, B_STRING);
+
+        assertEquals(List.of(TypeDef.OBJECT, TypeDef.OBJECT), parameterTypes(call.method()));
+    }
+
+    @Test
+    void variableArityArgumentsArePackedIntoAnArray() {
+        ExpressionDef.InvokeStaticMethod call = SUPPORT.invokeStatic("of", TypeDef.STRING, A_STRING, B_STRING);
+
+        assertEquals(List.of(TypeDef.OBJECT.array()), parameterTypes(call.method()));
+        assertEquals(1, call.values().size());
+        ExpressionDef packed = call.values().get(0);
+        assertEquals(TypeDef.OBJECT.array(), packed.type());
+        assertEquals(2, ((ExpressionDef.NewArrayInitialized) packed).expressions().size());
+    }
+
+    @Test
+    void anArrayAlreadyPassedForAVariableArityParameterIsLeftAlone() {
+        ExpressionDef array = new ExpressionDef.NewArrayInitialized(TypeDef.OBJECT.array(), List.of(A_STRING));
+
+        ExpressionDef.InvokeStaticMethod call = SUPPORT.invokeStatic("of", TypeDef.STRING, array);
+
+        assertEquals(List.of(TypeDef.OBJECT.array()), parameterTypes(call.method()));
+        assertEquals(List.of(array), call.values());
+    }
+
+    @Test
+    void constructorOverloadsAreToldApartByTheArgument() {
+        ExpressionDef list = new VariableDef.Local("values", ClassTypeDef.of(List.class));
+
+        ExpressionDef.NewInstance instance = ClassTypeDef.of(ArrayList.class).instantiate(list);
+
+        assertEquals(List.of(TypeDef.of(Collection.class)), instance.parameterTypes());
+    }
+
+    @Test
+    void aBridgeMethodIsAValidTarget() {
+        // ReentrantReadWriteLock covariantly overrides ReadWriteLock#readLock, leaving a bridge returning Lock
+        ExpressionDef lock = new VariableDef.Local("lock", ClassTypeDef.of(ReentrantReadWriteLock.class));
+
+        ExpressionDef.InvokeInstanceMethod call = lock.invoke("readLock", TypeDef.of(Lock.class));
+
+        assertEquals(List.of(), parameterTypes(call.method()));
+        assertEquals(TypeDef.of(Lock.class), call.method().getReturnType());
+    }
+
+    @Test
+    void aTypeKnownOnlyByNameKeepsTheInferredSignature() {
+        ExpressionDef.InvokeStaticMethod call = ClassTypeDef.of("com.example.Support")
+            .invokeStatic("concat", TypeDef.STRING, A_STRING, B_STRING);
+
+        assertEquals(List.of(TypeDef.STRING, TypeDef.STRING), parameterTypes(call.method()));
+    }
+
+    @Test
+    void ambiguousOverloadsKeepTheInferredSignature() {
+        ExpressionDef.InvokeStaticMethod call = SUPPORT.invokeStatic("ambiguous", TypeDef.STRING, A_STRING);
+
+        assertEquals(List.of(TypeDef.STRING), parameterTypes(call.method()));
+    }
+
+    @Test
+    void aReturnTypeMatchingNoDeclarationKeepsTheInferredSignature() {
+        // The Java writer lets javac resolve this; the bytecode writer reports it
+        ExpressionDef.InvokeStaticMethod call = SUPPORT.invokeStatic("concat", TypeDef.OBJECT, A_STRING, B_STRING);
+
+        assertEquals(List.of(TypeDef.STRING, TypeDef.STRING), parameterTypes(call.method()));
+    }
+
+    @SuppressWarnings("unused")
+    static class Support {
+
+        static String concat(Object left, Object right) {
+            return String.valueOf(left) + right;
+        }
+
+        static String of(Object... elements) {
+            return String.valueOf(elements.length);
+        }
+
+        static String ambiguous(CharSequence value) {
+            return value.toString();
+        }
+
+        static String ambiguous(Object value) {
+            return String.valueOf(value);
+        }
+
+        String join(Object left, Object right) {
+            return concat(left, right);
+        }
+    }
+
+}

--- a/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/MyRepository.java
+++ b/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/MyRepository.java
@@ -17,6 +17,14 @@ package io.micronaut.sourcegen.example;
 
 public interface MyRepository {
 
+    static String describe(Number number) {
+        return "number:" + number;
+    }
+
+    static String describe(String string) {
+        return "string:" + string;
+    }
+
     static String staticMethod(String string, Integer integer, int i) {
         return string + (integer + i);
     }

--- a/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/MethodInvokerTest.java
+++ b/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/MethodInvokerTest.java
@@ -167,6 +167,14 @@ public class MethodInvokerTest {
     }
 
     @Test
+    public void testInvokeOverloadedAstMethod() {
+        Assertions.assertEquals(
+            "number:1",
+            MethodInvoker.invokeOverloadedAstMethod(1)
+        );
+    }
+
+    @Test
     public void testInvokeWiderParameterMethod() {
         Assertions.assertEquals(
             "a",

--- a/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/MethodInvokerTest.java
+++ b/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/MethodInvokerTest.java
@@ -167,6 +167,22 @@ public class MethodInvokerTest {
     }
 
     @Test
+    public void testInvokeWiderParameterMethod() {
+        Assertions.assertEquals(
+            "a",
+            MethodInvoker.invokeWiderParameterMethod("a", "b")
+        );
+    }
+
+    @Test
+    public void testInvokeVarArgsMethod() {
+        Assertions.assertEquals(
+            "x-y",
+            MethodInvoker.invokeVarArgsMethod("%s-%s", "x", "y")
+        );
+    }
+
+    @Test
     public void testInvokeTryFinallyLockMethod() {
         ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
         Assertions.assertEquals(

--- a/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateMethodInvocationVisitor.java
+++ b/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateMethodInvocationVisitor.java
@@ -46,6 +46,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 @Internal
 public final class GenerateMethodInvocationVisitor implements TypeElementVisitor<GenerateMethodInvocation, Object> {
 
+    private static final String VALUE = "value";
+
     private static final java.lang.reflect.Method LOCK_METHOD = ReflectionUtils.getRequiredInternalMethod(
         Lock.class,
         "lock"
@@ -90,7 +92,7 @@ public final class GenerateMethodInvocationVisitor implements TypeElementVisitor
             // MyRepository.describe is overloaded for Number and String with the same arity; the argument
             // is an AST Integer, so the overload has to be picked through the element model
             .addMethod(MethodDef.builder("invokeOverloadedAstMethod")
-                .addParameter("value", integerType)
+                .addParameter(VALUE, integerType)
                 .returns(String.class)
                 .buildStatic(methodParameters -> repositoryType
                     .invokeStatic("describe", TypeDef.STRING, methodParameters)
@@ -219,7 +221,7 @@ public final class GenerateMethodInvocationVisitor implements TypeElementVisitor
             .addMethod(MethodDef.builder("invokeTypeVariable")
                 .addTypeVariable(new TypeVariable("T"))
                 .returns(TypeDef.STRING)
-                .addParameter("value", TypeDef.variable("T"))
+                .addParameter(VALUE, TypeDef.variable("T"))
                 .build((t, p) ->
                     p.get(0).invoke("toString", TypeDef.STRING).returning()
                 )
@@ -228,7 +230,7 @@ public final class GenerateMethodInvocationVisitor implements TypeElementVisitor
             .addMethod(MethodDef.builder("invokeTypeVariableWithBounds")
                 .addTypeVariable(new TypeVariable("T", List.of(TypeDef.of(CharSequence.class))))
                 .returns(TypeDef.Primitive.INT)
-                .addParameter("value", TypeDef.variable("T", List.of(TypeDef.of(CharSequence.class))))
+                .addParameter(VALUE, TypeDef.variable("T", List.of(TypeDef.of(CharSequence.class))))
                 .build((t, p) ->
                     p.get(0).invoke("length", TypeDef.Primitive.INT).returning()
                 )

--- a/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateMethodInvocationVisitor.java
+++ b/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateMethodInvocationVisitor.java
@@ -71,7 +71,10 @@ public final class GenerateMethodInvocationVisitor implements TypeElementVisitor
         ClassElement myRepository = context.getRequiredClassElement("io.micronaut.sourcegen.example.MyRepository", context.getElementAnnotationMetadataFactory());
         ClassTypeDef repositoryType = ClassTypeDef.of(myRepository);
 
-        ClassDef methodInvoker = createMethodInvokerClass(repositoryType);
+        // An AST type, so that the argument below is a ClassElementType rather than a reflective class
+        ClassTypeDef integerType = ClassTypeDef.of(context.getRequiredClassElement(Integer.class.getName(), context.getElementAnnotationMetadataFactory()));
+
+        ClassDef methodInvoker = createMethodInvokerClass(repositoryType, integerType);
         sourceGenerator.write(methodInvoker, context, element);
 
         ClassDef interfaceSuperInvokerDef = createInterfaceSuperInvoker(myRepository);
@@ -81,8 +84,18 @@ public final class GenerateMethodInvocationVisitor implements TypeElementVisitor
         sourceGenerator.write(swapper, context, element);
     }
 
-    private ClassDef createMethodInvokerClass(ClassTypeDef repositoryType) {
+    private ClassDef createMethodInvokerClass(ClassTypeDef repositoryType, ClassTypeDef integerType) {
         return ClassDef.builder("io.micronaut.sourcegen.example.MethodInvoker")
+
+            // MyRepository.describe is overloaded for Number and String with the same arity; the argument
+            // is an AST Integer, so the overload has to be picked through the element model
+            .addMethod(MethodDef.builder("invokeOverloadedAstMethod")
+                .addParameter("value", integerType)
+                .returns(String.class)
+                .buildStatic(methodParameters -> repositoryType
+                    .invokeStatic("describe", TypeDef.STRING, methodParameters)
+                    .returning())
+            )
 
             .addMethod(MethodDef.builder("invokeDefaultMethod")
                 .addParameter(repositoryType)

--- a/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateMethodInvocationVisitor.java
+++ b/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateMethodInvocationVisitor.java
@@ -38,6 +38,7 @@ import io.micronaut.sourcegen.model.VariableDef;
 
 import javax.lang.model.element.Modifier;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -148,6 +149,25 @@ public final class GenerateMethodInvocationVisitor implements TypeElementVisitor
                 .addStaticStatement(methodParameters -> repositoryType
                     .invokeStatic("staticMethod", TypeDef.STRING, methodParameters))
                 .buildStatic(methodParameters -> ExpressionDef.constant("Ignored").returning())
+            )
+
+            // The declared parameters are wider than the arguments: a signature inferred from the argument
+            // types would name Objects.toString(String, String), which does not exist
+            .addMethod(MethodDef.builder("invokeWiderParameterMethod")
+                .addParameters(String.class, String.class)
+                .returns(String.class)
+                .buildStatic(methodParameters -> ClassTypeDef.of(Objects.class)
+                    .invokeStatic("toString", TypeDef.STRING, methodParameters)
+                    .returning())
+            )
+
+            // A variable arity target: the trailing arguments belong in an array
+            .addMethod(MethodDef.builder("invokeVarArgsMethod")
+                .addParameters(String.class, String.class, String.class)
+                .returns(String.class)
+                .buildStatic(methodParameters -> ClassTypeDef.of(String.class)
+                    .invokeStatic("format", TypeDef.STRING, methodParameters)
+                    .returning())
             )
 
             .addMethod(MethodDef.builder("invokeTryFinallyReadLock")

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/MyRepository.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/MyRepository.java
@@ -17,6 +17,14 @@ package io.micronaut.sourcegen.example;
 
 public interface MyRepository {
 
+    static String describe(Number number) {
+        return "number:" + number;
+    }
+
+    static String describe(String string) {
+        return "string:" + string;
+    }
+
     static String staticMethod(String string, Integer integer, int i) {
         return string + (integer + i);
     }

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/MethodInvokerTest.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/MethodInvokerTest.java
@@ -168,6 +168,14 @@ public class MethodInvokerTest {
     }
 
     @Test
+    public void testInvokeOverloadedAstMethod() {
+        Assertions.assertEquals(
+            "number:1",
+            MethodInvoker.invokeOverloadedAstMethod(1)
+        );
+    }
+
+    @Test
     public void testInvokeWiderParameterMethod() {
         Assertions.assertEquals(
             "a",

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/MethodInvokerTest.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/MethodInvokerTest.java
@@ -168,6 +168,22 @@ public class MethodInvokerTest {
     }
 
     @Test
+    public void testInvokeWiderParameterMethod() {
+        Assertions.assertEquals(
+            "a",
+            MethodInvoker.invokeWiderParameterMethod("a", "b")
+        );
+    }
+
+    @Test
+    public void testInvokeVarArgsMethod() {
+        Assertions.assertEquals(
+            "x-y",
+            MethodInvoker.invokeVarArgsMethod("%s-%s", "x", "y")
+        );
+    }
+
+    @Test
     public void testInvokeTryFinallyLockMethod() {
         ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
         assertEquals(


### PR DESCRIPTION
## Problem

Five convenience overloads build the invoked `MethodDef` from `values.stream().map(ExpressionDef::type)` — the **static types of the arguments** — rather than from the signature the target declares:

| Location | Method |
|---|---|
| `ClassTypeDef` | `invokeStatic(String, TypeDef, List)` |
| `ClassTypeDef` | `instantiate(List)` |
| `ExpressionDef` | `invoke(String, TypeDef, List)` |
| `ExpressionDef` | `invokeConstructor(List)` |
| `VariableDef.Super` | `invokeSuperConstructor(List)` |

Whenever an argument's static type is narrower than the declared parameter, the descriptor names a method that does not exist. The Java writer hides this completely, because javac resolves the overload from the rendered call. The bytecode writer emits the descriptor verbatim and performs no resolution check, so the mismatch survives generation, survives compilation, and surfaces at run time.

The two new runtime tests reproduce it exactly. On `2.2.x` they **pass under the Java writer and fail under the bytecode writer**:

```
NoSuchMethodError: 'java.lang.String java.util.Objects.toString(java.lang.String, java.lang.String)'
NoSuchMethodError: 'java.lang.String java.lang.String.format(java.lang.String, java.lang.String, java.lang.String)'
```

### This is already shipping broken code

The check caught a latent bug in the project's own `@Builder` generator: `BuilderAnnotationVisitor` asks for `Map#entrySet` to return `Map.Entry` instead of `Set` (the sibling call site at line 464 gets it right). The generated builders in `test-suite-bytecode` contained

```
invokeinterface java/util/Map.entrySet:()Ljava/util/Map$Entry;
invokespecial   java/util/ArrayList."<init>":(Ljava/util/Map$Entry;)V
invokespecial   java/util/ArrayList."<init>":(Ljava/util/List;)V
invokespecial   java/util/ArrayList."<init>":(Ljava/util/Set;)V
```

None of those four exist. The tests passed only because nothing invoked those instructions. After this change every one of them names a real signature.

## Fix

`ClassTypeDef.findDeclaredMethods(String, int)` returns the candidates a call could target, implemented for the types that carry member information — `of(Class)` by reflection, `of(ClassElement)` by `ElementQuery`, and a definition being generated by its own methods. `of(String)` has nothing to resolve against and returns an empty list, which leaves the signature inferred exactly as before.

The overloads then:

* take the **parameter types from the declaration** — the candidate whose return type has the same erasure as the one requested;
* **pack the trailing arguments of a variable arity target into an array**;
* tell same-arity overloads apart by dropping the ones an argument *provably* cannot be passed to, so `ArrayList(Collection)` is picked over `ArrayList(int)`.

Anything ambiguous or unresolvable keeps today's behaviour, so the change can only turn a broken descriptor into a working one.

Two things I got wrong on the first pass, both caught by the repo's own suites and worth recording:

* **Bridge methods must count as candidates.** `ReentrantReadWriteLock.readLock()` covariantly overrides `ReadWriteLock#readLock`, leaving a bridge that returns `Lock`. `GenerateMethodInvocationVisitor` requests exactly that, and the descriptor genuinely resolves — but `Method.isSynthetic()` is true for bridges, so filtering them out made it look like a mismatch.
* **A requested return type that matches no declaration must not be rejected.** I first made it throw. That breaks legitimate source generation: `BuilderAnnotationVisitor` asks for `List#get` to return the element type, which javac resolves fine and which the bytecode suite never generates. It is left alone here — see below.

Return types are compared by **erasure**, ignoring nullability, the way a descriptor does; otherwise `Set<Map.Entry<K,V>>` would not match a requested raw `Set`.

## What this does not fix

The generic-return variant in the report — `<T> T coerceToType(...)` requested as `double` — cannot be fixed inside these overloads: the descriptor's return type *is* the expression's type (`InvokeStaticMethod.type()` returns `method.getReturnType()`), so correcting it would need the overload to return a `Cast`, and changing the declared return type from `InvokeStaticMethod` to `ExpressionDef` is a binary break.

The remedy is what the report says — request the declared return type and `.cast(...)` the result — and the place to catch it is suggestion 2, validating in the bytecode writer, which fails only the backend that is actually broken. That is a separate change; the javadoc added here points at the explicit-signature overloads in the meantime.

## Tests

`InvocationResolutionTest` (13 cases): declared parameter types for static and instance calls, varargs packing, an array already passed for a varargs parameter, constructor overload selection, bridge methods, and three regression guards — a name-only type, ambiguous overloads, and an unmatched return type all keep the inferred signature.

`MethodInvokerTest` in **both** `test-suite-java` and `test-suite-bytecode` gains three cases that generate, compile, load and **invoke** the calls above. That is the conformance shape the report asks for: compiling alone would not have caught this.

No binary incompatibility against 2.1.0 (`japiCmp` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review pass

A self-review after opening found and fixed four more things (second commit):

* two javadoc links still named the hook `findDeclaredMethod` and failed the javadoc build;
* boxing was checked in the wrong direction, so `pick(int)` was selected for an `Object` argument;
* array parameters were never checked, so `first(String[])` vs `first(Integer[])` could not be told apart;
* narrowing was blind to AST types — the reporter's case. A `ClassElement`-typed argument is now checked with `ClassElement.isAssignable`.

The AST case is tested end to end: `MyRepository.describe` is overloaded for `Number` and `String`, and `MethodInvoker.invokeOverloadedAstMethod` calls it with a **javac-typed** `Integer`. Without the fix it fails under the bytecode writer with `NoSuchMethodError: describe(java.lang.Integer)` and passes under the Java writer. (A unit test using `ClassElement.of(Class)` was removed: that reflective stub always answers `false` to `isAssignable(String)` and has no enclosed elements, so it cannot stand in for a real element.)

One more golden changed: `ByteCodeWriterTest.concatStrings` encoded `Arrays.toString([Ljava/lang/String;)`, which does not exist in the JDK. The source block in that golden is a **decompilation** of the bytecode, so the `(Object[])` it now shows is the check-cast, not Java writer output — the real Java output is unchanged: `Objects.toString(arg1, arg2)`, no casts. A varargs call renders as `String.format(arg1, new Object[]{arg2,arg3})`, which is valid, just explicit where javac would pack implicitly.
