### PR TITLE
Declare primitive concatenation parts as primitives in the indy descriptor

### DIFF
--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/expression/StringConcatenationExpressionWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/expression/StringConcatenationExpressionWriter.java
@@ -57,7 +57,9 @@ final class StringConcatenationExpressionWriter extends AbstractStatementAwareEx
             } else {
                 ++numDynamicParts;
                 stringExpression.append(ARG_CODE);
-                ExpressionWriter.writeExpressionCheckCast(generatorAdapter, context, value, TypeDef.OBJECT);
+                // Written as its own type: the descriptor below declares that type, and the concat factory
+                // accepts a primitive directly, which keeps it off the heap
+                ExpressionWriter.writeExpression(generatorAdapter, context, value);
             }
         }
 

--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
@@ -4219,6 +4219,59 @@ public class MyClass {
 """, decompileToJava(bytes));
     }
 
+    @Test
+    void testStringConcatenationWithPrimitives() {
+        ClassDef classDef = ClassDef.builder("example.MyClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("describe")
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter("count", TypeDef.Primitive.INT)
+                .addParameter("price", TypeDef.Primitive.DOUBLE)
+                .returns(TypeDef.STRING)
+                .build((t, params) ->
+                    ExpressionDef.constant("Count: ")
+                        .stringConcat(params.get(0))
+                        .stringConcat(ExpressionDef.constant(", price: "))
+                        .stringConcat(params.get(1))
+                        .returning()
+                )
+            )
+            .build();
+
+        // The descriptor has to declare what is on the stack: the primitives themselves, not their boxes
+        assertEquals("""
+// class version 61.0 (61)
+// access flags 0x1
+// signature Ljava/lang/Object;
+// declaration: example/MyClass
+public class example/MyClass {
+
+
+  // access flags 0x1
+  public <init>()V
+    ALOAD 0
+    INVOKESPECIAL java/lang/Object.<init> ()V
+    RETURN
+
+  // access flags 0x1
+  public describe(ID)Ljava/lang/String;
+   L0
+    ILOAD 1
+    DLOAD 2
+    INVOKEDYNAMIC makeConcatWithConstants(ID)Ljava/lang/String; [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/invoke/StringConcatFactory.makeConcatWithConstants(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;
+      // arguments:
+      "Count: \\u0001, price: \\u0001"
+    ]
+    ARETURN
+   L1
+    LOCALVARIABLE count I L0 L1 1
+    LOCALVARIABLE price D L0 L1 2
+}
+""", toBytecode(classDef));
+    }
+
     private String toBytecode(ObjectDef objectDef) {
         StringWriter stringWriter = new StringWriter();
         generateFile(objectDef, stringWriter);

--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
@@ -4238,6 +4238,10 @@ public class MyClass {
             )
             .build();
 
+        StringWriter bytecodeWriter = new StringWriter();
+        byte[] bytes = generateFile(classDef, bytecodeWriter);
+        String bytecode = bytecodeWriter.toString();
+
         // The descriptor has to declare what is on the stack: the primitives themselves, not their boxes
         assertEquals("""
 // class version 61.0 (61)
@@ -4269,7 +4273,16 @@ public class example/MyClass {
     LOCALVARIABLE count I L0 L1 1
     LOCALVARIABLE price D L0 L1 2
 }
-""", toBytecode(classDef));
+""", bytecode);
+        assertEquals("""
+package example;
+
+public class MyClass {
+   public String describe(int count, double price) {
+      return "Count: " + count + ", price: " + price;
+   }
+}
+""", decompileToJava(bytes));
     }
 
     private String toBytecode(ObjectDef objectDef) {

--- a/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/MyBean3Test.java
+++ b/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/MyBean3Test.java
@@ -50,6 +50,13 @@ class MyBean3Test {
     }
 
     @Test
+    void testConcatenateWithPrimitives() {
+        MyBean3 bean3 = new MyBean3();
+
+        assertEquals("Count: 3, price: 1.5, flag: true", bean3.concatenationWithPrimitives(3, 1.5, true));
+    }
+
+    @Test
     void testThrows() throws Exception {
         MyBean3 bean3 = new MyBean3();
 

--- a/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateMyBean3Visitor.java
+++ b/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateMyBean3Visitor.java
@@ -72,6 +72,17 @@ public final class GenerateMyBean3Visitor implements TypeElementVisitor<Generate
                 .returns(TypeDef.STRING)
                 .build((t, params) -> ExpressionDef.constant("Hello, ").stringConcat(params.get(0)).returning())
             )
+            // Primitive parts: the indy descriptor has to agree with what is on the stack
+            .addMethod(MethodDef.builder("concatenationWithPrimitives")
+                .addParameter(ParameterDef.of("count", TypeDef.Primitive.INT))
+                .addParameter(ParameterDef.of("price", TypeDef.Primitive.DOUBLE))
+                .addParameter(ParameterDef.of("flag", TypeDef.Primitive.BOOLEAN))
+                .returns(TypeDef.STRING)
+                .build((t, params) -> ExpressionDef.constant("Count: ").stringConcat(params.get(0))
+                    .stringConcat(ExpressionDef.constant(", price: ")).stringConcat(params.get(1))
+                    .stringConcat(ExpressionDef.constant(", flag: ")).stringConcat(params.get(2))
+                    .returning())
+            )
             .addMethod(createMethodWithThrows())
             .build();
 

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/MyBean3Test.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/MyBean3Test.java
@@ -56,4 +56,11 @@ class MyBean3Test {
 
         assertThrows(IOException.class, bean3::getStringUnsafe);
     }
+
+    @Test
+    void testConcatenateWithPrimitives() {
+        MyBean3 bean3 = new MyBean3();
+
+        assertEquals("Count: 3, price: 1.5, flag: true", bean3.concatenationWithPrimitives(3, 1.5, true));
+    }
 }


### PR DESCRIPTION
Fixes #472.

## Problem

`StringConcatenationExpressionWriter` boxes every dynamic part of an `ExpressionDef.StringConcatenation` — `write` emits each one through `writeExpressionCheckCast(..., TypeDef.OBJECT)` — but `createDynamicMethodDescriptor` builds the `makeConcatWithConstants` descriptor from `part.type()`, the primitive. The stack holds a `Double`, the call site declares a `D`, and the class fails verification when it is loaded:

```
java.lang.VerifyError: Bad type on operand stack
    io/micronaut/sourcegen/example/MyBean3.concatenationWithPrimitives(IDZ)Ljava/lang/String; @13: invokedynamic
```

The Java source writer renders the same model correctly (`"Price: " + book.getUnitPrice()`), so source-level tests never see it.

## Fix

Write each dynamic part as its own type, so the descriptor and the stack agree. The concat factory accepts primitives directly, which also keeps them off the heap — the point of the indy concatenation. Existing output for reference-typed parts is unchanged (`testStringConcatenation` golden untouched).

## Tests

* `ByteCodeWriterTest.testStringConcatenationWithPrimitives` — asserts the emitted `ILOAD`/`DLOAD` and the `(ID)Ljava/lang/String;` descriptor.
* `MyBean3.concatenationWithPrimitives(int, double, boolean)` generated by `GenerateMyBean3Visitor`, loaded and **invoked** by `MyBean3Test` in both `test-suite-bytecode` and `test-suite-java`. On `2.2.x` the bytecode suite fails with the exact `VerifyError` above; the Java suite passes — the disagreement the issue describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)