### PR TITLE
Skip the test suites in the Sonar analysis

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.sourcegen-testsuite.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.sourcegen-testsuite.gradle
@@ -21,3 +21,14 @@ repositories {
 dependencies {
     testRuntimeOnly(mnTest.junit.platform.suite)
 }
+
+// The test suites are fixtures: the generator visitors in their main sources run inside the annotation
+// processor of the suites that use them, where no coverage agent runs, so analysing them only reports
+// uncovered code. They are already left out of the aggregate coverage report for the same reason.
+// The extension is added by the root project after the subprojects are evaluated.
+gradle.projectsEvaluated {
+    def sonar = extensions.findByName("sonar")
+    if (sonar != null) {
+        sonar.skipProject = true
+    }
+}


### PR DESCRIPTION
## Problem

The test-suite modules are fixtures. The generator visitors in `test-suite-custom-generators/src/main` run *inside the annotation processor* of the suites that use them, where no JaCoCo agent is attached, so nothing can ever report them as covered. #469 already dropped the suites from the aggregate coverage report for that reason — but Sonar still analyses them, and a pull request that adds a fixture fails the quality gate on "new code coverage" no matter how well the product change is tested.

Concretely, #477 fixes one line in `StringConcatenationExpressionWriter` (covered), adds eight lines to `GenerateMyBean3Visitor` (fixture, uncoverable) and two runtime tests that load and invoke the generated class in both suites. Sonar reports **11.1 %** new coverage and fails the gate. #479 and #480 fail the same way.

## Fix

`sonar.skipProject = true` for every project using the `sourcegen-testsuite` convention plugin. The hook is `gradle.projectsEvaluated`, because the root project adds the `sonar` extension after the subprojects have been evaluated — an `afterEvaluate` in the subproject runs too early and finds nothing.

Verified with `./gradlew sonar -Dsonar.scanner.internal.dumpToFile=…`: `sonar.modules` goes from 14 entries to the 8 product modules.

The three PRs above need a re-analysis after this lands to turn their gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)