### PR TITLE
Add missing parentheses for nested conditionals and casts of negative values

### DIFF
--- a/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
+++ b/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
@@ -1027,8 +1027,13 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
                 );
             }
             case ExpressionDef.IfElse condition -> {
+                CodeBlock conditionBlock = renderExpression(objectDef, methodDef, scope, condition.condition());
+                if (unwrapCasts(condition.condition()) instanceof ExpressionDef.IfElse) {
+                    // `?:` is right-associative, a conditional used as a condition needs parentheses
+                    conditionBlock = addParentheses(conditionBlock);
+                }
                 return CodeBlock.concat(
-                    renderExpression(objectDef, methodDef, scope, condition.condition()),
+                    conditionBlock,
                     CodeBlock.of(" ? "),
                     renderExpression(objectDef, methodDef, scope, condition.ifExpression()),
                     CodeBlock.of(" : "),
@@ -1263,8 +1268,17 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
         return expressionDef instanceof ExpressionDef.ConditionExpressionDef
             || expressionDef instanceof ExpressionDef.IfElse
             || expressionDef instanceof ExpressionDef.MathBinaryOperation
+            || expressionDef instanceof ExpressionDef.MathUnaryOperation
             || expressionDef instanceof ExpressionDef.StringConcatenation
-            || expressionDef instanceof ExpressionDef.Switch;
+            || expressionDef instanceof ExpressionDef.Switch
+            || isNegativeNumericConstant(expressionDef);
+    }
+
+    private static boolean isNegativeNumericConstant(ExpressionDef expressionDef) {
+        // `(Object) -1` would parse as a subtraction of the variable `Object`
+        return expressionDef instanceof ExpressionDef.Constant constant
+            && constant.value() instanceof Number number
+            && number.toString().startsWith("-");
     }
 
     private static boolean requiresMethodCallTargetParentheses(ExpressionDef expressionDef) {

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
@@ -1221,6 +1221,58 @@ public class Example {
     }
 
     @Test
+    void returnIfElseWithIfElseConditionParentheses() throws IOException {
+        ExpressionDef expression = new ExpressionDef.IfElse(
+            new ExpressionDef.IfElse(ExpressionDef.constant(true), ExpressionDef.constant(false), ExpressionDef.constant(false)),
+            ExpressionDef.constant("yes"),
+            ExpressionDef.constant("no")
+        );
+        String result = writeMethodWithExpression(expression);
+
+        assertEquals("(true ? false : false) ? \"yes\" : \"no\"", result);
+    }
+
+    @Test
+    void returnIfElseWithIfElseElseBranchWithoutParentheses() throws IOException {
+        ExpressionDef expression = new ExpressionDef.IfElse(
+            ExpressionDef.constant(true),
+            ExpressionDef.constant("a"),
+            new ExpressionDef.IfElse(ExpressionDef.constant(false), ExpressionDef.constant("b"), ExpressionDef.constant("c"))
+        );
+        String result = writeMethodWithExpression(expression);
+
+        assertEquals("true ? \"a\" : false ? \"b\" : \"c\"", result);
+    }
+
+    @Test
+    void returnCastedNegativeConstantWithParentheses() throws IOException {
+        ExpressionDef castedExpression = ExpressionDef.constant(-1L)
+            .cast(TypeDef.OBJECT);
+        String result = writeMethodWithExpression(castedExpression);
+
+        assertEquals("(Object) (-1l)", result);
+    }
+
+    @Test
+    void returnCastedNegatedValueWithParentheses() throws IOException {
+        ExpressionDef castedExpression = ExpressionDef.constant(1L)
+            .math(NEGATE)
+            .cast(TypeDef.OBJECT);
+        String result = writeMethodWithExpression(castedExpression);
+
+        assertEquals("(Object) (-1l)", result);
+    }
+
+    @Test
+    void returnPrimitiveCastedNegativeConstantWithParentheses() throws IOException {
+        ExpressionDef castedExpression = ExpressionDef.constant(-1)
+            .cast(TypeDef.Primitive.LONG);
+        String result = writeMethodWithExpression(castedExpression);
+
+        assertEquals("(long) (-1)", result);
+    }
+
+    @Test
     void returnCastedMathOperationWithParentheses() throws IOException {
         ExpressionDef castedExpression = ExpressionDef.constant(1)
             .math(ADDITION, ExpressionDef.constant(2))


### PR DESCRIPTION
Fixes the two missing-parentheses shapes in the Java source writer reported in #478:

1. **A conditional used as the condition of another conditional** now renders in parentheses. `?:` is right-associative, so `a ? b : false ? true : c` parses as a different expression than the model describes; the writer now emits `(a ? b : false) ? true : c`. A nested conditional in the *else* branch is left untouched, since right-associativity already matches the model there.

2. **A cast of a unary negation or a negative numeric constant** now parenthesizes the operand: `(Object) (-1l)` instead of `(Object) -1l`, which javac parses as the subtraction `Object - 1l`. `requiresCastOperandParentheses` now includes `MathUnaryOperation` and negative numeric `Constant`s (detection via `Number.toString()`, which also covers `-0.0`). Primitive casts get the same treatment (`(long) (-1)`) — harmless, and keeps the check independent of the cast target type.

Deliberately did not switch the conditional's condition to `renderExpressionWithParentheses`, which would have wrapped every comparison condition (`(a == b) ? ...`) and churned existing output; only the nested-conditional case is actually ambiguous.

Fixes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)