### PR TITLE
Erase type variables and wildcards in TypeDef.erasure

### DIFF
--- a/sourcegen-bytecode-writer/src/test/groovy/io/micronaut/sourcegen/bytecode/ErasureSpec.groovy
+++ b/sourcegen-bytecode-writer/src/test/groovy/io/micronaut/sourcegen/bytecode/ErasureSpec.groovy
@@ -1,0 +1,74 @@
+package io.micronaut.sourcegen.bytecode
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.ElementQuery
+import io.micronaut.inject.ast.MethodElement
+import io.micronaut.sourcegen.model.ClassDef
+import io.micronaut.sourcegen.model.ClassTypeDef
+import io.micronaut.sourcegen.model.ExpressionDef
+import io.micronaut.sourcegen.model.MethodDef
+import io.micronaut.sourcegen.model.TypeDef
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.util.CheckClassAdapter
+
+import javax.lang.model.element.Modifier
+
+/**
+ * The erasure of a generic signature, taken from a javac {@link ClassElement}, rendered as class literals
+ * and read back from the decompiled class.
+ */
+class ErasureSpec extends AbstractTypeElementSpec {
+
+    void "type variables and wildcards erase to their bounds"() {
+        given:
+        ClassElement element = buildClassElement('''
+package test;
+
+import java.util.List;
+import java.util.Optional;
+
+interface Repository {
+    <T extends Number, U> T pick(T value, U unbounded, List<? extends Number> numbers,
+                                 List<? super Integer> sink, T[] values, Optional<T> optional);
+}
+''')
+        MethodElement pick = element.getEnclosedElement(ElementQuery.ALL_METHODS.named("pick")).orElseThrow()
+
+        List<TypeDef> erasures = []
+        for (parameter in pick.parameters) {
+            ClassElement type = parameter.genericType
+            erasures.add(TypeDef.erasure(type))
+            type.firstTypeArgument.ifPresent { erasures.add(TypeDef.erasure(it)) }
+        }
+        erasures.add(TypeDef.erasure(pick.genericReturnType))
+
+        ClassTypeDef classType = ClassTypeDef.of(Class)
+        ClassDef classDef = ClassDef.builder("example.Erasures")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("ofPick")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .returns(classType.array())
+                .build((t, params) -> classType.array()
+                    .instantiate(erasures.collect { new ExpressionDef.Constant(classType, it) })
+                    .returning()))
+            .build()
+
+        when:
+        def classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES)
+        new ByteCodeWriter(false, false).writeObject(new CheckClassAdapter(classWriter), classDef)
+
+        then:
+        DecompilerUtils.decompileToJava(classWriter.toByteArray()) == '''package example;
+
+import java.util.List;
+import java.util.Optional;
+
+public class Erasures {
+   public static Class[] ofPick() {
+      return new Class[]{Number.class, Object.class, List.class, Number.class, List.class, Object.class, Number[].class, Optional.class, Number.class, Number.class};
+   }
+}
+'''
+    }
+}

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassTypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassTypeDef.java
@@ -589,7 +589,9 @@ public sealed interface ClassTypeDef extends TypeDef {
                 new ClassElementType(classElement, classElement.isNullable()),
                 classElement.getTypeArguments().values()
                     .stream()
-                    .map(value -> TypeDef.of(value, resolvedVariableFn, erasure))
+                    // Erasure applies to the type itself; the arguments keep the generic signature, so
+                    // that `Set<?>` does not become `Set<Object>`
+                    .map(value -> TypeDef.of(value, resolvedVariableFn, false))
                     .toList()
             );
         }

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/TypeDef.java
@@ -323,6 +323,11 @@ public sealed interface TypeDef permits ClassTypeDef, TypeDef.Annotated, TypeDef
     /**
      * Creates a new type erasure.
      *
+     * <p>A type variable erases to the erasure of its bound and a wildcard to the erasure of its upper
+     * bound - {@link #OBJECT} when there is none - so the result can always be rendered, as a parameter
+     * type or as a class literal. Type arguments of a parameterized type are kept, so that an overriding
+     * signature stays generic.
+     *
      * @param typedElement The typed element
      * @return a new type definition
      */
