### PR TITLE
Compute parameter slots in the LocalVariableTable from the method shape

### DIFF
--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
@@ -476,6 +476,8 @@ public final class ByteCodeWriter {
         Label startMethod = null;
 
         int parameterIndex = 0;
+        // The slot of a parameter: `this` takes slot 0 of an instance method, and a long or double takes two
+        int slot = methodDef.getModifiers().contains(Modifier.STATIC) ? 0 : 1;
         for (ParameterDef parameter : methodDef.getParameters()) {
             if (startMethod == null) {
                 startMethod = new Label();
@@ -484,16 +486,18 @@ public final class ByteCodeWriter {
                 AnnotationVisitor annotationVisitor = generatorAdapter.visitParameterAnnotation(parameterIndex, TypeUtils.getType(annotation.getType(), null).getDescriptor(), true);
                 visitAnnotation(annotation, annotationVisitor);
             }
+            Type parameterType = TypeUtils.getType(parameter.getType(), objectDef);
             MethodContext.LocalData prevParam = context.locals().put(parameter.getName(), new MethodContext.LocalData(
                 parameter.getName(),
-                TypeUtils.getType(parameter.getType(), objectDef),
+                parameterType,
                 startMethod,
-                parameterIndex + 1
+                slot
             ));
             if (prevParam != null) {
                 throw new IllegalStateException("Duplicate method parameter: " + parameter.getName() + " of method: " + methodDef.getName() + " " + (objectDef == null ? "" : objectDef.getName()));
             }
             parameterIndex++;
+            slot += parameterType.getSize();
         }
 
         List<StatementDef> statements = methodDef.getStatements();

--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
@@ -699,7 +699,7 @@ public class example/MyClassWithLambda {
     INVOKEVIRTUAL java/lang/String.substring (I)Ljava/lang/String;
     ARETURN
    L1
-    LOCALVARIABLE arg1 Ljava/lang/String; L0 L1 1
+    LOCALVARIABLE arg1 Ljava/lang/String; L0 L1 0
 
   // access flags 0x1
   public callStatefulLambda(Ljava/lang/String;)Ljava/lang/String;
@@ -749,9 +749,9 @@ public class example/MyClassWithLambda {
     INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
     ARETURN
    L1
-    LOCALVARIABLE constant Ljava/lang/String; L0 L1 1
-    LOCALVARIABLE this Lexample/MyClassWithLambda; L0 L1 2
-    LOCALVARIABLE arg1 Ljava/lang/String; L0 L1 3
+    LOCALVARIABLE constant Ljava/lang/String; L0 L1 0
+    LOCALVARIABLE this Lexample/MyClassWithLambda; L0 L1 1
+    LOCALVARIABLE arg1 Ljava/lang/String; L0 L1 2
 
   // access flags 0x1
   public callGenericLambda(Ljava/lang/String;)Ljava/lang/String;
@@ -795,8 +795,8 @@ public class example/MyClassWithLambda {
     INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
     ARETURN
    L1
-    LOCALVARIABLE constant Ljava/lang/String; L0 L1 1
-    LOCALVARIABLE arg0 Ljava/lang/String; L0 L1 2
+    LOCALVARIABLE constant Ljava/lang/String; L0 L1 0
+    LOCALVARIABLE arg0 Ljava/lang/String; L0 L1 1
 
   // access flags 0x1
   public callGenericLambda2(Ljava/lang/String;)Ljava/lang/String;
@@ -836,8 +836,8 @@ public class example/MyClassWithLambda {
     INVOKEVIRTUAL java/lang/StringBuilder.toString ()Ljava/lang/String;
     ARETURN
    L1
-    LOCALVARIABLE constant Ljava/lang/String; L0 L1 1
-    LOCALVARIABLE arg1 Ljava/lang/String; L0 L1 2
+    LOCALVARIABLE constant Ljava/lang/String; L0 L1 0
+    LOCALVARIABLE arg1 Ljava/lang/String; L0 L1 1
 }
 """, bytecode);
 
@@ -862,8 +862,8 @@ public class MyClassWithLambda {
       return function.apply(input);
    }
 
-   private static String lambda$callLambda$0(String var0) {
-      return var0.substring(1);
+   private static String lambda$callLambda$0(String arg1) {
+      return arg1.substring(1);
    }
 
    public String callStatefulLambda(String input) {
@@ -872,8 +872,8 @@ public class MyClassWithLambda {
       return function.apply(input);
    }
 
-   private static String lambda$callStatefulLambda$0(String var0, MyClassWithLambda constant, String var2) {
-      return var0 + ((String)var2).substring(1) + ((MyClassWithLambda)constant).toString() + constant.name;
+   private static String lambda$callStatefulLambda$0(String constant, MyClassWithLambda var1, String arg1) {
+      return constant + arg1.substring(1) + var1.toString() + var1.name;
    }
 
    public String callGenericLambda(String input) {
@@ -882,8 +882,8 @@ public class MyClassWithLambda {
       return (String)function.apply(input);
    }
 
-   private static String lambda$callGenericLambda$0(String var0, String constant) {
-      return var0 + constant.substring(1);
+   private static String lambda$callGenericLambda$0(String constant, String arg0) {
+      return constant + arg0.substring(1);
    }
 
    public String callGenericLambda2(String input) {
@@ -891,8 +891,8 @@ public class MyClassWithLambda {
       return this.methodInvoker(MyClassWithLambda::lambda$callGenericLambda2$0, input);
    }
 
-   private static String lambda$callGenericLambda2$0(String var0, String constant) {
-      return var0 + constant.substring(1);
+   private static String lambda$callGenericLambda2$0(String constant, String arg1) {
+      return constant + arg1.substring(1);
    }
 }
 """, decompileToJava(bytes));
@@ -1521,7 +1521,7 @@ public class example/Example {
     ARETURN
    L1
     LOCALVARIABLE arg1 D L0 L1 1
-    LOCALVARIABLE arg2 D L0 L1 2
+    LOCALVARIABLE arg2 D L0 L1 3
 }
 """, bytecode);
 
@@ -1529,8 +1529,8 @@ public class example/Example {
 package example;
 
 public class Example {
-   Object myMethod(double arg1, double var3) {
-      return (long)Math.pow(arg1, var3);
+   Object myMethod(double arg1, double arg2) {
+      return (long)Math.pow(arg1, arg2);
    }
 }
 """, decompileToJava(bytes));
@@ -1918,7 +1918,7 @@ public class example/Example {
     LOCALVARIABLE arg3 F L0 L1 3
     LOCALVARIABLE arg4 F L0 L1 4
     LOCALVARIABLE arg5 D L0 L1 5
-    LOCALVARIABLE arg6 D L0 L1 6
+    LOCALVARIABLE arg6 D L0 L1 7
 }
 """, bytecode);
 
@@ -1926,8 +1926,8 @@ public class example/Example {
 package example;
 
 public class Example {
-   Object[] myMethod(int arg1, int arg2, float arg3, float arg4, double arg5, double var7) {
-      return new Object[]{arg1 + arg2, arg3 + arg4, arg5 + var7};
+   Object[] myMethod(int arg1, int arg2, float arg3, float arg4, double arg5, double arg6) {
+      return new Object[]{arg1 + arg2, arg3 + arg4, arg5 + arg6};
    }
 }
 """, decompileToJava(bytes));
@@ -2623,7 +2623,7 @@ final enum MyEnum extends java/lang/Enum {
     CHECKCAST MyEnum
     ARETURN
    L1
-    LOCALVARIABLE value Ljava/lang/String; L0 L1 1
+    LOCALVARIABLE value Ljava/lang/String; L0 L1 0
 }
 """, bytecode);
     }
@@ -3361,7 +3361,7 @@ public final enum example/MyEnumWithInnerTypes extends java/lang/Enum {
     CHECKCAST example/MyEnumWithInnerTypes
     ARETURN
    L1
-    LOCALVARIABLE value Ljava/lang/String; L0 L1 1
+    LOCALVARIABLE value Ljava/lang/String; L0 L1 0
 
   // access flags 0x1
   public myName()Ljava/lang/String;
@@ -4163,13 +4163,11 @@ public class MyClass {
       return items.filter(MyClass::lambda$evaluate$0);
    }
 
-   private static boolean lambda$evaluate$0(Object var0, Object context) {
-      return Objects.equals(var0, context);
+   private static boolean lambda$evaluate$0(Object context, Object item) {
+      return Objects.equals(context, item);
    }
 }
 """, decompileToJava(bytes));
-        // The captured parameter is the first argument of the synthetic method; the local variable names
-        // the decompiler shows are shifted by one, which is a separate defect of the debug information
     }
 
     @Test
