### PR TITLE
Ignore redeclared Object methods when resolving a functional interface

### DIFF
--- a/sourcegen-bytecode-writer/src/test/groovy/io/micronaut/sourcegen/bytecode/FunctionalInterfaceSpec.groovy
+++ b/sourcegen-bytecode-writer/src/test/groovy/io/micronaut/sourcegen/bytecode/FunctionalInterfaceSpec.groovy
@@ -1,0 +1,79 @@
+package io.micronaut.sourcegen.bytecode
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.sourcegen.model.ClassDef
+import io.micronaut.sourcegen.model.ClassTypeDef
+import io.micronaut.sourcegen.model.ExpressionDef
+import io.micronaut.sourcegen.model.MethodDef
+import io.micronaut.sourcegen.model.StatementDef
+import io.micronaut.sourcegen.model.TypeDef
+import io.micronaut.sourcegen.model.VariableDef
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.util.CheckClassAdapter
+
+import javax.lang.model.element.Modifier
+
+/**
+ * A lambda over a functional interface, taken from a javac {@link ClassElement}, that redeclares a
+ * public method of {@link Object} as abstract.
+ */
+class FunctionalInterfaceSpec extends AbstractTypeElementSpec {
+
+    void "a redeclared Object method does not count as a second abstract method"() {
+        given:
+        // Comparator redeclares equals(Object); this interface redeclares all three
+        ClassElement element = buildClassElement('''
+package test;
+
+interface Checker<T> {
+    boolean check(T value);
+
+    @Override
+    boolean equals(Object other);
+
+    @Override
+    int hashCode();
+
+    @Override
+    String toString();
+}
+''')
+        ClassTypeDef checkerType = ClassTypeDef.of(element)
+        VariableDef.Local checker = new VariableDef.Local("checker", TypeDef.of(element).resolveTypeVariables(["T": TypeDef.STRING]))
+
+        ClassDef classDef = ClassDef.builder("example.Checks")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("isEmpty")
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter("value", TypeDef.STRING)
+                .returns(TypeDef.Primitive.BOOLEAN)
+                .build((t, params) -> StatementDef.multi(
+                    checker.defineAndAssign(checkerType.getLambda(["T": TypeDef.STRING])
+                        .implement((lt, lp) -> lp.get(0).invoke("isEmpty", TypeDef.Primitive.BOOLEAN).returning())),
+                    checker.invoke("check", [TypeDef.OBJECT], TypeDef.Primitive.BOOLEAN, [params.get(0)]).returning()
+                )))
+            .build()
+
+        when:
+        def classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES)
+        new ByteCodeWriter(false, false).writeObject(new CheckClassAdapter(classWriter), classDef)
+
+        then:
+        DecompilerUtils.decompileToJava(classWriter.toByteArray()) == '''package example;
+
+import test.Checker;
+
+public class Checks {
+   public boolean isEmpty(String value) {
+      Checker checker = Checks::lambda$isEmpty$0;
+      return checker.check(value);
+   }
+
+   private static boolean lambda$isEmpty$0(String value) {
+      return value.isEmpty();
+   }
+}
+'''
+    }
+}

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassTypeDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassTypeDef.java
@@ -179,6 +179,24 @@ public sealed interface ClassTypeDef extends TypeDef {
     }
 
     /**
+     * An interface may redeclare a public method of {@link Object} as abstract - {@code Comparator} does
+     * with {@code equals} - without that making it a second abstract method for the purpose of being a
+     * functional interface (JLS 9.8).
+     *
+     * @param name           The method name
+     * @param parameterTypes The parameter type names
+     * @return True if the method is a public method of {@link Object}
+     * @since 2.2
+     */
+    private static boolean isObjectMethod(String name, List<String> parameterTypes) {
+        return switch (name) {
+            case "equals" -> parameterTypes.equals(List.of(Object.class.getName()));
+            case "hashCode", "toString" -> parameterTypes.isEmpty();
+            default -> false;
+        };
+    }
+
+    /**
      * Find the method that can be represented as a lambda.
      *
      * @param resolvedTypeVariables The resolved type variables
@@ -880,10 +898,14 @@ public sealed interface ClassTypeDef extends TypeDef {
         @Override
         public LambdaDef getLambda(Function<String, @Nullable TypeDef> resolveVariableFn) {
             List<MethodElement> abstractMethods = classElement.getEnclosedElements(
-                ElementQuery.of(MethodElement.class).onlyAbstract());
+                    ElementQuery.of(MethodElement.class).onlyAbstract())
+                .stream()
+                .filter(m -> !isObjectMethod(m.getName(), Arrays.stream(m.getParameters()).map(ParameterElement::getType).map(ClassElement::getName).toList()))
+                .toList();
             if (abstractMethods.size() != 1) {
                 throw new IllegalArgumentException("Parent of a lambda should have exactly one " +
-                    "abstract method but has " + abstractMethods.size());
+                    "abstract method but has " + abstractMethods.size() + ": "
+                    + abstractMethods.stream().map(MethodElement::getName).toList());
             }
             MethodElement methodElement = abstractMethods.get(0);
             MethodDef build = MethodDef.builder(methodElement, resolveVariableFn).addTypeVariables(methodElement, resolveVariableFn).build();
@@ -970,10 +992,15 @@ public sealed interface ClassTypeDef extends TypeDef {
             List<MethodDef> methods = objectDef.getMethods()
                 .stream()
                 .filter(v -> v.getModifiers().contains(Modifier.ABSTRACT))
+                .filter(v -> !isObjectMethod(v.getName(), v.getParameters().stream()
+                    .map(ParameterDef::getType)
+                    .map(t -> t instanceof ClassTypeDef classTypeDef ? classTypeDef.getName() : t.toString())
+                    .toList()))
                 .toList();
             if (methods.size() != 1) {
                 throw new IllegalArgumentException("Parent of a lambda should have exactly one " +
-                    "abstract method but has " + methods.size());
+                    "abstract method but has " + methods.size() + ": "
+                    + methods.stream().map(MethodDef::getName).toList());
             }
             MethodDef methodDef = methods.get(0);
             return new LambdaDef(

--- a/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/LambdaTest.java
+++ b/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/LambdaTest.java
@@ -52,4 +52,13 @@ class LambdaTest {
         assertEquals("prefix_ello!", owner.callGenericLambdaAst("Hello!"));
     }
 
+
+    @Test
+    public void testComparatorLambdaAst() {
+        MyClassWithLambda owner = new MyClassWithLambda();
+        assertEquals(0, owner.compareAst("a", "a"));
+        assertEquals(-1, owner.compareAst("a", "b"));
+        assertEquals(1, owner.compareAst("b", "a"));
+    }
+
 }

--- a/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateLambdaVisitor.java
+++ b/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateLambdaVisitor.java
@@ -37,6 +37,7 @@ import io.micronaut.sourcegen.model.TypeDef;
 import io.micronaut.sourcegen.model.VariableDef.Local;
 
 import javax.lang.model.element.Modifier;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -95,6 +96,7 @@ public final class GenerateLambdaVisitor implements TypeElementVisitor<GenerateL
             .addMethod(createGenericLambda2(methodInvokerDef));
         if (context != null) {
             classDefBuilder.addMethod(createGenericLambdaAst(context));
+            classDefBuilder.addMethod(createComparatorLambdaAst(context));
         }
         ClassDef theClass = classDefBuilder
             .build();
@@ -265,6 +267,36 @@ public final class GenerateLambdaVisitor implements TypeElementVisitor<GenerateL
                 function.defineAndAssign(lambda),
                 function.invoke("apply", List.of(TypeDef.OBJECT), TypeDef.OBJECT, List.of(params.get(0)))
                     .cast(TypeDef.STRING).returning()
+            ));
+    }
+
+    // compareAst(String left, String right) {
+    //    Comparator<String> comparator = (arg0, arg1) -> arg0.compareTo(arg1);
+    //    return comparator.compare(left, right);
+    // }
+    //
+    // Comparator redeclares Object#equals as abstract; it must not count as a second abstract method
+    private static MethodDef createComparatorLambdaAst(VisitorContext context) {
+        ClassElement comparatorType = context.getClassElement(Comparator.class).orElseThrow();
+        Map<String, TypeDef> resolvedVariables = Map.of("T", TypeDef.STRING);
+
+        Local comparator = new Local("comparator", TypeDef.of(comparatorType).resolveTypeVariables(resolvedVariables));
+
+        Lambda lambda = ClassTypeDef.of(comparatorType)
+            .getLambda(resolvedVariables)
+            .implement((t, params) -> params.get(0)
+                .invoke("compareTo", TypeDef.Primitive.INT, params.get(1))
+                .returning());
+
+        return MethodDef.builder("compareAst")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(TypeDef.Primitive.INT)
+            .addParameter("left", TypeDef.STRING)
+            .addParameter("right", TypeDef.STRING)
+            .build((t, params) -> StatementDef.multi(
+                comparator.defineAndAssign(lambda),
+                comparator.invoke("compare", List.of(TypeDef.OBJECT, TypeDef.OBJECT), TypeDef.Primitive.INT, List.of(params.get(0), params.get(1)))
+                    .returning()
             ));
     }
 }

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/LambdaTest.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/LambdaTest.java
@@ -52,4 +52,13 @@ class LambdaTest {
         assertEquals("prefix_ello!", owner.callGenericLambdaAst("Hello!"));
     }
 
+
+    @Test
+    public void testComparatorLambdaAst() {
+        MyClassWithLambda owner = new MyClassWithLambda();
+        assertEquals(0, owner.compareAst("a", "a"));
+        assertEquals(-1, owner.compareAst("a", "b"));
+        assertEquals(1, owner.compareAst("b", "a"));
+    }
+
 }


### PR DESCRIPTION
Fixes #476.

## Problem

`ClassTypeDef.getLambda()` on a `ClassTypeDef.of(ClassElement)` requires exactly one abstract method, so it throws for a functional interface that redeclares a public method of `Object` as abstract. `java.util.Comparator` redeclares `equals(Object)`:

```
error: Failed to generate 'io.micronaut.sourcegen.example.MyClassWithLambda':
  Parent of a lambda should have exactly one abstract method but has 2
```

JLS §9.8 excludes the public methods of `Object` — `equals(Object)`, `hashCode()`, `toString()` — from the count.

## Fix

Both element-backed paths — `ClassElementType` (`of(ClassElement)`) and `ClassDefType` (a generated `InterfaceDef`) — now skip those three signatures. The error message also lists the abstract methods it found, so the next ambiguity is diagnosable.

This is the `ClassElement` counterpart of what #466 does for the reflective `of(Class)` path; the two touch different records and do not conflict.

## Tests

`GenerateLambdaVisitor` gains `compareAst`, which builds a `Comparator<String>` lambda from a **javac** `ClassElement` — the reflective `ClassElement.of(Class)` stub cannot enumerate methods, so this is tested through an annotation-processing round. `LambdaTest` in both `test-suite-java` and `test-suite-bytecode` invokes it. On `2.2.x` generation fails with the error above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)