@@ -425,7 +430,7 @@ public sealed interface TypeDef permits ClassTypeDef, TypeDef.Annotated, TypeDef
             dimensions++;
         }
         if (dimensions > 0) {
-            return array(of(typedElement), dimensions);
+            return array(of(typedElement, resolvedVariableFn, erasure), dimensions);
         }
         if (typedElement.isPrimitive()) {
             return primitive(typedElement.getName());
@@ -439,12 +444,20 @@ public sealed interface TypeDef permits ClassTypeDef, TypeDef.Annotated, TypeDef
             if (resolved != null) {
                 return resolved;
             }
+            if (erasure) {
+                // JLS 4.6: a type variable erases to the erasure of its bound
+                return erasureOfBounds(placeholderElement.getBounds(), resolvedVariableFn);
+            }
             return TypeDef.variable(
                 placeholderElement.getVariableName(),
-                placeholderElement.getBounds().stream().map(e -> TypeDef.of(e, resolvedVariableFn, erasure)).toList()
+                placeholderElement.getBounds().stream().map(e -> TypeDef.of(e, resolvedVariableFn, false)).toList()
             );
         }
         if (typedElement instanceof WildcardElement wildcardElement) {
+            if (erasure) {
+                // A wildcard erases to the erasure of its upper bound; `?` and `? super X` to Object
+                return erasureOfBounds(wildcardElement.getUpperBounds(), resolvedVariableFn);
+            }
             return new Wildcard(
                 wildcardElement.getUpperBounds().stream().map(te -> of(te, resolvedVariableFn)).toList(),
                 wildcardElement.getLowerBounds().stream().map(te -> of(te, resolvedVariableFn)).toList()
@@ -454,6 +467,25 @@ public sealed interface TypeDef permits ClassTypeDef, TypeDef.Annotated, TypeDef
             return ClassTypeDef.of(classElement, resolvedVariableFn, erasure);
         }
         throw new IllegalStateException("Unknown typed element: " + typedElement);
+    }
+
+    /**
+     * Erases a list of bounds to the first one that does not erase to {@link Object}, the way the writers
+     * already resolve a type variable: an element model may list a self-referencing placeholder before
+     * the declared bound, so the leftmost entry is not always the one that carries the type.
+     *
+     * @param bounds             The bounds
+     * @param resolvedVariableFn The resolved variable function
+     * @return The erasure of the first significant bound, or {@link #OBJECT} without one
+     */
+    private static TypeDef erasureOfBounds(List<? extends ClassElement> bounds, Function<String, @Nullable TypeDef> resolvedVariableFn) {
+        for (ClassElement bound : bounds) {
+            TypeDef erased = of(bound, resolvedVariableFn, true);
+            if (!(erased instanceof ClassTypeDef classTypeDef && classTypeDef.getName().equals(Object.class.getName()))) {
+                return erased;
+            }
+        }
+        return TypeDef.OBJECT;
     }
 
     /**

--- a/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/MyRepository.java
+++ b/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/MyRepository.java
@@ -25,6 +25,14 @@ public interface MyRepository {
         return "string:" + string;
     }
 
+    /**
+     * A generic signature whose erasures are rendered by the generated code.
+     */
+    static <T extends Number, U> T pick(T value, U unbounded, java.util.List<? extends Number> numbers,
+                                      java.util.List<? super Integer> sink, T[] values, java.util.Optional<T> optional) {
+        return value;
+    }
+
     static String staticMethod(String string, Integer integer, int i) {
         return string + (integer + i);
     }

--- a/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/MethodInvokerTest.java
+++ b/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/MethodInvokerTest.java
@@ -191,6 +191,25 @@ public class MethodInvokerTest {
     }
 
     @Test