@@ -4212,8 +4210,8 @@ public class MyClass {
       items.forEach(MyClass::lambda$printAll$0);
    }
 
-   private static void lambda$printAll$0(Object var0) {
-      System.out.println(var0);
+   private static void lambda$printAll$0(Object item) {
+      System.out.println(item);
    }
 }
 """, decompileToJava(bytes));


### PR DESCRIPTION
Fixes #481.

## Problem

`ByteCodeWriter` registers every parameter's local-variable slot as `parameterIndex + 1`. That is only right for an instance method whose preceding parameters are all single-slot: a **static** method starts at slot 0, and a `long` or `double` takes two slots.

Execution is unaffected — parameters are loaded by argument index, not through this table — but the `LocalVariableTable` names the wrong slots, which is visible as soon as anything reads the debug information. Every synthetic lambda method is static, so every lambda is affected. Decompiling the existing `lambda()` golden gave:

```java
private static String lambda$callGenericLambda$0(String var0, String constant) {
   return var0 + constant.substring(1);
}
```

## Fix

Start at slot 0 for a static method and 1 otherwise, and advance by `Type.getSize()` — two for `long`/`double`.

## Tests

No new test: the existing goldens already encode the defect, and every change in this PR is one of two kinds — a `LOCALVARIABLE` line moving to its correct slot (`mathOpsCast2`, `math`, `testEnum`, `testInnerEnum`, `lambda`), or a decompiled block whose locals regain their names:

```java
-   Object myMethod(double arg1, double var3) {
+   Object myMethod(double arg1, double arg2) {
-   private static String lambda$callGenericLambda$0(String var0, String constant) {
+   private static String lambda$callGenericLambda$0(String constant, String arg1) {
```

The decompiled goldens added by #470 and #468 currently encode the shifted names too; they will change the same way once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)