+    public void testErasures() {
+        Assertions.assertArrayEquals(
+            new Class<?>[] {
+                Number.class,             // T extends Number
+                Object.class,             // U
+                java.util.List.class,     // List<? extends Number>
+                Number.class,             //   ? extends Number
+                java.util.List.class,     // List<? super Integer>
+                Object.class,             //   ? super Integer
+                Number[].class,           // T[]
+                java.util.Optional.class, // Optional<T>
+                Number.class,             //   T
+                Number.class              // T (return)
+            },
+            MethodInvoker.erasuresOfPick()
+        );
+    }
+
+    @Test
     public void testInvokeTryFinallyLockMethod() {
         ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
         Assertions.assertEquals(

--- a/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateMethodInvocationVisitor.java
+++ b/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateMethodInvocationVisitor.java
@@ -19,7 +19,9 @@ import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.NonNull;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.ElementQuery;
 import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.sourcegen.custom.example.GenerateMethodInvocation;
@@ -37,6 +39,7 @@ import io.micronaut.sourcegen.model.TypeDef.TypeVariable;
 import io.micronaut.sourcegen.model.VariableDef;
 
 import javax.lang.model.element.Modifier;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -76,7 +79,7 @@ public final class GenerateMethodInvocationVisitor implements TypeElementVisitor
         // An AST type, so that the argument below is a ClassElementType rather than a reflective class
         ClassTypeDef integerType = ClassTypeDef.of(context.getRequiredClassElement(Integer.class.getName(), context.getElementAnnotationMetadataFactory()));
 
-        ClassDef methodInvoker = createMethodInvokerClass(repositoryType, integerType);
+        ClassDef methodInvoker = createMethodInvokerClass(repositoryType, integerType, myRepository);
         sourceGenerator.write(methodInvoker, context, element);
 
         ClassDef interfaceSuperInvokerDef = createInterfaceSuperInvoker(myRepository);
@@ -86,8 +89,34 @@ public final class GenerateMethodInvocationVisitor implements TypeElementVisitor
         sourceGenerator.write(swapper, context, element);
     }
 
-    private ClassDef createMethodInvokerClass(ClassTypeDef repositoryType, ClassTypeDef integerType) {
+    /**
+     * Generates {@code static Class[] erasuresOfPick()} returning the erasure of every type in the signature
+     * of {@code MyRepository.pick}, as class literals - a type variable, a wildcard or an array of either
+     * cannot be rendered as one unless it is erased.
+     */
+    private static MethodDef createErasuresMethod(ClassElement myRepository) {
+        MethodElement pick = myRepository.getEnclosedElement(ElementQuery.ALL_METHODS.named("pick")).orElseThrow();
+        List<TypeDef> erasures = new ArrayList<>();
+        for (ParameterElement parameter : pick.getParameters()) {
+            ClassElement type = parameter.getGenericType();
+            erasures.add(TypeDef.erasure(type));
+            // The erasure of the type argument: `? extends Number` -> Number, `? super Integer` -> Object, T -> Number
+            type.getFirstTypeArgument().ifPresent(argument -> erasures.add(TypeDef.erasure(argument)));
+        }
+        erasures.add(TypeDef.erasure(pick.getGenericReturnType()));
+        ClassTypeDef classType = ClassTypeDef.of(Class.class);
+        return MethodDef.builder("erasuresOfPick")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .returns(classType.array())
+            .build((t, params) -> classType.array()
+                .instantiate(erasures.stream().map(e -> new ExpressionDef.Constant(classType, e)).toList())
+                .returning());
+    }
+
+    private ClassDef createMethodInvokerClass(ClassTypeDef repositoryType, ClassTypeDef integerType, ClassElement myRepository) {
         return ClassDef.builder("io.micronaut.sourcegen.example.MethodInvoker")
+
+            .addMethod(createErasuresMethod(myRepository))
 
             // MyRepository.describe is overloaded for Number and String with the same arity; the argument
             // is an AST Integer, so the overload has to be picked through the element model

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/MyRepository.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/MyRepository.java
@@ -25,6 +25,14 @@ public interface MyRepository {
         return "string:" + string;
     }
 
+    /**
+     * A generic signature whose erasures are rendered by the generated code.
+     */
+    static <T extends Number, U> T pick(T value, U unbounded, java.util.List<? extends Number> numbers,
+                                      java.util.List<? super Integer> sink, T[] values, java.util.Optional<T> optional) {
+        return value;
+    }
+
     static String staticMethod(String string, Integer integer, int i) {
         return string + (integer + i);
     }

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/MethodInvokerTest.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/MethodInvokerTest.java
@@ -192,6 +192,25 @@ public class MethodInvokerTest {
     }
 
     @Test
+    public void testErasures() {
+        Assertions.assertArrayEquals(
+            new Class<?>[] {
+                Number.class,             // T extends Number
+                Object.class,             // U
+                java.util.List.class,     // List<? extends Number>
+                Number.class,             //   ? extends Number
+                java.util.List.class,     // List<? super Integer>
+                Object.class,             //   ? super Integer
+                Number[].class,           // T[]
+                java.util.Optional.class, // Optional<T>
+                Number.class,             //   T
+                Number.class              // T (return)
+            },
+            MethodInvoker.erasuresOfPick()
+        );
+    }
+
+    @Test
     public void testInvokeTryFinallyLockMethod() {
         ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
         assertEquals(


### PR DESCRIPTION
Fixes #475.

## Problem

`TypeDef.erasure(TypedElement)` did not erase anything. The `erasure` flag was threaded through `TypeDef.of` and `ClassTypeDef.of` but never acted on: a `GenericPlaceholderElement` came back as a `TypeDef.TypeVariable`, a `WildcardElement` as a `TypeDef.Wildcard`, and neither can be rendered as a class literal:

```
error: Failed to generate 'io.micronaut.sourcegen.example.MethodInvoker': Unrecognized type def:
  TypeVariable[name=T, bounds=[ClassElementType[classElement=java.lang.Object, nullable=false]], nullable=false]
```

The array branch was worse: `array(of(typedElement), dimensions)` dropped both the flag and the variable resolver, so `T[]` never erased *and* never resolved, even when `T` was supplied.

## Fix

* A type variable erases to the erasure of its bound, a wildcard to the erasure of its upper bound — `Object` when there is none — per JLS §4.6.
* The bound is the **first one that does not erase to `Object`**, not literally the leftmost. The Groovy element model lists a self-referencing placeholder before the declared bound (`T` → `[T→Object, Person]`), and the bytecode writer's `getBoundsType` already resolves a variable that way; `erasure` now agrees with it.
* Arrays erase their component with the same flag and resolver.
* Type arguments of a parameterized type are **not** erased — `Set<?>` must stay `Set<?>` in an overriding signature, not become `Set<Object>`. `ClassTypeDef.of` now passes `erasure = false` into its arguments explicitly; before, the flag reached them but was a no-op there too.

### What I tried and reverted

A fallback erasing any `ClassElement` answering `isTypeVariable()`/`isWildcard()` to `Object`. In the Groovy AST a *resolved* type argument still answers `isTypeVariable() == true`, so it turned `SubPerson` and `URL` into `Object` and broke Micronaut **core's** AOP proxy generation — `micronaut-core-processor` builds its `Argument` metadata and proxy signatures on this model and calls `TypeDef.erasure` from `ArgumentExpUtils` and `AopProxyWriter`. `IntroductionGenericTypesSpec` in this repo exercises exactly that path and is green with the final change.

## Tests

`MyRepository` gains `<T extends Number, U> T pick(T, U, List<? extends Number>, List<? super Integer>, T[], Optional<T>)`. `GenerateMethodInvocationVisitor` emits `erasuresOfPick()` returning the erasure of every parameter, every first type argument, and the return type as **class literals**, and `MethodInvokerTest` in both suites asserts all ten:

```
Number, Object, List, Number, List, Object, Number[], Optional, Number, Number
```

On `2.2.x` both suites fail at generation with the `Unrecognized type def` error above. Reflective `ClassElement`s don't model generics, so this is tested through a real annotation-processing round rather than a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)