### PR TITLE
Bring the Kotlin writer up to the Java writer

### DIFF
--- a/sourcegen-generator-kotlin/build.gradle.kts
+++ b/sourcegen-generator-kotlin/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     implementation(libs.managed.kotlinpoet)
     implementation(libs.managed.kotlinpoet.javapoet)
 
+    testImplementation(projects.testSuiteCustomGenerators)
     testImplementation(mnTest.micronaut.test.junit5)
 
     testRuntimeOnly(mnTest.junit.jupiter.engine)

--- a/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
+++ b/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
@@ -863,7 +863,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                     "float" -> com.squareup.javapoet.TypeName.FLOAT.toKTypeName()
                     "double" -> com.squareup.javapoet.TypeName.DOUBLE.toKTypeName()
                     "boolean" -> com.squareup.javapoet.TypeName.BOOLEAN.toKTypeName()
-                    else -> throw IllegalStateException("Unrecognized primitive name: " + typeDef.name())
+                    else -> unrecognizedPrimitive(typeDef.name())
                 }
             } else if (typeDef is ClassTypeDef) {
                 asClassName(typeDef)
@@ -969,7 +969,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 "float" -> "kotlin.FloatArray"
                 "double" -> "kotlin.DoubleArray"
                 "boolean" -> "kotlin.BooleanArray"
-                else -> throw IllegalStateException("Unrecognized primitive name: " + componentType.name())
+                else -> unrecognizedPrimitive(componentType.name())
             }
         }
 
@@ -990,7 +990,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 "float" -> "floatArrayOf"
                 "double" -> "doubleArrayOf"
                 "boolean" -> "booleanArrayOf"
-                else -> throw IllegalStateException("Unrecognized primitive name: " + componentType.name())
+                else -> unrecognizedPrimitive(componentType.name())
             }
         }
 
@@ -1009,30 +1009,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 return builder.build()
             }
             if (statementDef is StatementDef.Try) {
-                val builder: CodeBlock.Builder = CodeBlock.builder()
-                builder.add("try {\n")
-                builder.indent()
-                builder.add(renderStatementCodeBlock(objectDef, methodDef, scope, statementDef.statement()))
-                builder.unindent()
-                for (aCatch in statementDef.catches()) {
-                    // Kotlin warns about shadowing, so a nested catch gets a name of its own
-                    val exceptionLocal = scope.allocate(EXCEPTION_NAME)
-                    builder.add("} catch (%L: %T) {\n", exceptionLocal, asType(aCatch.exception(), objectDef))
-                    builder.indent()
-                    val catchScope = scope.nested(null)
-                    catchScope.rename(EXCEPTION_NAME, exceptionLocal)
-                    builder.add(renderStatementCodeBlock(objectDef, methodDef, catchScope, aCatch.statement()))
-                    builder.unindent()
-                }
-                val finallyStatement = statementDef.finallyStatement()
-                if (finallyStatement != null) {
-                    builder.add("} finally {\n")
-                    builder.indent()
-                    builder.add(renderStatementCodeBlock(objectDef, methodDef, scope, finallyStatement))
-                    builder.unindent()
-                }
-                builder.add("}\n")
-                return builder.build()
+                return renderTry(objectDef, methodDef, scope, statementDef)
             }
             if (statementDef is StatementDef.Synchronized) {
                 val builder: CodeBlock.Builder = CodeBlock.builder()
@@ -1073,30 +1050,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 return builder.build()
             }
             if (statementDef is StatementDef.Switch) {
-                val builder: CodeBlock.Builder =
-                    CodeBlock.builder()
-                builder.add("when (")
-                builder.add(renderExpressionCode(objectDef, methodDef, scope, statementDef.expression))
-                builder.add(") {\n")
-                builder.indent()
-                for ((key, statement) in statementDef.cases) {
-                    builder.add(renderConstantExpression(key, methodDef, scope))
-                    builder.add("-> {\n")
-                    builder.indent()
-                    builder.add(renderStatementCodeBlock(objectDef, methodDef, scope, statement))
-                    builder.unindent()
-                    builder.add("}\n")
-                }
-                if (statementDef.defaultCase != null) {
-                    builder.add("else -> {\n")
-                    builder.indent()
-                    builder.add(renderStatementCodeBlock(objectDef, methodDef, scope, statementDef.defaultCase))
-                    builder.unindent()
-                    builder.add("}\n")
-                }
-                builder.unindent()
-                builder.add("}\n")
-                return builder.build()
+                return renderSwitchStatement(objectDef, methodDef, scope, statementDef)
             }
             if (statementDef is While) {
                 val builder: CodeBlock.Builder =
@@ -1113,6 +1067,69 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             return CodeBlock.builder()
                 .addStatement("%L", renderStatement(objectDef, methodDef, scope, statementDef))
                 .build()
+        }
+
+        private fun renderTry(
+            objectDef: @Nullable ObjectDef?,
+            methodDef: MethodDef,
+            scope: RenderScope,
+            statementDef: StatementDef.Try
+        ): CodeBlock {
+            val builder: CodeBlock.Builder = CodeBlock.builder()
+            builder.add("try {\n")
+            builder.indent()
+            builder.add(renderStatementCodeBlock(objectDef, methodDef, scope, statementDef.statement()))
+            builder.unindent()
+            for (aCatch in statementDef.catches()) {
+                // Kotlin warns about shadowing, so a nested catch gets a name of its own
+                val exceptionLocal = scope.allocate(EXCEPTION_NAME)
+                builder.add("} catch (%L: %T) {\n", exceptionLocal, asType(aCatch.exception(), objectDef))
+                builder.indent()
+                val catchScope = scope.nested(null)
+                catchScope.rename(EXCEPTION_NAME, exceptionLocal)
+                builder.add(renderStatementCodeBlock(objectDef, methodDef, catchScope, aCatch.statement()))
+                builder.unindent()
+            }
+            val finallyStatement = statementDef.finallyStatement()
+            if (finallyStatement != null) {
+                builder.add("} finally {\n")
+                builder.indent()
+                builder.add(renderStatementCodeBlock(objectDef, methodDef, scope, finallyStatement))
+                builder.unindent()
+            }
+            builder.add("}\n")
+            return builder.build()
+        }
+
+        private fun renderSwitchStatement(
+            objectDef: @Nullable ObjectDef?,
+            methodDef: MethodDef,
+            scope: RenderScope,
+            statementDef: StatementDef.Switch
+        ): CodeBlock {
+            val builder: CodeBlock.Builder = CodeBlock.builder()
+            builder.add("when (")
+            builder.add(renderExpressionCode(objectDef, methodDef, scope, statementDef.expression))
+            builder.add(") {\n")
+            builder.indent()
+            for ((key, statement) in statementDef.cases) {
+                builder.add(renderConstantExpression(key, methodDef, scope))
+                builder.add("-> {\n")
+                builder.indent()
+                builder.add(renderStatementCodeBlock(objectDef, methodDef, scope, statement))
+                builder.unindent()
+                builder.add("}\n")
+            }
+            if (statementDef.defaultCase != null) {
+                builder.add("else -> {\n")
+                builder.indent()
+                builder.add(renderStatementCodeBlock(objectDef, methodDef, scope, statementDef.defaultCase))
+                builder.unindent()
+                builder.add("}\n")
+            }
+            builder.unindent()
+            builder.add("}\n")
+            return builder.build()
         }
 
         private fun renderStatement(
@@ -1910,6 +1927,13 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             }
         }
 
+        /**
+         * @param name The primitive name that no lookup recognized
+         * @return Never, the name is not a primitive
+         */
+        private fun unrecognizedPrimitive(name: String): Nothing =
+            error("Unrecognized primitive name: $name")
+
         private fun numberConversion(name: String): String {
             return when (name) {
                 "byte" -> ".toByte()"
@@ -1918,7 +1942,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 "long" -> ".toLong()"
                 "float" -> ".toFloat()"
                 "double" -> ".toDouble()"
-                else -> throw IllegalStateException("Unrecognized primitive name: $name")
+                else -> unrecognizedPrimitive(name)
             }
         }
 
@@ -2063,7 +2087,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             return when (value) {
                 is Char -> value
                 is Number -> value.toInt().toChar()
-                else -> throw IllegalStateException("Expected a character constant; got: $value")
+                else -> error("Expected a character constant; got: $value")
             }
         }
 

--- a/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
+++ b/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
@@ -74,10 +74,75 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 writeEnumDef(writer, objectDef)
             }
 
+            is AnnotationObjectDef -> {
+                writeAnnotationObject(writer, objectDef)
+            }
+
             else -> {
                 throw IllegalStateException("Unknown object definition: $objectDef")
             }
         }
+    }
+
+    @Throws(IOException::class)
+    private fun writeAnnotationObject(writer: Writer, annotationDef: AnnotationObjectDef) {
+        FileSpec.builder(annotationDef.packageName, annotationDef.simpleName + ".kt")
+            .addType(getAnnotationObjectBuilder(annotationDef).build())
+            .build()
+            .writeTo(writer)
+    }
+
+    private fun getAnnotationObjectBuilder(def: AnnotationObjectDef): TypeSpec.Builder {
+        val builder = TypeSpec.annotationBuilder(def.simpleName)
+        builder.addModifiers(asKModifiers(def.modifiers))
+        def.javadoc.forEach(Consumer { format: String -> builder.addKdoc(format) })
+        for (annotation in def.annotations) {
+            builder.addAnnotation(asAnnotationSpec(annotation))
+        }
+        // A Kotlin annotation member is a constructor property, its default is the parameter default
+        if (def.members.isNotEmpty()) {
+            val constructor = FunSpec.constructorBuilder()
+            for (member in def.members) {
+                val memberType = asType(member.type, def)
+                val parameter = ParameterSpec.builder(member.name, memberType)
+                for (annotation in member.annotations) {
+                    parameter.addAnnotation(asAnnotationSpec(annotation))
+                }
+                renderAnnotationMemberDefault(def, member)?.let(parameter::defaultValue)
+                constructor.addParameter(parameter.build())
+
+                val property = PropertySpec.builder(member.name, memberType)
+                    .initializer(member.name)
+                member.javadoc.forEach(Consumer { format: String -> property.addKdoc(format) })
+                builder.addProperty(property.build())
+            }
+            builder.primaryConstructor(constructor.build())
+        }
+        var companionBuilder: TypeSpec.Builder? = null
+        for (field in def.fields) {
+            if (companionBuilder == null) {
+                companionBuilder = TypeSpec.companionObjectBuilder()
+            }
+            companionBuilder.addProperty(
+                buildProperty(field, stripStatic(field.modifiers), field.javadoc, def)
+            )
+        }
+        companionBuilder?.let { builder.addType(it.build()) }
+        addInnerTypes(def.innerTypes, builder)
+        return builder
+    }
+
+    private fun renderAnnotationMemberDefault(
+        def: AnnotationObjectDef,
+        member: AnnotationObjectDef.AnnotationMemberDef
+    ): CodeBlock? {
+        member.annotationDefaultValue?.let {
+            // A nested annotation default is a constructor call, not an annotation use
+            return CodeBlock.of("%L", asAnnotationSpec(it).toString().substring(1))
+        }
+        val defaultValue = member.defaultValue ?: return null
+        val init = MethodDef.builder(member.name).returns(member.type).build()
+        return renderExpressionCode(def, init, RenderScope.root(init), defaultValue)
     }
 
     @Throws(IOException::class)
@@ -188,11 +253,12 @@ class KotlinPoetSourceGenerator : SourceGenerator {
         companionBuilder = buildFields(classDef, companionBuilder, classBuilder)
 
         classDef.staticInitializer?.let { staticInitializerDef ->
+            val clinit = MethodDef.builder("<clinit>").build()
             val currentCompanion = companionBuilder ?: TypeSpec.companionObjectBuilder().also {
                 companionBuilder = it
             }
             currentCompanion.addInitializerBlock(
-                renderStatementCodeBlock(classDef, MethodDef.builder("<clinit>").build(), staticInitializerDef)
+                renderStatementCodeBlock(classDef, clinit, RenderScope.root(clinit), staticInitializerDef)
             )
         }
 
@@ -216,7 +282,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 if (superCallStatement2 != null) {
                     val superArgsCodeBlock = CodeBlock.builder()
                     for ((index, arg) in superCallStatement2.values.withIndex()) {
-                        superArgsCodeBlock.add(renderExpressionCode(classDef, method, arg))
+                        superArgsCodeBlock.add(renderExpressionCode(classDef, method, RenderScope.root(method), arg))
                         if (index < superCallStatement2.values.size - 1) {
                             superArgsCodeBlock.add(", ")
                         }
@@ -237,7 +303,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 } else if (superCallStatement != null) {
                     val superArgsCodeBlock = CodeBlock.builder()
                     for ((index, arg) in superCallStatement.values.withIndex()) {
-                        superArgsCodeBlock.add(renderExpressionCode(classDef, method, arg))
+                        superArgsCodeBlock.add(renderExpressionCode(classDef, method, RenderScope.root(method), arg))
                         if (index < superCallStatement.values.size - 1) {
                             superArgsCodeBlock.add(", ")
                         }
@@ -372,10 +438,16 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             if (enumConstant.constructorArgs != null && enumConstant.constructorArgs.isNotEmpty()) {
                 val exps = enumConstant.constructorArgs
                 val expBuilder: CodeBlock.Builder = CodeBlock.builder()
+                val constantInit = MethodDef.builder("").returns(TypeDef.VOID).build()
                 for (i in exps.indices) {
-                    expBuilder.add(renderExpressionCode(null,
-                        MethodDef.builder("").returns(TypeDef.VOID).build(),
-                        exps[i]))
+                    expBuilder.add(
+                        renderExpressionCode(
+                            null,
+                            constantInit,
+                            RenderScope.root(constantInit),
+                            exps[i]
+                        )
+                    )
                     if (i < exps.size - 1) {
                         expBuilder.add(", ")
                     }
@@ -436,6 +508,10 @@ class KotlinPoetSourceGenerator : SourceGenerator {
 
                 is EnumDef -> {
                     innerBuilder = getEnumBuilder(objectDef)
+                }
+
+                is AnnotationObjectDef -> {
+                    innerBuilder = getAnnotationObjectBuilder(objectDef)
                 }
 
                 else -> {
@@ -557,15 +633,11 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             )
         }
         if (initializer != null) {
-            if (initializer is Constant) {
-                propertyBuilder.initializer(
-                    CodeBlock.of(
-                        "%L", initializer.value
-                    )
-                )
-            }
-        }
-        if (typeDef.isNullable) {
+            val init = MethodDef.builder(name).returns(typeDef).build()
+            propertyBuilder.initializer(
+                renderExpressionCode(objectDef, init, RenderScope.root(init), initializer, typeDef)
+            )
+        } else if (typeDef.isNullable) {
             propertyBuilder.initializer("null")
         }
         return propertyBuilder.build()
@@ -651,14 +723,32 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                     .build(),
             )
         }
+        val scope = RenderScope.root(method)
         method.statements.stream()
-            .map { st: StatementDef -> renderStatementCodeBlock(objectDef, method, st) }
+            .map { st: StatementDef -> renderStatementCodeBlock(objectDef, method, scope, st) }
             .forEach(funBuilder::addCode)
         method.javadoc.forEach(Consumer { format: String -> funBuilder.addKdoc(format) })
         return funBuilder.build()
     }
 
     companion object {
+        private const val EXCEPTION_NAME = "e"
+
+        private val FLOAT = ClassName("kotlin", "Float")
+
+        private val DOUBLE = ClassName("kotlin", "Double")
+
+        private val BOXED_NUMBERS = setOf(
+            "java.lang.Byte",
+            "java.lang.Short",
+            "java.lang.Character",
+            "java.lang.Integer",
+            "java.lang.Long",
+            "java.lang.Float",
+            "java.lang.Double",
+            "java.lang.Number"
+        )
+
         private fun stripStatic(modifiers: MutableSet<Modifier>): MutableSet<Modifier> {
             val mutable = HashSet(modifiers)
             mutable.remove(Modifier.STATIC)
@@ -698,6 +788,22 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 return asNullable(result) as ClassName
             }
             return result
+        }
+
+        /**
+         * The owner of a static call. A Java type that Kotlin maps onto one of its own, such as
+         * `java.lang.String`, keeps its Java name here - the mapped Kotlin type does not declare the
+         * static members, so `String.valueOf` has to be spelled `java.lang.String.valueOf`.
+         *
+         * @param classType The declaring type
+         * @return The name to call the static member on
+         */
+        private fun asStaticOwnerName(classType: ClassTypeDef): ClassName {
+            val mapped = asClassName(classType)
+            if (classType.isInner || mapped.canonicalName == classType.canonicalName) {
+                return mapped
+            }
+            return ClassName(classType.packageName, classType.simpleName)
         }
 
         private fun asNullable(kClassName: TypeName): TypeName {
@@ -835,36 +941,118 @@ class KotlinPoetSourceGenerator : SourceGenerator {
         }
 
         private fun asArray(classType: TypeDef.Array, objectDef: ObjectDef?): TypeName {
-            var newDef = ClassTypeDef.Parameterized(
-                ClassTypeDef.of("kotlin.Array"), listOf(classType.componentType)
-            )
+            val componentType = classType.componentType
+            // Kotlin has a dedicated type per primitive array, Array<Int> is an Integer[]
+            val primitiveArray = primitiveArrayType(componentType)
+            var newDef: TypeDef = primitiveArray?.let { ClassTypeDef.of(it) }
+                ?: ClassTypeDef.Parameterized(ClassTypeDef.of("kotlin.Array"), listOf(componentType))
             for (i in 2..classType.dimensions) {
                 newDef = ClassTypeDef.Parameterized(ClassTypeDef.of("kotlin.Array"), listOf(newDef))
             }
             return asType(newDef, objectDef)
         }
 
+        /**
+         * @param componentType The component of an array
+         * @return The Kotlin type of an array of that component, or null if it is not a primitive
+         */
+        private fun primitiveArrayType(componentType: TypeDef): String? {
+            if (componentType !is TypeDef.Primitive) {
+                return null
+            }
+            return when (componentType.name()) {
+                "byte" -> "kotlin.ByteArray"
+                "short" -> "kotlin.ShortArray"
+                "char" -> "kotlin.CharArray"
+                "int" -> "kotlin.IntArray"
+                "long" -> "kotlin.LongArray"
+                "float" -> "kotlin.FloatArray"
+                "double" -> "kotlin.DoubleArray"
+                "boolean" -> "kotlin.BooleanArray"
+                else -> throw IllegalStateException("Unrecognized primitive name: " + componentType.name())
+            }
+        }
+
+        /**
+         * @param componentType The component of an array
+         * @return The factory function creating an array of that component
+         */
+        private fun arrayOfFunction(componentType: TypeDef): String {
+            if (componentType !is TypeDef.Primitive) {
+                return "arrayOf"
+            }
+            return when (componentType.name()) {
+                "byte" -> "byteArrayOf"
+                "short" -> "shortArrayOf"
+                "char" -> "charArrayOf"
+                "int" -> "intArrayOf"
+                "long" -> "longArrayOf"
+                "float" -> "floatArrayOf"
+                "double" -> "doubleArrayOf"
+                "boolean" -> "booleanArrayOf"
+                else -> throw IllegalStateException("Unrecognized primitive name: " + componentType.name())
+            }
+        }
+
         private fun renderStatementCodeBlock(
             objectDef: @Nullable ObjectDef?,
             methodDef: MethodDef,
+            scope: RenderScope,
             statementDef: StatementDef?
         ): CodeBlock {
             if (statementDef is Multi) {
                 val builder: CodeBlock.Builder =
                     CodeBlock.builder()
                 for (statement in statementDef.statements) {
-                    builder.add(renderStatementCodeBlock(objectDef, methodDef, statement))
+                    builder.add(renderStatementCodeBlock(objectDef, methodDef, scope, statement))
                 }
+                return builder.build()
+            }
+            if (statementDef is StatementDef.Try) {
+                val builder: CodeBlock.Builder = CodeBlock.builder()
+                builder.add("try {\n")
+                builder.indent()
+                builder.add(renderStatementCodeBlock(objectDef, methodDef, scope, statementDef.statement()))
+                builder.unindent()
+                for (aCatch in statementDef.catches()) {
+                    // Kotlin warns about shadowing, so a nested catch gets a name of its own
+                    val exceptionLocal = scope.allocate(EXCEPTION_NAME)
+                    builder.add("} catch (%L: %T) {\n", exceptionLocal, asType(aCatch.exception(), objectDef))
+                    builder.indent()
+                    val catchScope = scope.nested(null)
+                    catchScope.rename(EXCEPTION_NAME, exceptionLocal)
+                    builder.add(renderStatementCodeBlock(objectDef, methodDef, catchScope, aCatch.statement()))
+                    builder.unindent()
+                }
+                val finallyStatement = statementDef.finallyStatement()
+                if (finallyStatement != null) {
+                    builder.add("} finally {\n")
+                    builder.indent()
+                    builder.add(renderStatementCodeBlock(objectDef, methodDef, scope, finallyStatement))
+                    builder.unindent()
+                }
+                builder.add("}\n")
+                return builder.build()
+            }
+            if (statementDef is StatementDef.Synchronized) {
+                val builder: CodeBlock.Builder = CodeBlock.builder()
+                builder.add("synchronized(")
+                builder.add(renderExpressionCode(objectDef, methodDef, scope, statementDef.monitor(), true))
+                builder.add(") {\n")
+                builder.indent()
+                builder.add(renderStatementCodeBlock(objectDef, methodDef, scope, statementDef.statement()))
+                builder.unindent()
+                builder.add("}\n")
                 return builder.build()
             }
             if (statementDef is StatementDef.If) {
                 val builder: CodeBlock.Builder =
                     CodeBlock.builder()
                 builder.add("if (")
-                builder.add(renderExpressionCode(objectDef, methodDef, statementDef.condition))
+                builder.add(renderExpressionCode(objectDef, methodDef, scope, statementDef.condition))
                 builder.add(") {\n")
                 builder.indent()
-                builder.add(renderStatementCodeBlock(objectDef, methodDef, statementDef.statement))
+                builder.add(renderStatementCodeBlock(objectDef, methodDef, scope, statementDef.statement))
                 builder.unindent()
                 builder.add("}\n")
                 return builder.build()
@@ -872,14 +1060,14 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             if (statementDef is StatementDef.IfElse) {
                 val builder: CodeBlock.Builder = CodeBlock.builder()
                 builder.add("if (")
-                builder.add(renderExpressionCode(objectDef, methodDef, statementDef.condition))
+                builder.add(renderExpressionCode(objectDef, methodDef, scope, statementDef.condition))
                 builder.add(") {\n")
                 builder.indent()
-                builder.add(renderStatementCodeBlock(objectDef, methodDef, statementDef.statement))
+                builder.add(renderStatementCodeBlock(objectDef, methodDef, scope, statementDef.statement))
                 builder.unindent()
                 builder.add("} else {\n")
                 builder.indent()
-                builder.add(renderStatementCodeBlock(objectDef, methodDef, statementDef.elseStatement))
+                builder.add(renderStatementCodeBlock(objectDef, methodDef, scope, statementDef.elseStatement))
                 builder.unindent()
                 builder.add("}\n")
                 return builder.build()
@@ -888,21 +1076,21 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 val builder: CodeBlock.Builder =
                     CodeBlock.builder()
                 builder.add("when (")
-                builder.add(renderExpressionCode(objectDef, methodDef, statementDef.expression))
+                builder.add(renderExpressionCode(objectDef, methodDef, scope, statementDef.expression))
                 builder.add(") {\n")
                 builder.indent()
                 for ((key, statement) in statementDef.cases) {
-                    builder.add(renderConstantExpression(key, methodDef))
+                    builder.add(renderConstantExpression(key, methodDef, scope))
                     builder.add("-> {\n")
                     builder.indent()
-                    builder.add(renderStatementCodeBlock(objectDef, methodDef, statement))
+                    builder.add(renderStatementCodeBlock(objectDef, methodDef, scope, statement))
                     builder.unindent()
                     builder.add("}\n")
                 }
                 if (statementDef.defaultCase != null) {
                     builder.add("else -> {\n")
                     builder.indent()
-                    builder.add(renderStatementCodeBlock(objectDef, methodDef, statementDef.defaultCase))
+                    builder.add(renderStatementCodeBlock(objectDef, methodDef, scope, statementDef.defaultCase))
                     builder.unindent()
                     builder.add("}\n")
                 }
@@ -914,31 +1102,32 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 val builder: CodeBlock.Builder =
                     CodeBlock.builder()
                 builder.add("while (")
-                builder.add(renderExpressionCode(objectDef, methodDef, statementDef.expression))
+                builder.add(renderExpressionCode(objectDef, methodDef, scope, statementDef.expression))
                 builder.add(") {\n")
                 builder.indent()
-                builder.add(renderStatementCodeBlock(objectDef, methodDef, statementDef.statement))
+                builder.add(renderStatementCodeBlock(objectDef, methodDef, scope, statementDef.statement))
                 builder.unindent()
                 builder.add("}\n")
                 return builder.build()
             }
             return CodeBlock.builder()
-                .addStatement("%L", renderStatement(objectDef, methodDef, statementDef))
+                .addStatement("%L", renderStatement(objectDef, methodDef, scope, statementDef))
                 .build()
         }
 
         private fun renderStatement(
             objectDef: ObjectDef?,
             methodDef: MethodDef,
+            scope: RenderScope,
             statementDef: StatementDef?
         ): CodeBlock {
             if (statementDef is InvokeSuperConstructor) {
-                val instanceExp = renderExpressionCode(objectDef, methodDef, statementDef.superInstance())
+                val instanceExp = renderExpressionCode(objectDef, methodDef, scope, statementDef.superInstance())
                 val codeBuilder = CodeBlock.builder()
                 codeBuilder.add(instanceExp)
                 codeBuilder.add("(")
                 for ((index, parameter) in statementDef.values.withIndex()) {
-                    codeBuilder.add(renderExpressionCode(objectDef, methodDef, parameter))
+                    codeBuilder.add(renderExpressionCode(objectDef, methodDef, scope, parameter))
                     if (index != statementDef.values.size - 1) {
                         codeBuilder.add(", ")
                     }
@@ -949,13 +1138,14 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             if (statementDef is Throw) {
                 return CodeBlock.builder()
                     .add("throw ")
-                    .add(renderExpressionCode(objectDef, methodDef, statementDef.expression))
+                    .add(renderExpressionCode(objectDef, methodDef, scope, statementDef.expression))
                     .build()
             }
             if (statementDef is Return) {
                 val codeBlock = renderExpressionWithNotNullAssertion(
                     objectDef,
                     methodDef,
+                    scope,
                     statementDef.expression,
                     methodDef.returnType
                 )
@@ -966,13 +1156,30 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             }
             if (statementDef is PutField) {
                 val field = statementDef.field
-                val variableExp = renderVariable(objectDef, methodDef, field)
+                val variableExp = renderVariable(objectDef, methodDef, scope, field)
                 val codeBuilder = variableExp.toBuilder()
                 codeBuilder.add(" = ")
                 codeBuilder.add(
                     renderExpressionCode(
                         objectDef,
                         methodDef,
+                        scope,
+                        statementDef.expression,
+                        field.type()
+                    )
+                )
+                return codeBuilder.build()
+            }
+            if (statementDef is PutStaticField) {
+                val field = statementDef.field
+                val variableExp = renderVariable(objectDef, methodDef, scope, field)
+                val codeBuilder = variableExp.toBuilder()
+                codeBuilder.add(" = ")
+                codeBuilder.add(
+                    renderExpressionCode(
+                        objectDef,
+                        methodDef,
+                        scope,
                         statementDef.expression,
                         field.type()
                     )
@@ -980,13 +1187,14 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 return codeBuilder.build()
             }
             if (statementDef is Assign) {
-                val variableExp = renderVariable(objectDef, methodDef, statementDef.variable)
+                val variableExp = renderVariable(objectDef, methodDef, scope, statementDef.variable)
                 val codeBuilder = variableExp.toBuilder()
                 codeBuilder.add(" = ")
                 codeBuilder.add(
                     renderExpressionCode(
                         objectDef,
                         methodDef,
+                        scope,
                         statementDef.expression,
                         statementDef.variable.type()
                     )
@@ -994,21 +1202,25 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 return codeBuilder.build()
             }
             if (statementDef is DefineAndAssign) {
-                return CodeBlock.builder()
+                val definition = CodeBlock.builder()
                     .add("var %L:%T", statementDef.variable.name, asType(statementDef.variable.type, objectDef))
                     .add(" = ")
                     .add(
                         renderExpressionCode(
                             objectDef,
                             methodDef,
+                            scope,
                             statementDef.expression,
                             statementDef.variable.type
                         )
                     )
                     .build()
+                // Declared only after the initializer is rendered - a lambda in it cannot see the variable
+                scope.declare(statementDef.variable.name)
+                return definition
             }
             if (statementDef is ExpressionDef) {
-                return renderExpressionCode(objectDef, methodDef, statementDef)
+                return renderExpressionCode(objectDef, methodDef, scope, statementDef)
             }
 
             throw IllegalStateException("Unrecognized statement: $statementDef")
@@ -1017,6 +1229,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
         private fun renderYield(
             builder: CodeBlock.Builder,
             methodDef: MethodDef,
+            scope: RenderScope,
             statementDef: StatementDef,
             objectDef: ObjectDef?
         ) {
@@ -1024,7 +1237,15 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 builder.addStatement(
                     "%L",
                     CodeBlock.builder().add("return ")
-                        .add(renderExpressionCode(objectDef, methodDef, statementDef.expression, methodDef.returnType))
+                        .add(
+                            renderExpressionCode(
+                                objectDef,
+                                methodDef,
+                                scope,
+                                statementDef.expression,
+                                methodDef.returnType
+                            )
+                        )
                         .build()
                 )
             } else {
@@ -1035,10 +1256,11 @@ class KotlinPoetSourceGenerator : SourceGenerator {
         private fun renderExpressionCode(
             objectDef: ObjectDef?,
             methodDef: MethodDef,
+            scope: RenderScope,
             expressionDef: ExpressionDef?,
             expectedType: TypeDef
         ): CodeBlock {
-            val codeBlock = renderExpressionCode(objectDef, methodDef, expressionDef)
+            val codeBlock = renderExpressionCode(objectDef, methodDef, scope, expressionDef)
             val builder = codeBlock.toBuilder()
             if (!expectedType.isNullable && expressionDef?.type()?.isNullable == true) {
                 builder.add("!!")
@@ -1049,6 +1271,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
         private fun renderExpressionCode(
             objectDef: ObjectDef?,
             methodDef: MethodDef,
+            scope: RenderScope,
             expressionDef: ExpressionDef?,
             isRef: Boolean = false
         ): CodeBlock {
@@ -1056,7 +1279,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 val codeBuilder = CodeBlock.builder()
                 codeBuilder.add("%T(", asClassName(expressionDef.type))
                 for ((index, parameter) in expressionDef.values.withIndex()) {
-                    codeBuilder.add(renderExpressionCode(objectDef, methodDef, parameter))
+                    codeBuilder.add(renderExpressionCode(objectDef, methodDef, scope, parameter))
                     if (index != expressionDef.values.size - 1) {
                         codeBuilder.add(", ")
                     }
@@ -1065,12 +1288,15 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 return codeBuilder.build()
             }
             if (expressionDef is InvokeInstanceMethod) {
-                val instanceExp = renderExpressionCode(objectDef, methodDef, expressionDef.instance)
+                var instanceExp = renderExpressionCode(objectDef, methodDef, scope, expressionDef.instance)
                 val codeBuilder = CodeBlock.builder()
                 if (expressionDef.method.name == "<init>") {
                     codeBuilder.add(instanceExp)
                     codeBuilder.add("(")
                 } else {
+                    if (requiresMethodCallTargetParentheses(expressionDef.instance)) {
+                        instanceExp = addParentheses(instanceExp)
+                    }
                     codeBuilder.add(instanceExp)
                     if (expressionDef.instance is InvokeInstanceMethod) {
                         codeBuilder.add("\n")
@@ -1078,7 +1304,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                     codeBuilder.add(".%N(", expressionDef.method.name)
                 }
                 for ((index, parameter) in expressionDef.values.withIndex()) {
-                    codeBuilder.add(renderExpressionCode(objectDef, methodDef, parameter))
+                    codeBuilder.add(renderExpressionCode(objectDef, methodDef, scope, parameter))
                     if (index != expressionDef.values.size - 1) {
                         codeBuilder.add(", ")
                     }
@@ -1087,16 +1313,19 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 return codeBuilder.build()
             }
             if (expressionDef is GetPropertyValue) {
-                val instanceExp = renderExpressionCode(objectDef, methodDef, expressionDef.instance)
+                var instanceExp = renderExpressionCode(objectDef, methodDef, scope, expressionDef.instance)
+                if (requiresMethodCallTargetParentheses(expressionDef.instance)) {
+                    instanceExp = addParentheses(instanceExp)
+                }
                 val codeBuilder = instanceExp.toBuilder()
                 codeBuilder.add(".%L", expressionDef.propertyElement.name)
                 return codeBuilder.build()
             }
             if (expressionDef is InvokeStaticMethod) {
                 val codeBuilder = CodeBlock.builder()
-                codeBuilder.add("%T.%N(", asClassName(expressionDef.classDef), expressionDef.method.name)
+                codeBuilder.add("%T.%N(", asStaticOwnerName(expressionDef.classDef), expressionDef.method.name)
                 for ((index, parameter) in expressionDef.values.withIndex()) {
-                    codeBuilder.add(renderExpressionCode(objectDef, methodDef, parameter))
+                    codeBuilder.add(renderExpressionCode(objectDef, methodDef, scope, parameter))
                     if (index != expressionDef.values.size - 1) {
                         codeBuilder.add(", ")
                     }
@@ -1104,80 +1333,106 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 codeBuilder.add(")")
                 return codeBuilder.build()
             }
-            if (expressionDef is Cast) {
-                var exp: ExpressionDef = expressionDef.expressionDef
-                while (exp is Cast) {
-                    if (exp.type().isPrimitive) {
-                        val previousCastType = exp.expressionDef().type()
-                        if (previousCastType != TypeDef.OBJECT) {
-                            break
-                        }
-                    }
-                    // Only keep the last cast
-                    exp = exp.expressionDef()
+            if (expressionDef is ArrayElement) {
+                var array = renderExpressionCode(objectDef, methodDef, scope, expressionDef.expression)
+                if (requiresMethodCallTargetParentheses(expressionDef.expression)) {
+                    array = addParentheses(array)
                 }
+                return array.toBuilder()
+                    .add("[")
+                    .add(renderExpressionCode(objectDef, methodDef, scope, expressionDef.indexExpression))
+                    .add("]")
+                    .build()
+            }
+            if (expressionDef is Cast) {
+                val exp: ExpressionDef = collapseNestedCasts(expressionDef.expressionDef)
                 if (expressionDef.type == exp.type() || isRef) {
-                    return renderExpressionCode(objectDef, methodDef, exp)
+                    return renderExpressionCode(objectDef, methodDef, scope, exp)
+                }
+                val castType = expressionDef.type
+                val rendered = renderExpressionCode(objectDef, methodDef, scope, exp, castType)
+                val conversion = primitiveConversion(castType, exp.type())
+                if (conversion != null) {
+                    // Kotlin has no primitive casts, a numeric conversion is a member function
+                    var operand = rendered
+                    if (requiresConversionTargetParentheses(unwrapCasts(exp))) {
+                        operand = addParentheses(operand)
+                    }
+                    return operand.toBuilder().add(conversion).build()
                 }
                 val codeBuilder = CodeBlock.builder()
-                codeBuilder.add(
-                    renderExpressionCode(
-                        objectDef,
-                        methodDef,
-                        exp,
-                        expressionDef.type
-                    )
-                )
-                codeBuilder.add(" as %T", asType(expressionDef.type, objectDef))
+                if (requiresCastOperandParentheses(unwrapCasts(exp))) {
+                    codeBuilder.add(addParentheses(rendered))
+                } else {
+                    codeBuilder.add(rendered)
+                }
+                codeBuilder.add(" as %T", asType(castType, objectDef))
                 return codeBuilder.build()
             }
             if (expressionDef is VariableDef) {
-                return renderVariable(objectDef, methodDef, expressionDef)
+                return renderVariable(objectDef, methodDef, scope, expressionDef)
             }
             if (expressionDef is Constant) {
-                return renderConstantExpression(expressionDef, methodDef)
+                return renderConstantExpression(expressionDef, methodDef, scope)
             }
             if (expressionDef is And) {
                 return CodeBlock.builder()
-                    .add(renderCondition(objectDef, methodDef, expressionDef.left))
+                    .add(renderAndConditionOperand(objectDef, methodDef, scope, expressionDef.left))
                     .add(" && ")
-                    .add(renderCondition(objectDef, methodDef, expressionDef.right))
+                    .add(renderAndConditionOperand(objectDef, methodDef, scope, expressionDef.right))
                     .build()
             }
             if (expressionDef is Or) {
                 return CodeBlock.builder()
-                    .add(renderCondition(objectDef, methodDef, expressionDef.left))
+                    .add(renderCondition(objectDef, methodDef, scope, expressionDef.left))
                     .add(" || ")
-                    .add(renderCondition(objectDef, methodDef, expressionDef.right))
+                    .add(renderCondition(objectDef, methodDef, scope, expressionDef.right))
                     .build()
             }
             if (expressionDef is IfElse) {
                 return CodeBlock.builder()
                     .add("if (")
-                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.condition, TypeDef.Primitive.BOOLEAN))
+                    .add(
+                        renderExpressionCode(
+                            objectDef,
+                            methodDef,
+                            scope,
+                            expressionDef.condition,
+                            TypeDef.Primitive.BOOLEAN
+                        )
+                    )
                     .add(") ")
-                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.ifExpression, expressionDef.type()))
+                    .add(
+                        renderExpressionCode(
+                            objectDef,
+                            methodDef,
+                            scope,
+                            expressionDef.ifExpression,
+                            expressionDef.type()
+                        )
+                    )
                     .add(" else ")
-                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.elseExpression, expressionDef.type()))
+                    .add(
+                        renderExpressionCode(
+                            objectDef,
+                            methodDef,
+                            scope,
+                            expressionDef.elseExpression,
+                            expressionDef.type()
+                        )
+                    )
                     .build()
             }
             if (expressionDef is Switch) {
                 val builder: CodeBlock.Builder = CodeBlock.builder()
                 builder.add("when (")
-                builder.add(
-                    renderExpressionCode(
-                        objectDef,
-                        methodDef,
-                        expressionDef.expression,
-                        TypeDef.Primitive.BOOLEAN
-                    )
-                )
+                builder.add(renderExpressionCode(objectDef, methodDef, scope, expressionDef.expression))
                 builder.add(") {\n")
                 builder.indent()
                 for ((key, value) in expressionDef.cases) {
-                    builder.add(renderExpressionCode(objectDef, methodDef, key))
+                    builder.add(renderExpressionCode(objectDef, methodDef, scope, key))
                     builder.add(" -> ")
-                    builder.add(renderExpressionCode(objectDef, methodDef, value))
+                    builder.add(renderExpressionCode(objectDef, methodDef, scope, value))
                     if (value is SwitchYieldCase) {
                         builder.add("\n")
                     } else {
@@ -1186,7 +1441,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 }
                 if (expressionDef.defaultCase != null) {
                     builder.add("else -> ")
-                    builder.add(renderExpressionCode(objectDef, methodDef, expressionDef.defaultCase))
+                    builder.add(renderExpressionCode(objectDef, methodDef, scope, expressionDef.defaultCase))
                 }
                 builder.unindent()
                 builder.add("}")
@@ -1201,10 +1456,11 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 check(!flatten.isEmpty()) { "SwitchYieldCase did not return any statements" }
                 val last = flatten[flatten.size - 1]
                 val rest: List<StatementDef> = flatten.subList(0, flatten.size - 1)
+                val caseScope = scope.nested(null)
                 for (statementDef in rest) {
-                    builder.add(renderStatementCodeBlock(objectDef, methodDef, statementDef))
+                    builder.add(renderStatementCodeBlock(objectDef, methodDef, caseScope, statementDef))
                 }
-                renderYield(builder, methodDef, last, objectDef)
+                renderYield(builder, methodDef, caseScope, last, objectDef)
                 builder.unindent()
                 builder.add("}")
                 val str: String = builder.build().toString()
@@ -1213,72 +1469,106 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             }
             if (expressionDef is IsNull) {
                 return CodeBlock.builder()
-                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.expression, true))
+                    .add(renderExpressionCode(objectDef, methodDef, scope, expressionDef.expression, true))
                     .add(" == null")
                     .build()
             }
             if (expressionDef is IsNotNull) {
                 return CodeBlock.builder()
-                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.expression, true))
+                    .add(renderExpressionCode(objectDef, methodDef, scope, expressionDef.expression, true))
                     .add(" != null")
                     .build()
             }
             if (expressionDef is IsTrue) {
-                return renderExpressionCode(objectDef, methodDef, expressionDef.expression)
+                val expression = unwrapCasts(expressionDef.expression)
+                if (expression is ConditionExpressionDef) {
+                    return renderExpressionCode(objectDef, methodDef, scope, expression)
+                }
+                return renderExpressionCode(objectDef, methodDef, scope, expressionDef.expression)
             }
             if (expressionDef is IsFalse) {
+                val expression = unwrapCasts(expressionDef.expression)
+                if (expression is ConditionExpressionDef) {
+                    return CodeBlock.builder()
+                        .add("!")
+                        .add(addParentheses(renderExpressionCode(objectDef, methodDef, scope, expression)))
+                        .build()
+                }
                 return CodeBlock.builder()
                     .add("!")
-                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.expression))
+                    .add(renderExpressionWithParentheses(objectDef, methodDef, scope, expressionDef.expression))
+                    .build()
+            }
+            if (expressionDef is InstanceOf) {
+                return CodeBlock.builder()
+                    .add(renderExpressionCode(objectDef, methodDef, scope, expressionDef.expression, true))
+                    .add(" is %T", asType(expressionDef.instanceType, objectDef))
                     .build()
             }
             if (expressionDef is MathBinaryOperation) {
                 return CodeBlock.builder()
-                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.left))
+                    .add(renderMathOperand(objectDef, methodDef, scope, expressionDef, expressionDef.left, false))
                     .add(getMathOp(expressionDef.opType))
-                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.right))
+                    .add(renderMathOperand(objectDef, methodDef, scope, expressionDef, expressionDef.right, true))
                     .build()
             }
             if (expressionDef is MathUnaryOperation) {
                 return CodeBlock.builder()
                     .add(getMathOp(expressionDef.opType))
-                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.expression))
+                    .add(renderExpressionWithParentheses(objectDef, methodDef, scope, expressionDef.expression))
                     .build()
             }
             if (expressionDef is ComparisonOperation) {
                 return CodeBlock.builder()
-                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.left))
+                    .add(renderExpressionWithParentheses(objectDef, methodDef, scope, expressionDef.left))
                     .add(getOpType(expressionDef.opType))
-                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.right))
+                    .add(renderExpressionWithParentheses(objectDef, methodDef, scope, expressionDef.right))
                     .build()
             }
             if (expressionDef is NewArrayOfSize) {
+                val componentType = expressionDef.type.componentType
+                val primitiveArray = primitiveArrayType(componentType)
+                if (primitiveArray != null) {
+                    // A primitive array is sized rather than filled with nulls
+                    return CodeBlock.of("%T(%L)", asType(ClassTypeDef.of(primitiveArray), objectDef), expressionDef.size)
+                }
                 return CodeBlock.of(
                     "arrayOfNulls<%T>(%L)",
-                    asType(expressionDef.type.componentType, objectDef),
+                    asType(componentType, objectDef),
                     expressionDef.size
                 )
             }
             if (expressionDef is NewArrayInitialized) {
+                val componentType = expressionDef.type.componentType
                 val builder: CodeBlock.Builder = CodeBlock.builder()
-                builder.add("arrayOf<%T>(", asType(expressionDef.type.componentType, objectDef))
+                if (componentType is TypeDef.Primitive) {
+                    builder.add("%L(", arrayOfFunction(componentType))
+                } else {
+                    builder.add("arrayOf<%T>(", asType(componentType, objectDef))
+                }
                 val iterator: Iterator<ExpressionDef> = expressionDef.expressions.iterator()
                 while (iterator.hasNext()) {
                     val expression = iterator.next()
-                    builder.add(renderExpressionCode(objectDef, methodDef, expression))
+                    builder.add(renderExpressionCode(objectDef, methodDef, scope, expression))
                     if (iterator.hasNext()) {
-                        builder.add(",")
+                        builder.add(", ")
                     }
                 }
                 builder.add(")")
                 return builder.build()
             }
             if (expressionDef is InvokeGetClassMethod) {
-                val instanceExp = renderExpressionCode(objectDef, methodDef, expressionDef.instance)
+                var instanceExp = renderExpressionCode(objectDef, methodDef, scope, expressionDef.instance)
+                if (requiresMethodCallTargetParentheses(expressionDef.instance)) {
+                    instanceExp = addParentheses(instanceExp)
+                }
                 return instanceExp.toBuilder().add(".javaClass").build()
             }
             if (expressionDef is InvokeHashCodeMethod) {
-                val instanceExp = renderExpressionCode(objectDef, methodDef, expressionDef.instance)
+                var instanceExp = renderExpressionCode(objectDef, methodDef, scope, expressionDef.instance)
+                if (requiresMethodCallTargetParentheses(expressionDef.instance)) {
+                    instanceExp = addParentheses(instanceExp)
+                }
                 val type = expressionDef.instance.type()
                 if (type.isArray) {
                     if (type is TypeDef.Array && type.dimensions > 1) {
@@ -1291,91 +1581,95 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             if (expressionDef is EqualsStructurally) {
                 val type = expressionDef.instance.type()
                 if (type.isArray) {
-                    if (type is TypeDef.Array && type.dimensions > 1) {
-                        return CodeBlock.builder()
-                            .add(renderExpressionCode(objectDef, methodDef, expressionDef.instance))
-                            .add(".contentDeepEquals(")
-                            .add(renderExpressionCode(objectDef, methodDef, expressionDef.other))
-                            .add(")")
-                            .build()
+                    val method = if (type is TypeDef.Array && type.dimensions > 1) {
+                        ".contentDeepEquals("
+                    } else {
+                        ".contentEquals("
                     }
                     return CodeBlock.builder()
-                        .add(renderExpressionCode(objectDef, methodDef, expressionDef.instance))
-                        .add(".contentEquals(")
-                        .add(renderExpressionCode(objectDef, methodDef, expressionDef.other))
+                        .add(renderExpressionWithParentheses(objectDef, methodDef, scope, expressionDef.instance))
+                        .add(method)
+                        .add(renderExpressionCode(objectDef, methodDef, scope, expressionDef.other))
                         .add(")")
                         .build()
                 }
                 return CodeBlock.builder()
-                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.instance))
+                    .add(renderExpressionWithParentheses(objectDef, methodDef, scope, expressionDef.instance))
                     .add(" == ")
-                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.other))
+                    .add(renderExpressionWithParentheses(objectDef, methodDef, scope, expressionDef.other))
                     .build()
             }
             if (expressionDef is NotEqualsStructurally) {
                 val type = expressionDef.instance.type()
                 if (type.isArray) {
-                    if (type is TypeDef.Array && type.dimensions > 1) {
-                        return CodeBlock.builder()
-                            .add("!")
-                            .add(renderExpressionCode(objectDef, methodDef, expressionDef.instance))
-                            .add(".contentDeepEquals(")
-                            .add(renderExpressionCode(objectDef, methodDef, expressionDef.other))
-                            .add(")")
-                            .build()
+                    val method = if (type is TypeDef.Array && type.dimensions > 1) {
+                        ".contentDeepEquals("
+                    } else {
+                        ".contentEquals("
                     }
                     return CodeBlock.builder()
                         .add("!")
-                        .add(renderExpressionCode(objectDef, methodDef, expressionDef.instance))
-                        .add(".contentEquals(")
-                        .add(renderExpressionCode(objectDef, methodDef, expressionDef.other))
+                        .add(renderExpressionWithParentheses(objectDef, methodDef, scope, expressionDef.instance))
+                        .add(method)
+                        .add(renderExpressionCode(objectDef, methodDef, scope, expressionDef.other))
                         .add(")")
                         .build()
                 }
                 return CodeBlock.builder()
-                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.instance))
+                    .add(renderExpressionWithParentheses(objectDef, methodDef, scope, expressionDef.instance))
                     .add(" != ")
-                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.other))
+                    .add(renderExpressionWithParentheses(objectDef, methodDef, scope, expressionDef.other))
                     .build()
             }
             if (expressionDef is EqualsReferentially) {
                 return CodeBlock.builder()
-                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.instance, true))
+                    .add(renderExpressionWithParentheses(objectDef, methodDef, scope, expressionDef.instance, true))
                     .add(" === ")
-                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.other, true))
+                    .add(renderExpressionWithParentheses(objectDef, methodDef, scope, expressionDef.other, true))
                     .build()
             }
             if (expressionDef is NotEqualsReferentially) {
                 return CodeBlock.builder()
-                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.instance, true))
+                    .add(renderExpressionWithParentheses(objectDef, methodDef, scope, expressionDef.instance, true))
                     .add(" !== ")
-                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.other, true))
+                    .add(renderExpressionWithParentheses(objectDef, methodDef, scope, expressionDef.other, true))
                     .build()
             }
             if (expressionDef is Lambda) {
+                val implementation = expressionDef.implementation
+                val lambdaScope = scope.nested(implementation)
                 val builder = CodeBlock.builder()
                     .add("%T ", asType(expressionDef.type, objectDef))
                     .add("{")
-                val parameter: Iterator<ParameterDef> = expressionDef.implementation.parameters.iterator()
+                val parameter: Iterator<ParameterDef> = implementation.parameters.iterator()
                 if (!parameter.hasNext()) {
                     builder.add("()")
                 }
                 while (parameter.hasNext()) {
                     val param = parameter.next()
-                    builder.add("%L: %T", param.name, asType(param.type, objectDef))
+                    val emittedName = if (scope.isTaken(param.name)) lambdaScope.allocate(param.name) else param.name
+                    lambdaScope.rename(param.name, emittedName)
+                    builder.add("%L: %T", emittedName, asType(param.type, objectDef))
                     if (parameter.hasNext()) {
                         builder.add(", ")
                     }
                 }
                 builder.add(" -> ")
-                val statements: List<StatementDef> = expressionDef.implementation.statements
+                val statements: List<StatementDef> = implementation.statements
                 if (statements.size == 1 && statements[0] is Return) {
                     val returnStatement = statements[0] as Return
-                    builder.add(renderExpressionCode(objectDef, expressionDef.implementation, returnStatement.expression))
+                    builder.add(
+                        renderExpressionCode(
+                            objectDef,
+                            implementation,
+                            lambdaScope,
+                            returnStatement.expression
+                        )
+                    )
                 } else {
                     builder.add("{")
                     for (statement in statements) {
-                        builder.add(renderStatementCodeBlock(objectDef, expressionDef.implementation, statement))
+                        builder.add(renderStatementCodeBlock(objectDef, implementation, lambdaScope, statement))
                     }
                     builder.unindent()
                 }
@@ -1390,9 +1684,11 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                     // Kotlin spells a constructor reference ::ClassName
                     expressionDef.isConstructor ->
                         builder.add("::%T", asType(expressionDef.owner(), objectDef))
+
                     instance != null -> builder
-                        .add(renderExpressionCode(objectDef, methodDef, instance, true))
+                        .add(renderExpressionWithParentheses(objectDef, methodDef, scope, instance, true))
                         .add("::%L", expressionDef.method().name)
+
                     else ->
                         builder.add("%T::%L", asType(expressionDef.owner(), objectDef), expressionDef.method().name)
                 }
@@ -1404,12 +1700,237 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                     left = TypeDef.STRING.invokeStatic("valueOf", TypeDef.STRING, left)
                 }
                 return CodeBlock.builder()
-                    .add(renderExpressionCode(objectDef, methodDef, left))
+                    .add(renderExpressionCode(objectDef, methodDef, scope, left))
                     .add(" + ")
-                    .add(renderExpressionCode(objectDef, methodDef, expressionDef.right))
+                    .add(renderConcatenationOperand(objectDef, methodDef, scope, expressionDef.right()))
                     .build()
             }
             throw IllegalStateException("Unrecognized expression: $expressionDef")
+        }
+
+        private fun renderConcatenationOperand(
+            objectDef: ObjectDef?,
+            methodDef: MethodDef,
+            scope: RenderScope,
+            operand: ExpressionDef
+        ): CodeBlock {
+            val rendered = renderExpressionCode(objectDef, methodDef, scope, operand)
+            if (unwrapCasts(operand) is StringConcatenation) {
+                return addParentheses(rendered)
+            }
+            return rendered
+        }
+
+        private fun renderAndConditionOperand(
+            objectDef: ObjectDef?,
+            methodDef: MethodDef,
+            scope: RenderScope,
+            expressionDef: ConditionExpressionDef
+        ): CodeBlock {
+            val rendered = renderExpressionCode(objectDef, methodDef, scope, expressionDef)
+            if (isOrCondition(expressionDef)) {
+                return addParentheses(rendered)
+            }
+            return rendered
+        }
+
+        private fun isOrCondition(expressionDef: ConditionExpressionDef): Boolean {
+            if (expressionDef is Or) {
+                return true
+            }
+            if (expressionDef is IsTrue) {
+                val expression = unwrapCasts(expressionDef.expression)
+                return expression is ConditionExpressionDef && isOrCondition(expression)
+            }
+            return false
+        }
+
+        private fun renderMathOperand(
+            objectDef: ObjectDef?,
+            methodDef: MethodDef,
+            scope: RenderScope,
+            parent: MathBinaryOperation,
+            operand: ExpressionDef,
+            rightOperand: Boolean
+        ): CodeBlock {
+            if (operand is MathBinaryOperation) {
+                val rendered = renderExpressionCode(objectDef, methodDef, scope, operand)
+                if (requiresMathParentheses(parent, operand, rightOperand)) {
+                    return addParentheses(rendered)
+                }
+                return rendered
+            }
+            return renderExpressionWithParentheses(objectDef, methodDef, scope, operand)
+        }
+
+        private fun requiresMathParentheses(
+            parent: MathBinaryOperation,
+            child: MathBinaryOperation,
+            rightOperand: Boolean
+        ): Boolean {
+            val parentPrecedence = mathPrecedence(parent.opType)
+            val childPrecedence = mathPrecedence(child.opType)
+            return childPrecedence < parentPrecedence || (rightOperand && childPrecedence == parentPrecedence)
+        }
+
+        /**
+         * The Kotlin precedence of a binary operation. The bitwise operations are named infix functions,
+         * which all share one precedence level below the arithmetic operators.
+         */
+        private fun mathPrecedence(opType: MathBinaryOperation.OpType): Int {
+            return when (opType) {
+                MathBinaryOperation.OpType.MULTIPLICATION,
+                MathBinaryOperation.OpType.DIVISION,
+                MathBinaryOperation.OpType.MODULUS -> 3
+
+                MathBinaryOperation.OpType.ADDITION,
+                MathBinaryOperation.OpType.SUBTRACTION -> 2
+
+                else -> 1
+            }
+        }
+
+        private fun renderExpressionWithParentheses(
+            objectDef: ObjectDef?,
+            methodDef: MethodDef,
+            scope: RenderScope,
+            expressionDef: ExpressionDef,
+            isRef: Boolean = false
+        ): CodeBlock {
+            val rendered = renderExpressionCode(objectDef, methodDef, scope, expressionDef, isRef)
+            if (!requiresParentheses(expressionDef)) {
+                return rendered
+            }
+            return addParentheses(rendered)
+        }
+
+        private fun requiresParentheses(expressionDef: ExpressionDef): Boolean {
+            val expression = unwrapCasts(expressionDef)
+            if (expression is InvokeHashCodeMethod) {
+                val type = expression.instance().type()
+                return !type.isPrimitive && !type.isArray
+            }
+            return !(expression is StatementDef
+                || expression is VariableDef
+                || expression is And
+                || expression is Constant
+                || expression is GetPropertyValue
+                || expression is InvokeGetClassMethod
+                || expression is ArrayElement
+                || expression is NewArrayOfSize
+                || expression is NewArrayInitialized
+                || expression is NewInstance
+                || expression is Switch)
+        }
+
+        private fun requiresMethodCallTargetParentheses(expressionDef: ExpressionDef): Boolean {
+            return expressionDef is Cast
+                || expressionDef is IfElse
+                || expressionDef is StringConcatenation
+                || expressionDef is Switch
+                || expressionDef is MathBinaryOperation
+                || expressionDef is MathUnaryOperation
+                || expressionDef is ConditionExpressionDef
+        }
+
+        /**
+         * A conversion is a member call, and both `.` and a prefix minus bind tighter than the
+         * binary operators, so anything looser than a postfix expression has to be wrapped.
+         */
+        private fun requiresConversionTargetParentheses(expressionDef: ExpressionDef): Boolean {
+            return requiresMethodCallTargetParentheses(expressionDef)
+                || isNegativeNumericConstant(expressionDef)
+        }
+
+        private fun isNegativeNumericConstant(expressionDef: ExpressionDef): Boolean {
+            return expressionDef is Constant
+                && expressionDef.value is Number
+                && expressionDef.value.toString().startsWith("-")
+        }
+
+        private fun requiresCastOperandParentheses(expressionDef: ExpressionDef): Boolean {
+            return expressionDef is ConditionExpressionDef
+                || expressionDef is IfElse
+                || expressionDef is MathBinaryOperation
+                || expressionDef is StringConcatenation
+                || expressionDef is Switch
+        }
+
+        private fun unwrapCasts(expressionDef: ExpressionDef): ExpressionDef {
+            var expression = expressionDef
+            while (expression is Cast) {
+                expression = expression.expressionDef()
+            }
+            return expression
+        }
+
+        private fun collapseNestedCasts(expressionDef: ExpressionDef): ExpressionDef {
+            var expression = expressionDef
+            while (expression is Cast) {
+                if (expression.type().isPrimitive) {
+                    val previousCastType = expression.expressionDef().type()
+                    if (previousCastType != TypeDef.OBJECT) {
+                        break
+                    }
+                }
+                // Only keep the last cast
+                expression = expression.expressionDef()
+            }
+            return expression
+        }
+
+        /**
+         * Kotlin has no primitive casts. A conversion between two number-like types is a member
+         * function, so a cast of one is emitted as a call instead of an `as` expression.
+         *
+         * @return The conversion to append, or null if the cast should be emitted as `as`
+         */
+        private fun primitiveConversion(castType: TypeDef, sourceType: TypeDef): String? {
+            if (castType !is TypeDef.Primitive || !isNumberLike(sourceType)) {
+                return null
+            }
+            if (sourceType.isPrimitive && (sourceType as TypeDef.Primitive).name() == "char") {
+                // Char has no numeric conversions of its own, its code goes through Int
+                return when (castType.name()) {
+                    "char" -> null
+                    "int" -> ".code"
+                    else -> ".code" + numberConversion(castType.name())
+                }
+            }
+            return when (castType.name()) {
+                "boolean" -> null
+                // Only Int declares toChar, the others are deprecated
+                "char" -> if (sourceType.isPrimitive && (sourceType as TypeDef.Primitive).name() == "int") {
+                    ".toChar()"
+                } else {
+                    ".toInt().toChar()"
+                }
+
+                else -> numberConversion(castType.name())
+            }
+        }
+
+        private fun numberConversion(name: String): String {
+            return when (name) {
+                "byte" -> ".toByte()"
+                "short" -> ".toShort()"
+                "int" -> ".toInt()"
+                "long" -> ".toLong()"
+                "float" -> ".toFloat()"
+                "double" -> ".toDouble()"
+                else -> throw IllegalStateException("Unrecognized primitive name: $name")
+            }
+        }
+
+        private fun isNumberLike(typeDef: TypeDef): Boolean {
+            if (typeDef is TypeDef.Primitive) {
+                return typeDef.name() != "boolean"
+            }
+            return typeDef is ClassTypeDef && BOXED_NUMBERS.contains(typeDef.name)
+        }
+
+        private fun addParentheses(rendered: CodeBlock): CodeBlock {
+            return CodeBlock.builder().add("(").add(rendered).add(")").build()
         }
 
         private fun getMathOp(opType: MathBinaryOperation.OpType): String {
@@ -1419,12 +1940,13 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 MathBinaryOperation.OpType.MULTIPLICATION -> " * "
                 MathBinaryOperation.OpType.DIVISION -> " / "
                 MathBinaryOperation.OpType.MODULUS -> " % "
-                MathBinaryOperation.OpType.BITWISE_AND -> " & "
-                MathBinaryOperation.OpType.BITWISE_OR -> " | "
-                MathBinaryOperation.OpType.BITWISE_XOR -> " ^ "
-                MathBinaryOperation.OpType.BITWISE_LEFT_SHIFT -> " << "
-                MathBinaryOperation.OpType.BITWISE_RIGHT_SHIFT -> " >> "
-                MathBinaryOperation.OpType.BITWISE_UNSIGNED_RIGHT_SHIFT -> " >>> "
+                // Kotlin spells the bitwise operations as infix functions
+                MathBinaryOperation.OpType.BITWISE_AND -> " and "
+                MathBinaryOperation.OpType.BITWISE_OR -> " or "
+                MathBinaryOperation.OpType.BITWISE_XOR -> " xor "
+                MathBinaryOperation.OpType.BITWISE_LEFT_SHIFT -> " shl "
+                MathBinaryOperation.OpType.BITWISE_RIGHT_SHIFT -> " shr "
+                MathBinaryOperation.OpType.BITWISE_UNSIGNED_RIGHT_SHIFT -> " ushr "
             }
         }
 
@@ -1448,25 +1970,27 @@ class KotlinPoetSourceGenerator : SourceGenerator {
         private fun renderCondition(
             objectDef: @Nullable ObjectDef?,
             methodDef: MethodDef,
+            scope: RenderScope,
             expressionDef: ExpressionDef
         ): CodeBlock {
-            val needsParentheses = expressionDef is And || expressionDef is Or
-            val rendered = renderExpressionCode(objectDef, methodDef, expressionDef)
+            val needsParentheses = expressionDef is And
+            val rendered = renderExpressionCode(objectDef, methodDef, scope, expressionDef)
             if (needsParentheses) {
-                return CodeBlock.builder().add("(").add(rendered).add(")").build()
+                return addParentheses(rendered)
             }
             return rendered
         }
 
         private fun renderConstantExpression(
             constant: Constant,
-            methodDef: MethodDef
+            methodDef: MethodDef,
+            scope: RenderScope
         ): CodeBlock {
             val type = constant.type
             val value = constant.value ?: return CodeBlock.of("null")
             if (type is ClassTypeDef && type.isEnum) {
                 return renderExpressionCode(
-                    null, methodDef, VariableDef.StaticField(
+                    null, methodDef, scope, VariableDef.StaticField(
                         type,
                         if (value is Enum<*>) value.name else value.toString(),
                         type
@@ -1474,50 +1998,45 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 )
             }
             if (type is TypeDef.Primitive) {
-                return when (type.name()) {
-                    "long" -> CodeBlock.of(value.toString() + "l")
-                    "float" -> CodeBlock.of(value.toString() + "f")
-                    "double" -> CodeBlock.of(value.toString() + "d")
-                    else -> CodeBlock.of("%L", value)
-                }
+                return renderPrimitiveConstant(type.name(), value)
             } else if (type is TypeDef.Array) {
                 if (value.javaClass.isArray) {
-                    val array = value
                     val builder = CodeBlock.builder()
-                    val length = Array.getLength(array)
+                    val length = Array.getLength(value)
                     val componentType = type.componentType
-                    for (i in 0..length) {
+                    for (i in 0 until length) {
                         builder.add(
                             renderConstantExpression(
-                                Constant(componentType, Array.get(array, i)),
-                                methodDef
+                                Constant(componentType, Array.get(value, i)),
+                                methodDef,
+                                scope
                             )
                         )
                         if (i + 1 != length) {
-                            builder.add(",")
+                            builder.add(", ")
                         }
                     }
-                    val values = builder.build()
-                    val typeName: String = if (componentType is ClassTypeDef) {
-                        componentType.simpleName
-                    } else if (componentType is TypeDef.Primitive) {
-                        componentType.name()
+                    val result = CodeBlock.builder()
+                    if (componentType is TypeDef.Primitive) {
+                        result.add("%L(", arrayOfFunction(componentType))
                     } else {
-                        throw java.lang.IllegalStateException("Unrecognized expression: $constant")
+                        result.add("arrayOf<%T>(", asType(componentType, null))
                     }
-                    return CodeBlock.builder()
-                        .add("new %N[] {", typeName)
-                        .add(values)
-                        .add("}")
-                        .build()
+                    return result.add(builder.build()).add(")").build()
                 }
             } else if (type is ClassTypeDef) {
+                if (value is TypeDef) {
+                    return CodeBlock.of("%T::class.java", asType(value, null))
+                }
                 val name = type.name
                 return if (ClassUtils.isJavaLangType(name)) {
                     when (name) {
-                        "java.lang.Long" -> CodeBlock.of(value.toString() + "l")
-                        "java.lang.Float" -> CodeBlock.of(value.toString() + "f")
-                        "java.lang.Double" -> CodeBlock.of(value.toString() + "d")
+                        "java.lang.Byte" -> renderPrimitiveConstant("byte", value)
+                        "java.lang.Short" -> renderPrimitiveConstant("short", value)
+                        "java.lang.Character" -> renderPrimitiveConstant("char", value)
+                        "java.lang.Long" -> renderPrimitiveConstant("long", value)
+                        "java.lang.Float" -> renderPrimitiveConstant("float", value)
+                        "java.lang.Double" -> renderPrimitiveConstant("double", value)
                         "java.lang.String" -> CodeBlock.of("%S", value)
                         else -> CodeBlock.of("%L", value)
                     }
@@ -1528,15 +2047,69 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             throw IllegalStateException("Unrecognized expression: $constant")
         }
 
+        private fun renderPrimitiveConstant(name: String, value: Any): CodeBlock {
+            return when (name) {
+                // Kotlin only accepts an upper case long suffix, and a byte or a short is written as
+                // an integer literal - the expected type converts it
+                "long" -> CodeBlock.of("%LL", value)
+                "float" -> asFloatingPointLiteral(value, FLOAT)
+                "double" -> asFloatingPointLiteral(value, DOUBLE)
+                "char" -> CodeBlock.of("'%L'", characterLiteralWithoutSingleQuotes(asChar(value)))
+                else -> CodeBlock.of("%L", value)
+            }
+        }
+
+        private fun asChar(value: Any): Char {
+            return when (value) {
+                is Char -> value
+                is Number -> value.toInt().toChar()
+                else -> throw IllegalStateException("Expected a character constant; got: $value")
+            }
+        }
+
+        /**
+         * A floating point literal. Kotlin has no suffix for a double, needs a fraction to infer one
+         * and spells the non-finite values as constants of the type.
+         *
+         * @param value The value
+         * @param type  The Kotlin type declaring the non-finite constants
+         * @return The literal
+         */
+        private fun asFloatingPointLiteral(value: Any, type: ClassName): CodeBlock {
+            val number = value as? Number
+                ?: throw IllegalStateException("Expected a floating point constant; got: $value")
+            val suffix = if (type == FLOAT) "f" else ""
+            val literal = when {
+                number.toDouble().isNaN() -> return CodeBlock.of("%T.NaN", type)
+                number.toDouble() == Double.POSITIVE_INFINITY -> return CodeBlock.of("%T.POSITIVE_INFINITY", type)
+                number.toDouble() == Double.NEGATIVE_INFINITY -> return CodeBlock.of("%T.NEGATIVE_INFINITY", type)
+                else -> number.toString()
+            }
+            if (literal.contains('.') || literal.contains('e') || literal.contains('E')) {
+                return CodeBlock.of("%L%L", literal, suffix)
+            }
+            return CodeBlock.of("%L.0%L", literal, suffix)
+        }
+
         private fun renderVariable(
             objectDef: ObjectDef?,
             methodDef: MethodDef?,
+            scope: RenderScope,
             variableDef: VariableDef
         ): CodeBlock {
+            if (variableDef is VariableDef.ExceptionVar) {
+                val name = scope.resolveRename(EXCEPTION_NAME)
+                checkNotNull(name) { "The exception variable is only available in a catch block" }
+                return CodeBlock.of("%L", name)
+            }
             if (variableDef is VariableDef.MethodParameter) {
                 checkNotNull(methodDef) { "Accessing method parameters is not available" }
-                methodDef.getParameter(variableDef.name) // Check if exists
-                return CodeBlock.of("%N", variableDef.name)
+                // The parameter can belong to an enclosing method - a lambda body can capture one
+                val name = scope.resolveParameter(variableDef.name)
+                checkNotNull(name) {
+                    "Method: " + methodDef.name + " doesn't have parameter: " + variableDef.name
+                }
+                return CodeBlock.of("%N", name)
             }
             if (variableDef is VariableDef.Field) {
                 checkNotNull(objectDef) { "Field 'this' is not available" }
@@ -1548,7 +2121,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                     throw IllegalStateException("Field access not supported on the object definition: $objectDef")
                 }
                 checkNotNull(methodDef) { "Accessing field is not available" }
-                val codeBlock = renderExpressionCode(objectDef, methodDef, variableDef.instance)
+                val codeBlock = renderExpressionCode(objectDef, methodDef, scope, variableDef.instance)
                 val builder = codeBlock.toBuilder()
                 if (variableDef.instance.type().isNullable) {
                     builder.add("!!")
@@ -1583,10 +2156,11 @@ class KotlinPoetSourceGenerator : SourceGenerator {
         private fun renderExpressionWithNotNullAssertion(
             objectDef: ObjectDef?,
             methodDef: MethodDef,
+            scope: RenderScope,
             expressionDef: ExpressionDef?,
             result: TypeDef
         ): CodeBlock {
-            val codeBlock = renderExpressionCode(objectDef, methodDef, expressionDef)
+            val codeBlock = renderExpressionCode(objectDef, methodDef, scope, expressionDef)
             val builder = codeBlock.toBuilder()
             if (!result.isNullable && expressionDef?.type()?.isNullable == true) {
                 builder.add("!!")
@@ -1603,9 +2177,29 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 }
             var builder = AnnotationSpec.builder(ClassName.bestGuess(annName))
             for ((memberName, value) in annotationDef.values) {
-                builder = addAnnotationValue(builder, memberName, value)
+                // Kotlin has no single value shorthand for an array member, it takes an array literal
+                val memberValue = if (value !is Collection<*> && isArrayMember(annotationDef.type, memberName)) {
+                    listOf(value)
+                } else {
+                    value
+                }
+                builder = addAnnotationValue(builder, memberName, memberValue)
             }
             return builder.build()
+        }
+
+        /**
+         * @param type       The annotation type
+         * @param memberName The member name
+         * @return True if the member is declared as an array, false when that cannot be established
+         */
+        private fun isArrayMember(type: ClassTypeDef, memberName: String): Boolean {
+            val javaClass = (type as? ClassTypeDef.JavaClass)?.type ?: return false
+            return try {
+                javaClass.getMethod(memberName).returnType.isArray
+            } catch (e: NoSuchMethodException) {
+                false
+            }
         }
 
         private fun addAnnotationValue(
@@ -1648,7 +2242,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             }
 
             is VariableDef -> {
-                builder.addMember("$memberName = %L", renderVariable(null, null, value))
+                builder.addMember("$memberName = %L", renderVariable(null, null, RenderScope.root(null), value))
             }
 
             is AnnotationDef -> {
@@ -1683,6 +2277,130 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 '\\' -> "\\\\"
                 else -> if (Character.isISOControl(c)) String.format("\\u%04x", c.code) else c.toString()
             }
+        }
+    }
+
+    /**
+     * The names visible at a point of the rendering. Kotlin allows a lambda parameter or a catch
+     * variable to shadow an enclosing name, but the shadow is a warning and it hides the outer
+     * value, so a colliding name is emitted under an allocated one and its references remapped.
+     *
+     * @param parent The enclosing scope
+     * @param owner  The method the scope belongs to
+     */
+    private class RenderScope private constructor(
+        private val parent: RenderScope?,
+        private val owner: MethodDef?
+    ) {
+        private val renames = LinkedHashMap<String, String>()
+        private val taken = LinkedHashSet<String>()
+
+        init {
+            owner?.parameters?.forEach { taken.add(it.name) }
+        }
+
+        companion object {
+            /**
+             * @param owner The method the scope belongs to
+             * @return A root scope
+             */
+            fun root(owner: MethodDef?) = RenderScope(null, owner)
+        }
+
+        /**
+         * @param owner The method the nested scope belongs to
+         * @return A scope nested in this one
+         */
+        fun nested(owner: MethodDef?) = RenderScope(this, owner)
+
+        /**
+         * Records a name as declared in this scope, so that a nested lambda does not reuse it.
+         *
+         * @param name The name
+         */
+        fun declare(name: String) {
+            taken.add(name)
+        }
+
+        /**
+         * Records that a name of the owning method is emitted under a different name.
+         *
+         * @param name        The name in the model
+         * @param emittedName The name to emit
+         */
+        fun rename(name: String, emittedName: String) {
+            renames[name] = emittedName
+            taken.add(emittedName)
+        }
+
+        /**
+         * @param name The name
+         * @return True if the name is already used by this scope or any enclosing one
+         */
+        fun isTaken(name: String): Boolean {
+            var scope: RenderScope? = this
+            while (scope != null) {
+                if (scope.taken.contains(name)) {
+                    return true
+                }
+                scope = scope.parent
+            }
+            return false
+        }
+
+        /**
+         * Allocates a name that is not used by this scope or any enclosing one.
+         *
+         * @param name The preferred name
+         * @return The preferred name, or a name derived from it
+         */
+        fun allocate(name: String): String {
+            if (!isTaken(name)) {
+                return name
+            }
+            var i = 1
+            var candidate = name + i
+            while (isTaken(candidate)) {
+                candidate = name + ++i
+            }
+            return candidate
+        }
+
+        /**
+         * Resolves the name a method parameter is emitted under, looking in the innermost scope that
+         * declares it and walking outwards so that a lambda body can capture a parameter of the
+         * enclosing method.
+         *
+         * @param name The parameter name
+         * @return The name to emit, or null if no scope declares the parameter
+         */
+        fun resolveParameter(name: String): String? {
+            var scope: RenderScope? = this
+            while (scope != null) {
+                if (scope.owner?.findParameter(name) != null) {
+                    return scope.renames.getOrDefault(name, name)
+                }
+                scope = scope.parent
+            }
+            return null
+        }
+
+        /**
+         * Resolves a name recorded by [rename], walking outwards.
+         *
+         * @param name The name in the model
+         * @return The name to emit, or null if no scope renamed it
+         */
+        fun resolveRename(name: String): String? {
+            var scope: RenderScope? = this
+            while (scope != null) {
+                val emittedName = scope.renames[name]
+                if (emittedName != null) {
+                    return emittedName
+                }
+                scope = scope.parent
+            }
+            return null
         }
     }
 }

--- a/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
+++ b/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
@@ -953,6 +953,20 @@ class KotlinPoetSourceGenerator : SourceGenerator {
         }
 
         /**
+         * The type of an element of an array. `componentType` is always the innermost type, so for
+         * anything past one dimension the element is itself an array.
+         *
+         * @param type The array type
+         * @return The element type
+         */
+        private fun arrayElementType(type: TypeDef.Array): TypeDef =
+            if (type.dimensions > 1) {
+                TypeDef.Array(type.componentType, type.dimensions - 1, false)
+            } else {
+                type.componentType
+            }
+
+        /**
          * @param componentType The component of an array
          * @return The Kotlin type of an array of that component, or null if it is not a primitive
          */
@@ -1525,25 +1539,25 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             if (expressionDef is MathBinaryOperation) {
                 return CodeBlock.builder()
                     .add(renderMathOperand(objectDef, methodDef, scope, expressionDef, expressionDef.left, false))
-                    .add(getMathOp(expressionDef.opType))
+                    .add("%L", getMathOp(expressionDef.opType))
                     .add(renderMathOperand(objectDef, methodDef, scope, expressionDef, expressionDef.right, true))
                     .build()
             }
             if (expressionDef is MathUnaryOperation) {
                 return CodeBlock.builder()
-                    .add(getMathOp(expressionDef.opType))
+                    .add("%L", getMathOp(expressionDef.opType))
                     .add(renderExpressionWithParentheses(objectDef, methodDef, scope, expressionDef.expression))
                     .build()
             }
             if (expressionDef is ComparisonOperation) {
                 return CodeBlock.builder()
                     .add(renderExpressionWithParentheses(objectDef, methodDef, scope, expressionDef.left))
-                    .add(getOpType(expressionDef.opType))
+                    .add("%L", getOpType(expressionDef.opType))
                     .add(renderExpressionWithParentheses(objectDef, methodDef, scope, expressionDef.right))
                     .build()
             }
             if (expressionDef is NewArrayOfSize) {
-                val componentType = expressionDef.type.componentType
+                val componentType = arrayElementType(expressionDef.type)
                 val primitiveArray = primitiveArrayType(componentType)
                 if (primitiveArray != null) {
                     // A primitive array is sized rather than filled with nulls
@@ -1556,7 +1570,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 )
             }
             if (expressionDef is NewArrayInitialized) {
-                val componentType = expressionDef.type.componentType
+                val componentType = arrayElementType(expressionDef.type)
                 val builder: CodeBlock.Builder = CodeBlock.builder()
                 if (componentType is TypeDef.Primitive) {
                     builder.add("%L(", arrayOfFunction(componentType))

--- a/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/AnnotationClassWriteTest.kt
+++ b/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/AnnotationClassWriteTest.kt
@@ -1,0 +1,76 @@
+package io.micronaut.sourcegen
+
+import io.micronaut.sourcegen.custom.visitor.GenerateAnnotationClassVisitor
+import io.micronaut.sourcegen.model.ObjectDef
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.io.StringWriter
+
+/**
+ * An annotation class is a Kotlin `annotation class`, whose members are the properties of its
+ * primary constructor and whose defaults are the parameter defaults.
+ *
+ * Note that the fixture below cannot be compiled by kotlinc: a member of a Java annotation type
+ * (`inner` here) crashes the JVM backend, whatever writes the source. That is why the annotation
+ * class is covered here rather than by a trigger in the Kotlin test suite.
+ */
+class AnnotationClassWriteTest {
+
+    @Test
+    fun writeAnnotationClass() {
+        val annotationDef = GenerateAnnotationClassVisitor.createAnnotation("test.TestAnnotation")
+
+        Assertions.assertEquals(
+            """
+            package test
+
+            import java.lang.`annotation`.ElementType
+            import java.lang.`annotation`.Retention
+            import java.lang.`annotation`.RetentionPolicy
+            import java.lang.`annotation`.Target
+            import kotlin.FloatArray
+            import kotlin.Int
+            import kotlin.IntArray
+            import kotlin.String
+
+            /**
+             * This is my annotation
+             */
+            @Retention(value = RetentionPolicy.RUNTIME)
+            @Target(value = [java.lang.`annotation`.ElementType.TYPE])
+            public annotation class TestAnnotation(
+              /**
+               * This is a string value
+               */
+              public val string: String = "hello",
+              /**
+               * This is a primitive value
+               */
+              public val primitive: Int = 2,
+              /**
+               * This is a primitive array value
+               */
+              public val floats: FloatArray,
+              /**
+               * An enum value with default
+               */
+              public val enumValue: ElementType = ElementType.TYPE,
+              /**
+               * An annotation value with default
+               */
+              public val `inner`:
+                  Target = java.lang.`annotation`.Target(value = [java.lang.`annotation`.ElementType.TYPE]),
+              public val array: IntArray = intArrayOf(1, 2, 3),
+            )
+            """.trimIndent(),
+            write(annotationDef)
+        )
+    }
+
+    private fun write(objectDef: ObjectDef): String {
+        StringWriter().use { writer ->
+            KotlinPoetSourceGenerator().write(objectDef, writer)
+            return writer.toString().trim()
+        }
+    }
+}

--- a/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/ControlFlowWriteTest.kt
+++ b/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/ControlFlowWriteTest.kt
@@ -1,0 +1,299 @@
+package io.micronaut.sourcegen
+
+import io.micronaut.sourcegen.model.ClassDef
+import io.micronaut.sourcegen.model.ClassTypeDef
+import io.micronaut.sourcegen.model.ExpressionDef
+import io.micronaut.sourcegen.model.MethodDef
+import io.micronaut.sourcegen.model.StatementDef
+import io.micronaut.sourcegen.model.TypeDef
+import io.micronaut.sourcegen.model.VariableDef
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.io.StringWriter
+import javax.lang.model.element.Modifier
+
+/**
+ * The control flow statements and the expressions that carry a body, all of which Kotlin writes as
+ * an expression rather than a statement.
+ */
+class ControlFlowWriteTest {
+
+    @Test
+    fun writeIf() {
+        Assertions.assertEquals(
+            """
+            if (`value` == null) {
+              return "empty"
+            }
+            return `value`
+            """.trimIndent(),
+            writeBody(TypeDef.STRING, TypeDef.STRING) { _, params ->
+                StatementDef.multi(
+                    params[0].isNull().doIf(ExpressionDef.constant("empty").returning()),
+                    params[0].returning()
+                )
+            }
+        )
+    }
+
+    @Test
+    fun writeIfElse() {
+        Assertions.assertEquals(
+            """
+            if (`value` == null) {
+              return "empty"
+            } else {
+              return `value`
+            }
+            """.trimIndent(),
+            writeBody(TypeDef.STRING, TypeDef.STRING) { _, params ->
+                params[0].isNull().doIfElse(
+                    ExpressionDef.constant("empty").returning(),
+                    params[0].returning()
+                )
+            }
+        )
+    }
+
+    @Test
+    fun writeWhile() {
+        val counter = VariableDef.Local("counter", TypeDef.Primitive.INT)
+        Assertions.assertEquals(
+            """
+            var counter:Int = 0
+            while (counter < 3) {
+              counter = counter + 1
+            }
+            return counter
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.INT) { _, _ ->
+                StatementDef.multi(
+                    counter.defineAndAssign(ExpressionDef.constant(0)),
+                    StatementDef.While(
+                        counter.compare(
+                            ExpressionDef.ComparisonOperation.OpType.LESS_THAN,
+                            ExpressionDef.constant(3)
+                        ),
+                        counter.assign(
+                            counter.math(
+                                ExpressionDef.MathBinaryOperation.OpType.ADDITION,
+                                ExpressionDef.constant(1)
+                            )
+                        )
+                    ),
+                    counter.returning()
+                )
+            }
+        )
+    }
+
+    @Test
+    fun writeThrow() {
+        Assertions.assertEquals(
+            """
+            throw IllegalStateException("broken")
+            """.trimIndent(),
+            writeBody(TypeDef.VOID) { _, _ ->
+                ClassTypeDef.of(IllegalStateException::class.java)
+                    .instantiate(ExpressionDef.constant("broken"))
+                    .doThrow()
+            }
+        )
+    }
+
+    @Test
+    fun writeStatementSwitchWithDefault() {
+        val cases = linkedMapOf<ExpressionDef.Constant, StatementDef>(
+            ExpressionDef.constant(1) to ExpressionDef.constant("one").returning(),
+            ExpressionDef.constant(2) to ExpressionDef.constant("two").returning()
+        )
+        Assertions.assertEquals(
+            """
+            when (`value`) {
+              1-> {
+                return "one"
+              }
+              2-> {
+                return "two"
+              }
+              else -> {
+                return "many"
+              }
+            }
+            """.trimIndent(),
+            writeBody(TypeDef.STRING, TypeDef.Primitive.INT) { _, params ->
+                params[0].asStatementSwitch(
+                    TypeDef.STRING,
+                    cases,
+                    ExpressionDef.constant("many").returning()
+                )
+            }
+        )
+    }
+
+    @Test
+    fun writeExpressionSwitch() {
+        val cases = linkedMapOf<ExpressionDef.Constant, ExpressionDef>(
+            ExpressionDef.constant(1) to ExpressionDef.constant("one"),
+            ExpressionDef.constant(2) to ExpressionDef.constant("two")
+        )
+        Assertions.assertEquals(
+            """
+            return when (`value`) {
+                  1 -> "one";
+                  2 -> "two";
+                  else -> "many"}
+            """.trimIndent(),
+            writeBody(TypeDef.STRING, TypeDef.Primitive.INT) { _, params ->
+                params[0].asExpressionSwitch(TypeDef.STRING, cases, ExpressionDef.constant("many"))
+                    .returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeExpressionSwitchWithAYieldingCase() {
+        val cases = linkedMapOf<ExpressionDef.Constant, ExpressionDef>(
+            ExpressionDef.constant(1) to ExpressionDef.SwitchYieldCase(
+                TypeDef.STRING,
+                StatementDef.multi(
+                    VariableDef.Local("held", TypeDef.STRING).defineAndAssign(ExpressionDef.constant("one")),
+                    VariableDef.Local("held", TypeDef.STRING).returning()
+                )
+            )
+        )
+        val body = writeBody(TypeDef.STRING, TypeDef.Primitive.INT) { _, params ->
+            params[0].asExpressionSwitch(TypeDef.STRING, cases, ExpressionDef.constant("many")).returning()
+        }
+        Assertions.assertTrue(body.contains("var held:kotlin.String = \"one\""), "was: $body")
+        Assertions.assertTrue(body.contains("return held"), "was: $body")
+    }
+
+    @Test
+    fun writeLambdaWithParameters() {
+        val fnType = ClassTypeDef.of(java.util.function.Function::class.java)
+        Assertions.assertEquals(
+            """
+            return Function {arg0: Any -> arg0}
+            """.trimIndent(),
+            writeBody(fnType) { _, _ ->
+                fnType.getLambda().implement { _, params -> params[0].returning() }.returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeLambdaParameterShadowingAnEnclosingOne() {
+        val fnType = ClassTypeDef.of(java.util.function.Function::class.java)
+        // The enclosing parameter is already named `arg0`, so the lambda's own is renamed
+        val method = MethodDef.builder("run")
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter("arg0", TypeDef.STRING)
+            .returns(fnType)
+            .build { _, params ->
+                fnType.getLambda().implement { _, _ -> params[0].returning() }.returning()
+            }
+        val body = writeMethod(method)
+        Assertions.assertEquals(
+            """
+            return Function {arg01: Any -> arg01}
+            """.trimIndent(),
+            body
+        )
+    }
+
+    @Test
+    fun writeCallWithSeveralArguments() {
+        Assertions.assertEquals(
+            """
+            return `value`.substring(1, 2)
+            """.trimIndent(),
+            writeBody(TypeDef.STRING, TypeDef.STRING) { _, params ->
+                params[0].invoke(
+                    "substring",
+                    listOf(TypeDef.Primitive.INT, TypeDef.Primitive.INT),
+                    TypeDef.STRING,
+                    listOf(ExpressionDef.constant(1), ExpressionDef.constant(2))
+                ).returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeStaticCallWithSeveralArguments() {
+        Assertions.assertEquals(
+            """
+            return LangString.format("%s", `value`)
+            """.trimIndent(),
+            writeBody(TypeDef.STRING, TypeDef.OBJECT) { _, params ->
+                ClassTypeDef.of(String::class.java).invokeStatic(
+                    "format",
+                    listOf(TypeDef.STRING, TypeDef.OBJECT.array()),
+                    TypeDef.STRING,
+                    listOf(ExpressionDef.constant("%s"), params[0])
+                ).returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeArrayElementOfAConditional() {
+        Assertions.assertEquals(
+            """
+            return (if (`value` == null) arrayOf<String>("a") else arrayOf<String>("b"))[0]
+            """.trimIndent(),
+            writeBody(TypeDef.STRING, TypeDef.OBJECT) { _, params ->
+                params[0].isNull()
+                    .doIfElse(
+                        TypeDef.STRING.array().instantiate(ExpressionDef.constant("a")),
+                        TypeDef.STRING.array().instantiate(ExpressionDef.constant("b"))
+                    )
+                    .arrayElement(0)
+                    .returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeConcatenationOfTwoNonStrings() {
+        // Neither side is a String, so the left one is turned into one first
+        Assertions.assertEquals(
+            """
+            return LangString.valueOf(1) + 2
+            """.trimIndent(),
+            writeBody(TypeDef.STRING) { _, _ ->
+                ExpressionDef.StringConcatenation(
+                    ExpressionDef.constant(1),
+                    ExpressionDef.constant(2)
+                ).returning()
+            }
+        )
+    }
+
+    private fun writeBody(
+        returns: TypeDef,
+        vararg parameters: TypeDef,
+        body: (ExpressionDef, List<ExpressionDef>) -> StatementDef
+    ): String {
+        val method = MethodDef.builder("run")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(returns)
+        parameters.forEach { method.addParameter("value", it) }
+        return writeMethod(method.build(body))
+    }
+
+    private fun writeMethod(method: MethodDef): String {
+        val classDef = ClassDef.builder("test.MyClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(method)
+            .build()
+        StringWriter().use { writer ->
+            KotlinPoetSourceGenerator().write(classDef, writer)
+            return writer.toString().lines()
+                .dropWhile { !it.contains("fun run") }
+                .drop(1)
+                .takeWhile { it != "  }" }
+                .joinToString("\n") { it.removePrefix("    ") }
+        }
+    }
+}

--- a/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/ConversionWriteTest.kt
+++ b/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/ConversionWriteTest.kt
@@ -1,0 +1,225 @@
+package io.micronaut.sourcegen
+
+import io.micronaut.sourcegen.model.ClassDef
+import io.micronaut.sourcegen.model.ClassTypeDef
+import io.micronaut.sourcegen.model.ExpressionDef
+import io.micronaut.sourcegen.model.MethodDef
+import io.micronaut.sourcegen.model.StatementDef
+import io.micronaut.sourcegen.model.TypeDef
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.io.StringWriter
+import javax.lang.model.element.Modifier
+
+/**
+ * Kotlin has no primitive casts and no numeric widening, so every primitive `Cast` is a conversion
+ * function, and each primitive has an array type and an array factory of its own.
+ */
+class ConversionWriteTest {
+
+    @Test
+    fun writeNumericConversions() {
+        for ((type, call) in listOf(
+            TypeDef.Primitive.BYTE to ".toByte()",
+            TypeDef.Primitive.SHORT to ".toShort()",
+            TypeDef.Primitive.INT to ".toInt()",
+            TypeDef.Primitive.FLOAT to ".toFloat()",
+            TypeDef.Primitive.DOUBLE to ".toDouble()"
+        )) {
+            Assertions.assertEquals(
+                "return `value`$call",
+                writeBody(type, TypeDef.Primitive.LONG) { _, params -> params[0].cast(type).returning() }
+            )
+        }
+        Assertions.assertEquals(
+            "return `value`.toLong()",
+            writeBody(TypeDef.Primitive.LONG, TypeDef.Primitive.INT) { _, params ->
+                params[0].cast(TypeDef.Primitive.LONG).returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeConversionsFromChar() {
+        // Char has no numeric conversions of its own, so its code is taken first
+        Assertions.assertEquals(
+            "return `value`.code",
+            writeBody(TypeDef.Primitive.INT, TypeDef.Primitive.CHAR) { _, params ->
+                params[0].cast(TypeDef.Primitive.INT).returning()
+            }
+        )
+        Assertions.assertEquals(
+            "return `value`.code.toLong()",
+            writeBody(TypeDef.Primitive.LONG, TypeDef.Primitive.CHAR) { _, params ->
+                params[0].cast(TypeDef.Primitive.LONG).returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeConversionsToChar() {
+        // Only Int declares toChar, so the others go through it
+        Assertions.assertEquals(
+            "return `value`.toChar()",
+            writeBody(TypeDef.Primitive.CHAR, TypeDef.Primitive.INT) { _, params ->
+                params[0].cast(TypeDef.Primitive.CHAR).returning()
+            }
+        )
+        Assertions.assertEquals(
+            "return `value`.toInt().toChar()",
+            writeBody(TypeDef.Primitive.CHAR, TypeDef.Primitive.LONG) { _, params ->
+                params[0].cast(TypeDef.Primitive.CHAR).returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeNestedCastsKeepOnlyTheLastReferenceCast() {
+        Assertions.assertEquals(
+            "return `value` as String",
+            writeBody(TypeDef.STRING, TypeDef.OBJECT) { _, params ->
+                params[0].cast(TypeDef.OBJECT).cast(TypeDef.STRING).returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeNestedCastsKeepAPrimitiveNarrowing() {
+        // Narrowing to Int and widening back is not the same as converting straight to Long,
+        // so the inner conversion has to survive
+        Assertions.assertEquals(
+            "return `value`.toInt().toLong()",
+            writeBody(TypeDef.Primitive.LONG, TypeDef.Primitive.DOUBLE) { _, params ->
+                params[0].cast(TypeDef.Primitive.INT).cast(TypeDef.Primitive.LONG).returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeCastOfANegativeConstant() {
+        Assertions.assertEquals(
+            "return (-1).toLong()",
+            writeBody(TypeDef.Primitive.LONG) { _, _ ->
+                ExpressionDef.constant(-1).cast(TypeDef.Primitive.LONG).returning()
+            }
+        )
+    }
+
+    @Test
+    fun writePrimitiveArrayTypes() {
+        for ((type, name) in listOf(
+            TypeDef.Primitive.BYTE to "ByteArray",
+            TypeDef.Primitive.SHORT to "ShortArray",
+            TypeDef.Primitive.CHAR to "CharArray",
+            TypeDef.Primitive.INT to "IntArray",
+            TypeDef.Primitive.LONG to "LongArray",
+            TypeDef.Primitive.FLOAT to "FloatArray",
+            TypeDef.Primitive.DOUBLE to "DoubleArray",
+            TypeDef.Primitive.BOOLEAN to "BooleanArray"
+        )) {
+            Assertions.assertEquals(
+                "return $name(2)",
+                writeBody(type.array()) { _, _ -> type.array().instantiate(2).returning() }
+            )
+        }
+    }
+
+    @Test
+    fun writePrimitiveArrayFactories() {
+        for ((type, factory) in listOf(
+            TypeDef.Primitive.BYTE to "byteArrayOf",
+            TypeDef.Primitive.SHORT to "shortArrayOf",
+            TypeDef.Primitive.CHAR to "charArrayOf",
+            TypeDef.Primitive.INT to "intArrayOf",
+            TypeDef.Primitive.LONG to "longArrayOf",
+            TypeDef.Primitive.FLOAT to "floatArrayOf",
+            TypeDef.Primitive.DOUBLE to "doubleArrayOf",
+            TypeDef.Primitive.BOOLEAN to "booleanArrayOf"
+        )) {
+            val value: Any = if (type == TypeDef.Primitive.BOOLEAN) true else 1
+            val body = writeBody(type.array()) { _, _ ->
+                type.array().instantiate(ExpressionDef.Constant(type, value)).returning()
+            }
+            Assertions.assertTrue(body.startsWith("return $factory("), "was: $body")
+        }
+    }
+
+    @Test
+    fun writeNestedArrayCreation() {
+        // `componentType` is always the innermost type, so a second dimension has to be put back
+        Assertions.assertEquals(
+            "return arrayOfNulls<Array<String>>(2)",
+            writeBody(TypeDef.STRING.array(2)) { _, _ -> TypeDef.STRING.array(2).instantiate(2).returning() }
+        )
+        Assertions.assertEquals(
+            "return arrayOfNulls<IntArray>(2)",
+            writeBody(TypeDef.Primitive.INT.array(2)) { _, _ ->
+                TypeDef.Primitive.INT.array(2).instantiate(2).returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeBoxedConstants() {
+        for ((type, expected) in listOf(
+            ClassTypeDef.of(java.lang.Long::class.java) to "5L",
+            ClassTypeDef.of(java.lang.Double::class.java) to "5.0",
+            ClassTypeDef.of(java.lang.Float::class.java) to "5.0f",
+            ClassTypeDef.of(java.lang.Byte::class.java) to "5",
+            ClassTypeDef.of(java.lang.Short::class.java) to "5"
+        )) {
+            Assertions.assertEquals(
+                "return $expected",
+                writeBody(type) { _, _ -> ExpressionDef.Constant(type, 5).returning() }
+            )
+        }
+        Assertions.assertEquals(
+            "return 'c'",
+            writeBody(ClassTypeDef.of(Character::class.java)) { _, _ ->
+                ExpressionDef.Constant(ClassTypeDef.of(Character::class.java), 'c').returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeEscapedCharacterConstants() {
+        for ((value, expected) in listOf(
+            '\n' to "\\n",
+            '\t' to "\\t",
+            '\r' to "\\r",
+            '\b' to "\\b",
+            '\u000C' to "\\f",
+            '\'' to "\\'",
+            '\\' to "\\\\",
+            '\u0001' to "\\u0001"
+        )) {
+            Assertions.assertEquals(
+                "return '$expected'",
+                writeBody(TypeDef.Primitive.CHAR) { _, _ -> ExpressionDef.constant(value).returning() }
+            )
+        }
+    }
+
+    private fun writeBody(
+        returns: TypeDef,
+        vararg parameters: TypeDef,
+        body: (ExpressionDef, List<ExpressionDef>) -> StatementDef
+    ): String {
+        val method = MethodDef.builder("run")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(returns)
+        parameters.forEach { method.addParameter("value", it) }
+        val classDef = ClassDef.builder("test.MyClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(method.build(body))
+            .build()
+        StringWriter().use { writer ->
+            KotlinPoetSourceGenerator().write(classDef, writer)
+            return writer.toString().lines()
+                .dropWhile { !it.contains("fun run") }
+                .drop(1)
+                .takeWhile { !it.trim().startsWith("}") }
+                .joinToString("\n") { it.trim() }
+        }
+    }
+}

--- a/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/ExpressionWriteTest.kt
+++ b/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/ExpressionWriteTest.kt
@@ -1,0 +1,246 @@
+package io.micronaut.sourcegen
+
+import io.micronaut.sourcegen.model.ClassDef
+import io.micronaut.sourcegen.model.ClassTypeDef
+import io.micronaut.sourcegen.model.ExpressionDef
+import io.micronaut.sourcegen.model.ExpressionDef.MathBinaryOperation.OpType
+import io.micronaut.sourcegen.model.MethodDef
+import io.micronaut.sourcegen.model.StatementDef
+import io.micronaut.sourcegen.model.TypeDef
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.io.StringWriter
+import javax.lang.model.element.Modifier
+
+/**
+ * The expressions whose Kotlin form differs from the Java one - an array of a primitive has a type
+ * of its own, a primitive cast is a conversion function and the operators bind differently.
+ */
+class ExpressionWriteTest {
+
+    @Test
+    fun writeArrayElement() {
+        Assertions.assertEquals(
+            """
+            return arrayOf<String>("a", "b")[1]
+            """.trimIndent(),
+            writeBody(TypeDef.STRING) { _, _ ->
+                TypeDef.STRING.array()
+                    .instantiate(ExpressionDef.constant("a"), ExpressionDef.constant("b"))
+                    .arrayElement(1)
+                    .returning()
+            }
+        )
+    }
+
+    @Test
+    fun writePrimitiveArrayElement() {
+        Assertions.assertEquals(
+            """
+            return intArrayOf(10, 20)[1]
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.INT) { _, _ ->
+                TypeDef.Primitive.INT.array()
+                    .instantiate(ExpressionDef.constant(10), ExpressionDef.constant(20))
+                    .arrayElement(1)
+                    .returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeSizedPrimitiveArray() {
+        Assertions.assertEquals(
+            """
+            return LongArray(3)
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.LONG.array()) { _, _ ->
+                TypeDef.Primitive.LONG.array().instantiate(3).returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeInstanceOf() {
+        Assertions.assertEquals(
+            """
+            return `value` is String
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.BOOLEAN, TypeDef.OBJECT) { _, params ->
+                params[0].instanceOf(ClassTypeDef.of(String::class.java)).returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeMathPrecedence() {
+        Assertions.assertEquals(
+            """
+            return 2 * (3 + 4)
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.INT) { _, _ ->
+                ExpressionDef.constant(2)
+                    .math(OpType.MULTIPLICATION, ExpressionDef.constant(3).math(OpType.ADDITION, ExpressionDef.constant(4)))
+                    .returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeBitwiseOperationsAsInfixFunctions() {
+        Assertions.assertEquals(
+            """
+            return 1 or (2 and 3)
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.INT) { _, _ ->
+                ExpressionDef.constant(1)
+                    .math(OpType.BITWISE_OR, ExpressionDef.constant(2).math(OpType.BITWISE_AND, ExpressionDef.constant(3)))
+                    .returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeOrNestedInAnd() {
+        Assertions.assertEquals(
+            """
+            return (`value` == null || `value` != null) && `value` == null
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.BOOLEAN, TypeDef.OBJECT) { _, params ->
+                params[0].isNull()
+                    .or(params[0].isNonNull())
+                    .and(params[0].isNull())
+                    .returning()
+            }
+        )
+    }
+
+    @Test
+    fun writePrimitiveCastAsConversion() {
+        Assertions.assertEquals(
+            """
+            return (`value` + 1).toLong()
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.LONG, TypeDef.Primitive.INT) { _, params ->
+                params[0].math(OpType.ADDITION, ExpressionDef.constant(1))
+                    .cast(TypeDef.Primitive.LONG)
+                    .returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeReferenceCastAsAs() {
+        Assertions.assertEquals(
+            """
+            return `value` as String
+            """.trimIndent(),
+            writeBody(TypeDef.STRING, TypeDef.OBJECT) { _, params ->
+                params[0].cast(TypeDef.STRING).returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeStaticCallOnAMappedType() {
+        Assertions.assertEquals(
+            """
+            return LangString.valueOf(1)
+            """.trimIndent(),
+            writeBody(TypeDef.STRING) { _, _ ->
+                ClassTypeDef.of(String::class.java)
+                    .invokeStatic("valueOf", listOf(TypeDef.Primitive.INT), TypeDef.STRING, ExpressionDef.constant(1))
+                    .returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeLongAndDoubleConstants() {
+        Assertions.assertEquals(
+            """
+            return 5L
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.LONG) { _, _ -> ExpressionDef.constant(5L).returning() }
+        )
+        Assertions.assertEquals(
+            """
+            return 5.0
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.DOUBLE) { _, _ -> ExpressionDef.constant(5.0).returning() }
+        )
+        Assertions.assertEquals(
+            """
+            return 'c'
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.CHAR) { _, _ -> ExpressionDef.constant('c').returning() }
+        )
+    }
+
+    @Test
+    fun writeNonFiniteConstants() {
+        Assertions.assertEquals(
+            """
+            return Double.NaN
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.DOUBLE) { _, _ -> ExpressionDef.constant(Double.NaN).returning() }
+        )
+        Assertions.assertEquals(
+            """
+            return Float.POSITIVE_INFINITY
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.FLOAT) { _, _ ->
+                ExpressionDef.constant(Float.POSITIVE_INFINITY).returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeClassConstant() {
+        Assertions.assertEquals(
+            """
+            return String::class.java
+            """.trimIndent(),
+            writeBody(ClassTypeDef.of(Class::class.java)) { _, _ ->
+                ExpressionDef.constant(TypeDef.STRING).returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeLambdaCapturingAnEnclosingParameter() {
+        val fnType = ClassTypeDef.of(java.util.function.Supplier::class.java)
+        Assertions.assertEquals(
+            """
+            return Supplier {() -> `value`}
+            """.trimIndent(),
+            writeBody(fnType, TypeDef.STRING) { _, params ->
+                fnType.getLambda().implement { _, _ -> params[0].returning() }.returning()
+            }
+        )
+    }
+
+    private fun writeBody(
+        returns: TypeDef,
+        vararg parameters: TypeDef,
+        body: (ExpressionDef, List<ExpressionDef>) -> StatementDef
+    ): String {
+        val method = MethodDef.builder("run")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(returns)
+        parameters.forEach { method.addParameter("value", it) }
+        val classDef = ClassDef.builder("test.MyClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(method.build(body))
+            .build()
+        StringWriter().use { writer ->
+            KotlinPoetSourceGenerator().write(classDef, writer)
+            // Only the body of the single method is of interest here
+            return writer.toString().lines()
+                .dropWhile { !it.contains("fun run") }
+                .drop(1)
+                .takeWhile { !it.trim().startsWith("}") }
+                .joinToString("\n") { it.trim() }
+        }
+    }
+}

--- a/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/OperatorWriteTest.kt
+++ b/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/OperatorWriteTest.kt
@@ -1,0 +1,344 @@
+package io.micronaut.sourcegen
+
+import io.micronaut.sourcegen.model.ClassDef
+import io.micronaut.sourcegen.model.ClassTypeDef
+import io.micronaut.sourcegen.model.ExpressionDef
+import io.micronaut.sourcegen.model.ExpressionDef.ComparisonOperation
+import io.micronaut.sourcegen.model.ExpressionDef.MathBinaryOperation.OpType
+import io.micronaut.sourcegen.model.ExpressionDef.MathUnaryOperation
+import io.micronaut.sourcegen.model.MethodDef
+import io.micronaut.sourcegen.model.StatementDef
+import io.micronaut.sourcegen.model.TypeDef
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.io.StringWriter
+import javax.lang.model.element.Modifier
+
+/**
+ * The operator and comparison expressions. Kotlin agrees with Java on most of the spelling, so what
+ * is pinned here is where the operands need parentheses and where an operation is a function call
+ * rather than an operator.
+ */
+class OperatorWriteTest {
+
+    @Test
+    fun writeConditionalExpression() {
+        Assertions.assertEquals(
+            """
+            return if (`value` == null) "empty" else "present"
+            """.trimIndent(),
+            writeBody(TypeDef.STRING, TypeDef.OBJECT) { _, params ->
+                params[0].isNull()
+                    .doIfElse(ExpressionDef.constant("empty"), ExpressionDef.constant("present"))
+                    .returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeComparisons() {
+        for ((op, symbol) in listOf(
+            ComparisonOperation.OpType.EQUAL_TO to "==",
+            ComparisonOperation.OpType.NOT_EQUAL_TO to "!=",
+            ComparisonOperation.OpType.GREATER_THAN to ">",
+            ComparisonOperation.OpType.LESS_THAN to "<",
+            ComparisonOperation.OpType.GREATER_THAN_OR_EQUAL to ">=",
+            ComparisonOperation.OpType.LESS_THAN_OR_EQUAL to "<="
+        )) {
+            Assertions.assertEquals(
+                "return `value` $symbol 1",
+                writeBody(TypeDef.Primitive.BOOLEAN, TypeDef.Primitive.INT) { _, params ->
+                    params[0].compare(op, ExpressionDef.constant(1)).returning()
+                }
+            )
+        }
+    }
+
+    @Test
+    fun writeNegation() {
+        Assertions.assertEquals(
+            """
+            return -(`value` + 1)
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.INT, TypeDef.Primitive.INT) { _, params ->
+                params[0].math(OpType.ADDITION, ExpressionDef.constant(1))
+                    .math(MathUnaryOperation.OpType.NEGATE)
+                    .returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeNegatedCondition() {
+        Assertions.assertEquals(
+            """
+            return !(`value` == null || `value` != null)
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.BOOLEAN, TypeDef.OBJECT) { _, params ->
+                params[0].isNull().or(params[0].isNonNull()).isFalse().returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeNegatedValue() {
+        Assertions.assertEquals(
+            """
+            return !`value`
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.BOOLEAN, TypeDef.Primitive.BOOLEAN) { _, params ->
+                params[0].isFalse().returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeGetClassAndHashCode() {
+        Assertions.assertEquals(
+            """
+            return `value`.javaClass
+            """.trimIndent(),
+            writeBody(ClassTypeDef.of(Class::class.java), TypeDef.OBJECT) { _, params ->
+                params[0].invokeGetClass().returning()
+            }
+        )
+        Assertions.assertEquals(
+            """
+            return `value`.hashCode()
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.INT, TypeDef.OBJECT) { _, params ->
+                params[0].invokeHashCode().returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeHashCodeOfAnArray() {
+        Assertions.assertEquals(
+            """
+            return `value`.contentHashCode()
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.INT, TypeDef.STRING.array()) { _, params ->
+                params[0].invokeHashCode().returning()
+            }
+        )
+        Assertions.assertEquals(
+            """
+            return `value`.contentDeepHashCode()
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.INT, TypeDef.STRING.array(2)) { _, params ->
+                params[0].invokeHashCode().returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeStructuralEquality() {
+        Assertions.assertEquals(
+            """
+            return `value` == "other"
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.BOOLEAN, TypeDef.STRING) { _, params ->
+                params[0].equalsStructurally(ExpressionDef.constant("other")).returning()
+            }
+        )
+        Assertions.assertEquals(
+            """
+            return `value` != "other"
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.BOOLEAN, TypeDef.STRING) { _, params ->
+                params[0].notEqualsStructurally(ExpressionDef.constant("other")).returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeStructuralEqualityOfArrays() {
+        val other = TypeDef.STRING.array().instantiate(ExpressionDef.constant("a"))
+        Assertions.assertEquals(
+            """
+            return `value`.contentEquals(arrayOf<String>("a"))
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.BOOLEAN, TypeDef.STRING.array()) { _, params ->
+                params[0].equalsStructurally(other).returning()
+            }
+        )
+        Assertions.assertEquals(
+            """
+            return !`value`.contentEquals(arrayOf<String>("a"))
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.BOOLEAN, TypeDef.STRING.array()) { _, params ->
+                params[0].notEqualsStructurally(other).returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeStructuralEqualityOfNestedArrays() {
+        val other = TypeDef.STRING.array(2).instantiate(0)
+        Assertions.assertEquals(
+            """
+            return `value`.contentDeepEquals(arrayOfNulls<Array<String>>(0))
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.BOOLEAN, TypeDef.STRING.array(2)) { _, params ->
+                params[0].equalsStructurally(other).returning()
+            }
+        )
+        Assertions.assertEquals(
+            """
+            return !`value`.contentDeepEquals(arrayOfNulls<Array<String>>(0))
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.BOOLEAN, TypeDef.STRING.array(2)) { _, params ->
+                params[0].notEqualsStructurally(other).returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeReferentialEquality() {
+        Assertions.assertEquals(
+            """
+            return `value` === "other"
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.BOOLEAN, TypeDef.STRING) { _, params ->
+                params[0].equalsReferentially(ExpressionDef.constant("other")).returning()
+            }
+        )
+        Assertions.assertEquals(
+            """
+            return `value` !== "other"
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.BOOLEAN, TypeDef.STRING) { _, params ->
+                params[0].notEqualsReferentially(ExpressionDef.constant("other")).returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeNestedConcatenation() {
+        Assertions.assertEquals(
+            """
+            return "a" + ("b" + "c")
+            """.trimIndent(),
+            writeBody(TypeDef.STRING) { _, _ ->
+                ExpressionDef.StringConcatenation(
+                    ExpressionDef.constant("a"),
+                    ExpressionDef.StringConcatenation(ExpressionDef.constant("b"), ExpressionDef.constant("c"))
+                ).returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeCallOnAConcatenationTarget() {
+        Assertions.assertEquals(
+            """
+            return ("a" + "b").trim()
+            """.trimIndent(),
+            writeBody(TypeDef.STRING) { _, _ ->
+                ExpressionDef.StringConcatenation(ExpressionDef.constant("a"), ExpressionDef.constant("b"))
+                    .invoke("trim", TypeDef.STRING)
+                    .returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeShiftsAndXorAsInfixFunctions() {
+        for ((op, name) in listOf(
+            OpType.BITWISE_XOR to "xor",
+            OpType.BITWISE_LEFT_SHIFT to "shl",
+            OpType.BITWISE_RIGHT_SHIFT to "shr",
+            OpType.BITWISE_UNSIGNED_RIGHT_SHIFT to "ushr"
+        )) {
+            Assertions.assertEquals(
+                "return `value` $name 2",
+                writeBody(TypeDef.Primitive.INT, TypeDef.Primitive.INT) { _, params ->
+                    params[0].math(op, ExpressionDef.constant(2)).returning()
+                }
+            )
+        }
+    }
+
+    @Test
+    fun writeSubtractionOfASubtraction() {
+        // `-` is left-associative, so only the right operand needs the parentheses back
+        Assertions.assertEquals(
+            """
+            return 1 - (2 - 3)
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.INT) { _, _ ->
+                ExpressionDef.constant(1)
+                    .math(
+                        OpType.SUBTRACTION,
+                        ExpressionDef.constant(2).math(OpType.SUBTRACTION, ExpressionDef.constant(3))
+                    )
+                    .returning()
+            }
+        )
+        Assertions.assertEquals(
+            """
+            return 1 - 2 - 3
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.INT) { _, _ ->
+                ExpressionDef.constant(1)
+                    .math(OpType.SUBTRACTION, ExpressionDef.constant(2))
+                    .math(OpType.SUBTRACTION, ExpressionDef.constant(3))
+                    .returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeModulusInsideMultiplication() {
+        Assertions.assertEquals(
+            """
+            return 2 * 3 % 4
+            """.trimIndent(),
+            writeBody(TypeDef.Primitive.INT) { _, _ ->
+                ExpressionDef.constant(2)
+                    .math(OpType.MULTIPLICATION, ExpressionDef.constant(3))
+                    .math(OpType.MODULUS, ExpressionDef.constant(4))
+                    .returning()
+            }
+        )
+    }
+
+    @Test
+    fun writeDivisionAsACallTarget() {
+        Assertions.assertEquals(
+            """
+            return (100 / `value`).toString()
+            """.trimIndent(),
+            writeBody(TypeDef.STRING, TypeDef.Primitive.INT) { _, params ->
+                ExpressionDef.constant(100)
+                    .math(OpType.DIVISION, params[0])
+                    .invoke("toString", TypeDef.STRING)
+                    .returning()
+            }
+        )
+    }
+
+    private fun writeBody(
+        returns: TypeDef,
+        vararg parameters: TypeDef,
+        body: (ExpressionDef, List<ExpressionDef>) -> StatementDef
+    ): String {
+        val method = MethodDef.builder("run")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(returns)
+        parameters.forEach { method.addParameter("value", it) }
+        val classDef = ClassDef.builder("test.MyClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(method.build(body))
+            .build()
+        StringWriter().use { writer ->
+            KotlinPoetSourceGenerator().write(classDef, writer)
+            return writer.toString().lines()
+                .dropWhile { !it.contains("fun run") }
+                .drop(1)
+                .takeWhile { !it.trim().startsWith("}") }
+                .joinToString("\n") { it.trim() }
+        }
+    }
+}

--- a/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/StatementWriteTest.kt
+++ b/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/StatementWriteTest.kt
@@ -1,0 +1,167 @@
+package io.micronaut.sourcegen
+
+import io.micronaut.sourcegen.model.ClassDef
+import io.micronaut.sourcegen.model.ClassTypeDef
+import io.micronaut.sourcegen.model.ExpressionDef
+import io.micronaut.sourcegen.model.MethodDef
+import io.micronaut.sourcegen.model.StatementDef
+import io.micronaut.sourcegen.model.TypeDef
+import io.micronaut.sourcegen.model.VariableDef
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.io.StringWriter
+import javax.lang.model.element.Modifier
+
+/**
+ * The statements that Kotlin spells differently to Java - a catch variable has to be named, a
+ * synchronized block is a function taking the body and a static field lives on a companion object.
+ */
+class StatementWriteTest {
+
+    @Test
+    fun writeTryCatchFinally() {
+        val body = MethodDef.builder("run")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(TypeDef.STRING)
+            .build { _, _ ->
+                ExpressionDef.constant("value").returning()
+                    .doTry()
+                    .doCatch(IllegalStateException::class.java) { e -> e.invoke("toString", TypeDef.STRING).returning() }
+                    .doFinally(ExpressionDef.constant("cleanup").invoke("trim", TypeDef.STRING))
+            }
+
+        Assertions.assertEquals(
+            """
+            package test
+
+            import java.lang.IllegalStateException
+            import kotlin.String
+
+            public class MyClass {
+              public fun run(): String {
+                try {
+                  return "value"
+                } catch (e: IllegalStateException) {
+                  return e.toString()
+                } finally {
+                  "cleanup".trim()
+                }
+              }
+            }
+            """.trimIndent(),
+            writeClass(body)
+        )
+    }
+
+    @Test
+    fun writeNestedCatchesUnderDistinctNames() {
+        val body = MethodDef.builder("run")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(TypeDef.STRING)
+            .build { _, _ ->
+                ExpressionDef.constant("value").returning()
+                    .doTry()
+                    .doCatch(IllegalStateException::class.java) { outer ->
+                        outer.invoke("toString", TypeDef.STRING).returning()
+                            .doTry()
+                            .doCatch(RuntimeException::class.java) { inner ->
+                                inner.invoke("toString", TypeDef.STRING).returning()
+                            }
+                    }
+            }
+
+        Assertions.assertEquals(
+            """
+            package test
+
+            import java.lang.IllegalStateException
+            import java.lang.RuntimeException
+            import kotlin.String
+
+            public class MyClass {
+              public fun run(): String {
+                try {
+                  return "value"
+                } catch (e: IllegalStateException) {
+                  try {
+                    return e.toString()
+                  } catch (e1: RuntimeException) {
+                    return e1.toString()
+                  }
+                }
+              }
+            }
+            """.trimIndent(),
+            writeClass(body)
+        )
+    }
+
+    @Test
+    fun writeSynchronized() {
+        val result = VariableDef.Local("result", TypeDef.STRING)
+        val body = MethodDef.builder("run")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(TypeDef.STRING)
+            .build { aThis, _ ->
+                StatementDef.multi(
+                    result.defineAndAssign(ExpressionDef.constant("before")),
+                    StatementDef.Synchronized(aThis, result.assign(ExpressionDef.constant("locked"))),
+                    result.returning()
+                )
+            }
+
+        Assertions.assertEquals(
+            """
+            package test
+
+            import kotlin.String
+
+            public class MyClass {
+              public fun run(): String {
+                var result:String = "before"
+                synchronized(this) {
+                  result = "locked"
+                }
+                return result
+              }
+            }
+            """.trimIndent(),
+            writeClass(body)
+        )
+    }
+
+    @Test
+    fun writePutStaticField() {
+        val owner = ClassTypeDef.of("test.Owner")
+        val body = MethodDef.builder("run")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(TypeDef.VOID)
+            .build { _, _ ->
+                owner.getStaticField("NAME", TypeDef.STRING).put(ExpressionDef.constant("value"))
+            }
+
+        Assertions.assertEquals(
+            """
+            package test
+
+            public class MyClass {
+              public fun run() {
+                Owner.NAME = "value"
+              }
+            }
+            """.trimIndent(),
+            writeClass(body)
+        )
+    }
+
+    private fun writeClass(method: MethodDef): String {
+        val classDef = ClassDef.builder("test.MyClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(method)
+            .build()
+        StringWriter().use { writer ->
+            KotlinPoetSourceGenerator().write(classDef, writer)
+            return writer.toString().trim()
+        }
+    }
+}

--- a/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/Trigger.java
+++ b/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/Trigger.java
@@ -22,6 +22,7 @@ import io.micronaut.sourcegen.custom.example.GenerateIfsPredicate;
 import io.micronaut.sourcegen.custom.example.GenerateInnerTypes;
 import io.micronaut.sourcegen.custom.example.GenerateLambda;
 import io.micronaut.sourcegen.custom.example.GenerateMethodInvocation;
+import io.micronaut.sourcegen.custom.example.GenerateStatements;
 import io.micronaut.sourcegen.custom.example.GenerateMyBean1;
 import io.micronaut.sourcegen.custom.example.GenerateMyBean2;
 import io.micronaut.sourcegen.custom.example.GenerateMyBean3;
@@ -48,6 +49,7 @@ import io.micronaut.sourcegen.custom.example.GenerateSwitch;
 @GenerateMethodInvocation
 @GenerateInnerTypes
 @GenerateLambda
+@GenerateStatements
 @GenerateExpressions
 public class Trigger {
 }

--- a/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/StatementsTest.java
+++ b/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/StatementsTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2003-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StatementsTest {
+
+    @Test
+    void tryCatchTakesTheCatchBranch() {
+        assertEquals(50, MyStatements.divideOrFallback(2));
+        assertEquals(-1, MyStatements.divideOrFallback(0));
+    }
+
+    @Test
+    void catchBlockSeesTheException() {
+        assertEquals("50", MyStatements.catchAndDescribe(2));
+        assertEquals("java.lang.ArithmeticException: / by zero", MyStatements.catchAndDescribe(0));
+    }
+
+    @Test
+    void finallyRunsAfterTheBody() {
+        StringBuilder builder = new StringBuilder();
+        assertEquals("t", MyStatements.tryFinally(builder));
+        assertEquals("tf", builder.toString());
+    }
+
+    @Test
+    void synchronizedBlockRunsItsBody() {
+        assertEquals("locked", MyStatements.synchronizedAssign(new Object()));
+    }
+
+    @Test
+    void staticFieldIsAssignedAndRead() {
+        assertEquals("none", MyStatements.recallValue());
+        MyStatements.rememberValue("remembered");
+        assertEquals("remembered", MyStatements.recallValue());
+    }
+
+    @Test
+    void arrayElementsAreIndexed() {
+        assertEquals("b", MyStatements.elementOfObjectArray(1));
+        assertEquals(30, MyStatements.elementOfPrimitiveArray(2));
+        assertEquals(0L, MyStatements.sizedPrimitiveArray());
+    }
+
+    @Test
+    void instanceOfIsChecked() {
+        assertTrue(MyStatements.isString("text"));
+        assertFalse(MyStatements.isString(1));
+    }
+
+    @Test
+    void operandsKeepTheirPrecedence() {
+        assertEquals(20, MyStatements.multiplyBySum(4, 2, 3));
+        assertEquals(20, MyStatements.shiftOfSum(2, 3, 2));
+        assertTrue(MyStatements.orThenAnd(false, true, true));
+        assertFalse(MyStatements.orThenAnd(true, false, false));
+        assertEquals(-5L, MyStatements.negatedSumAsLong(2, 3));
+        assertEquals("5", MyStatements.sumAsString(2, 3));
+    }
+
+}

--- a/test-suite-custom-annotations/src/main/java/io/micronaut/sourcegen/custom/example/GenerateStatements.java
+++ b/test-suite-custom-annotations/src/main/java/io/micronaut/sourcegen/custom/example/GenerateStatements.java
@@ -13,24 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.sourcegen.example
+package io.micronaut.sourcegen.custom.example;
 
-import io.micronaut.sourcegen.custom.example.*
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
-@GenerateMyBean1
-@GenerateMyBean2
-@GenerateMyBean3
-@GenerateInterface
-@GenerateMyRepository1
-@GenerateMyRecord1
-@GenerateMyEnum1
-@GenerateIfsPredicate
-@GenerateSwitch
-@GenerateArray
-@GenerateAnnotatedType
-@GenerateInnerTypes
-@GenerateMyEnum2
-@GenerateLambda
-@GenerateStatements
-@GenerateSuperTypeReference
-class Trigger
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+public @interface GenerateStatements {
+}

--- a/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateStatementsVisitor.java
+++ b/test-suite-custom-generators/src/main/java/io/micronaut/sourcegen/custom/visitor/GenerateStatementsVisitor.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.custom.visitor;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+import io.micronaut.sourcegen.custom.example.GenerateStatements;
+import io.micronaut.sourcegen.generator.SourceGenerator;
+import io.micronaut.sourcegen.generator.SourceGenerators;
+import io.micronaut.sourcegen.model.ClassDef;
+import io.micronaut.sourcegen.model.ClassTypeDef;
+import io.micronaut.sourcegen.model.ExpressionDef;
+import io.micronaut.sourcegen.model.ExpressionDef.MathBinaryOperation.OpType;
+import io.micronaut.sourcegen.model.FieldDef;
+import io.micronaut.sourcegen.model.MethodDef;
+import io.micronaut.sourcegen.model.StatementDef;
+import io.micronaut.sourcegen.model.TypeDef;
+import io.micronaut.sourcegen.model.VariableDef;
+import io.micronaut.sourcegen.model.VariableDef.Local;
+import org.jspecify.annotations.NonNull;
+
+import javax.lang.model.element.Modifier;
+import java.util.List;
+
+/**
+ * Generates a class exercising the statements and expressions that have no dedicated syntax of their
+ * own in every language - a try/catch/finally, a synchronized block, a static field assignment, an
+ * array element, an instanceof and the operations whose rendering depends on operator precedence.
+ */
+@Internal
+public final class GenerateStatementsVisitor implements TypeElementVisitor<GenerateStatements, Object> {
+
+    private static final String CLASS_NAME = "MyStatements";
+
+    @Override
+    public @NonNull VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        SourceGenerator sourceGenerator = SourceGenerators.findByLanguage(context.getLanguage()).orElse(null);
+        if (sourceGenerator == null) {
+            return;
+        }
+        sourceGenerator.write(createClass(element.getPackageName()), context, element);
+    }
+
+    public static ClassDef createClass(String packageName) {
+        String className = packageName + "." + CLASS_NAME;
+        ClassTypeDef selfType = ClassTypeDef.of(className);
+        FieldDef lastValue = FieldDef.builder("lastValue")
+            .ofType(TypeDef.STRING)
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .initializer(ExpressionDef.constant("none"))
+            .build();
+
+        return ClassDef.builder(className)
+            .addModifiers(Modifier.PUBLIC)
+            .addField(lastValue)
+            .addMethod(divideOrFallback())
+            .addMethod(catchAndDescribe())
+            .addMethod(tryFinally())
+            .addMethod(synchronizedAssign())
+            .addMethod(rememberValue(selfType, lastValue))
+            .addMethod(recallValue(selfType, lastValue))
+            .addMethod(elementOfObjectArray())
+            .addMethod(elementOfPrimitiveArray())
+            .addMethod(sizedPrimitiveArray())
+            .addMethod(isString())
+            .addMethod(multiplyBySum())
+            .addMethod(shiftOfSum())
+            .addMethod(orThenAnd())
+            .addMethod(negatedSumAsLong())
+            .addMethod(sumAsString())
+            .build();
+    }
+
+    // divideOrFallback(int divisor) { try { return 100 / divisor; } catch (ArithmeticException e) { return -1; } }
+    private static MethodDef divideOrFallback() {
+        return MethodDef.builder("divideOrFallback")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addParameter("divisor", TypeDef.Primitive.INT)
+            .returns(TypeDef.Primitive.INT)
+            .buildStatic(params -> ExpressionDef.constant(100)
+                .math(OpType.DIVISION, params.get(0))
+                .returning()
+                .doTry()
+                .doCatch(ArithmeticException.class, e -> ExpressionDef.constant(-1).returning()));
+    }
+
+    // catchAndDescribe(int divisor) { try { ... } catch (ArithmeticException e) { return e.getMessage(); } }
+    private static MethodDef catchAndDescribe() {
+        return MethodDef.builder("catchAndDescribe")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addParameter("divisor", TypeDef.Primitive.INT)
+            .returns(TypeDef.STRING)
+            .buildStatic(params -> ClassTypeDef.of(String.class)
+                .invokeStatic("valueOf", List.of(TypeDef.Primitive.INT), TypeDef.STRING,
+                    ExpressionDef.constant(100).math(OpType.DIVISION, params.get(0)))
+                .returning()
+                .doTry()
+                .doCatch(ArithmeticException.class,
+                    e -> e.invoke("toString", TypeDef.STRING).returning()));
+    }
+
+    // tryFinally(StringBuilder builder) { try { return builder.append("t").toString(); } finally { builder.append("f"); } }
+    private static MethodDef tryFinally() {
+        return MethodDef.builder("tryFinally")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addParameter("builder", StringBuilder.class)
+            .returns(TypeDef.STRING)
+            .buildStatic(params -> params.get(0)
+                .invoke("append", TypeDef.of(StringBuilder.class), ExpressionDef.constant("t"))
+                .invoke("toString", TypeDef.STRING)
+                .returning()
+                .doTry()
+                .doFinally(
+                    params.get(0).invoke("append", TypeDef.of(StringBuilder.class), ExpressionDef.constant("f"))));
+    }
+
+    // synchronizedAssign(Object monitor) { String result = "before"; synchronized (monitor) { result = "locked"; } return result; }
+    private static MethodDef synchronizedAssign() {
+        Local result = new Local("result", TypeDef.STRING);
+        return MethodDef.builder("synchronizedAssign")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addParameter("monitor", TypeDef.OBJECT)
+            .returns(TypeDef.STRING)
+            .buildStatic(params -> StatementDef.multi(
+                result.defineAndAssign(ExpressionDef.constant("before")),
+                new StatementDef.Synchronized(params.get(0), result.assign(ExpressionDef.constant("locked"))),
+                result.returning()
+            ));
+    }
+
+    // rememberValue(String value) { lastValue = value; }
+    private static MethodDef rememberValue(ClassTypeDef selfType, FieldDef field) {
+        return MethodDef.builder("rememberValue")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addParameter("value", TypeDef.STRING)
+            .returns(TypeDef.VOID)
+            .buildStatic(params -> selfType.getStaticField(field).put(params.get(0)));
+    }
+
+    // recallValue() { return lastValue; }
+    private static MethodDef recallValue(ClassTypeDef selfType, FieldDef field) {
+        return MethodDef.builder("recallValue")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .returns(TypeDef.STRING)
+            .buildStatic(params -> selfType.getStaticField(field).returning());
+    }
+
+    // elementOfObjectArray(int index) { return new String[]{"a", "b", "c"}[index]; }
+    private static MethodDef elementOfObjectArray() {
+        return MethodDef.builder("elementOfObjectArray")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addParameter("index", TypeDef.Primitive.INT)
+            .returns(TypeDef.STRING)
+            .buildStatic(params -> TypeDef.STRING.array()
+                .instantiate(ExpressionDef.constant("a"), ExpressionDef.constant("b"), ExpressionDef.constant("c"))
+                .arrayElement(params.get(0))
+                .returning());
+    }
+
+    // elementOfPrimitiveArray(int index) { return new int[]{10, 20, 30}[index]; }
+    private static MethodDef elementOfPrimitiveArray() {
+        return MethodDef.builder("elementOfPrimitiveArray")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addParameter("index", TypeDef.Primitive.INT)
+            .returns(TypeDef.Primitive.INT)
+            .buildStatic(params -> TypeDef.Primitive.INT.array()
+                .instantiate(ExpressionDef.constant(10), ExpressionDef.constant(20), ExpressionDef.constant(30))
+                .arrayElement(params.get(0))
+                .returning());
+    }
+
+    // sizedPrimitiveArray() { return new long[3].length; }
+    private static MethodDef sizedPrimitiveArray() {
+        Local values = new Local("values", TypeDef.Primitive.LONG.array());
+        return MethodDef.builder("sizedPrimitiveArray")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .returns(TypeDef.Primitive.LONG)
+            .buildStatic(params -> StatementDef.multi(
+                values.defineAndAssign(TypeDef.Primitive.LONG.array().instantiate(3)),
+                values.arrayElement(2).returning()
+            ));
+    }
+
+    // isString(Object value) { return value instanceof String; }
+    private static MethodDef isString() {
+        return MethodDef.builder("isString")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addParameter("value", TypeDef.OBJECT)
+            .returns(TypeDef.Primitive.BOOLEAN)
+            .buildStatic(params -> params.get(0).instanceOf(ClassTypeDef.of(String.class)).returning());
+    }
+
+    // multiplyBySum(int a, int b, int c) { return a * (b + c); }
+    private static MethodDef multiplyBySum() {
+        return MethodDef.builder("multiplyBySum")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addParameter("a", TypeDef.Primitive.INT)
+            .addParameter("b", TypeDef.Primitive.INT)
+            .addParameter("c", TypeDef.Primitive.INT)
+            .returns(TypeDef.Primitive.INT)
+            .buildStatic(params -> params.get(0)
+                .math(OpType.MULTIPLICATION, params.get(1).math(OpType.ADDITION, params.get(2)))
+                .returning());
+    }
+
+    // shiftOfSum(int a, int b, int c) { return (a + b) << c; }
+    private static MethodDef shiftOfSum() {
+        return MethodDef.builder("shiftOfSum")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addParameter("a", TypeDef.Primitive.INT)
+            .addParameter("b", TypeDef.Primitive.INT)
+            .addParameter("c", TypeDef.Primitive.INT)
+            .returns(TypeDef.Primitive.INT)
+            .buildStatic(params -> params.get(0)
+                .math(OpType.ADDITION, params.get(1))
+                .math(OpType.BITWISE_LEFT_SHIFT, params.get(2))
+                .returning());
+    }
+
+    // orThenAnd(boolean a, boolean b, boolean c) { return (a || b) && c; }
+    private static MethodDef orThenAnd() {
+        return MethodDef.builder("orThenAnd")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addParameter("a", TypeDef.Primitive.BOOLEAN)
+            .addParameter("b", TypeDef.Primitive.BOOLEAN)
+            .addParameter("c", TypeDef.Primitive.BOOLEAN)
+            .returns(TypeDef.Primitive.BOOLEAN)
+            .buildStatic(params -> params.get(0).isTrue()
+                .or(params.get(1).isTrue())
+                .and(params.get(2).isTrue())
+                .returning());
+    }
+
+    // negatedSumAsLong(int a, int b) { return (long) -(a + b); }
+    private static MethodDef negatedSumAsLong() {
+        return MethodDef.builder("negatedSumAsLong")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addParameter("a", TypeDef.Primitive.INT)
+            .addParameter("b", TypeDef.Primitive.INT)
+            .returns(TypeDef.Primitive.LONG)
+            .buildStatic(params -> params.get(0)
+                .math(OpType.ADDITION, params.get(1))
+                .math(ExpressionDef.MathUnaryOperation.OpType.NEGATE)
+                .cast(TypeDef.Primitive.LONG)
+                .returning());
+    }
+
+    // sumAsString(int a, int b) { return String.valueOf(a + b); }
+    private static MethodDef sumAsString() {
+        return MethodDef.builder("sumAsString")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addParameter("a", TypeDef.Primitive.INT)
+            .addParameter("b", TypeDef.Primitive.INT)
+            .returns(TypeDef.STRING)
+            .buildStatic(params -> ClassTypeDef.of(String.class)
+                .invokeStatic("valueOf", List.of(TypeDef.Primitive.INT), TypeDef.STRING,
+                    params.get(0).math(OpType.ADDITION, params.get(1)))
+                .returning());
+    }
+
+}

--- a/test-suite-custom-generators/src/main/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/test-suite-custom-generators/src/main/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -20,6 +20,7 @@ io.micronaut.sourcegen.custom.visitor.innerTypes.GenerateInnerTypeInInterfaceVis
 io.micronaut.sourcegen.custom.visitor.GenerateAnnotatedTypeVisitor
 io.micronaut.sourcegen.custom.visitor.GenerateMyEnum2Visitor
 io.micronaut.sourcegen.custom.visitor.GenerateLambdaVisitor
+io.micronaut.sourcegen.custom.visitor.GenerateStatementsVisitor
 io.micronaut.sourcegen.custom.visitor.GenerateAnnotationClassVisitor
 io.micronaut.sourcegen.custom.visitor.GenerateAccessVisitor
 io.micronaut.sourcegen.custom.visitor.GenerateExpressionsVisitor

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/Trigger.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/Trigger.java
@@ -36,6 +36,7 @@ import java.util.List;
 @GenerateMyEnum2
 @GenerateMethodInvocation
 @GenerateLambda
+@GenerateStatements
 @GenerateAnnotationClass
 public class Trigger {
     public List<String> copyAddresses;

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/StatementsTest.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/StatementsTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2003-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StatementsTest {
+
+    @Test
+    void tryCatchTakesTheCatchBranch() {
+        assertEquals(50, MyStatements.divideOrFallback(2));
+        assertEquals(-1, MyStatements.divideOrFallback(0));
+    }
+
+    @Test
+    void catchBlockSeesTheException() {
+        assertEquals("50", MyStatements.catchAndDescribe(2));
+        assertEquals("java.lang.ArithmeticException: / by zero", MyStatements.catchAndDescribe(0));
+    }
+
+    @Test
+    void finallyRunsAfterTheBody() {
+        StringBuilder builder = new StringBuilder();
+        assertEquals("t", MyStatements.tryFinally(builder));
+        assertEquals("tf", builder.toString());
+    }
+
+    @Test
+    void synchronizedBlockRunsItsBody() {
+        assertEquals("locked", MyStatements.synchronizedAssign(new Object()));
+    }
+
+    @Test
+    void staticFieldIsAssignedAndRead() {
+        assertEquals("none", MyStatements.recallValue());
+        MyStatements.rememberValue("remembered");
+        assertEquals("remembered", MyStatements.recallValue());
+    }
+
+    @Test
+    void arrayElementsAreIndexed() {
+        assertEquals("b", MyStatements.elementOfObjectArray(1));
+        assertEquals(30, MyStatements.elementOfPrimitiveArray(2));
+        assertEquals(0L, MyStatements.sizedPrimitiveArray());
+    }
+
+    @Test
+    void instanceOfIsChecked() {
+        assertTrue(MyStatements.isString("text"));
+        assertFalse(MyStatements.isString(1));
+    }
+
+    @Test
+    void operandsKeepTheirPrecedence() {
+        assertEquals(20, MyStatements.multiplyBySum(4, 2, 3));
+        assertEquals(20, MyStatements.shiftOfSum(2, 3, 2));
+        assertTrue(MyStatements.orThenAnd(false, true, true));
+        assertFalse(MyStatements.orThenAnd(true, false, false));
+        assertEquals(-5L, MyStatements.negatedSumAsLong(2, 3));
+        assertEquals("5", MyStatements.sumAsString(2, 3));
+    }
+
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/sourcegen/example/StatementsTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/sourcegen/example/StatementsTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2003-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class StatementsTest {
+
+    @Test
+    fun tryCatchTakesTheCatchBranch() {
+        assertEquals(50, MyStatements.divideOrFallback(2))
+        assertEquals(-1, MyStatements.divideOrFallback(0))
+    }
+
+    @Test
+    fun catchBlockSeesTheException() {
+        assertEquals("50", MyStatements.catchAndDescribe(2))
+        assertEquals("java.lang.ArithmeticException: / by zero", MyStatements.catchAndDescribe(0))
+    }
+
+    @Test
+    fun finallyRunsAfterTheBody() {
+        val builder = StringBuilder()
+        assertEquals("t", MyStatements.tryFinally(builder))
+        assertEquals("tf", builder.toString())
+    }
+
+    @Test
+    fun synchronizedBlockRunsItsBody() {
+        assertEquals("locked", MyStatements.synchronizedAssign(Any()))
+    }
+
+    @Test
+    fun staticFieldIsAssignedAndRead() {
+        assertEquals("none", MyStatements.recallValue())
+        MyStatements.rememberValue("remembered")
+        assertEquals("remembered", MyStatements.recallValue())
+    }
+
+    @Test
+    fun arrayElementsAreIndexed() {
+        assertEquals("b", MyStatements.elementOfObjectArray(1))
+        assertEquals(30, MyStatements.elementOfPrimitiveArray(2))
+        assertEquals(0L, MyStatements.sizedPrimitiveArray())
+    }
+
+    @Test
+    fun instanceOfIsChecked() {
+        assertTrue(MyStatements.isString("text"))
+        assertFalse(MyStatements.isString(1))
+    }
+
+    @Test
+    fun operandsKeepTheirPrecedence() {
+        assertEquals(20, MyStatements.multiplyBySum(4, 2, 3))
+        assertEquals(20, MyStatements.shiftOfSum(2, 3, 2))
+        assertTrue(MyStatements.orThenAnd(false, true, true))
+        assertFalse(MyStatements.orThenAnd(true, false, false))
+        assertEquals(-5L, MyStatements.negatedSumAsLong(2, 3))
+        assertEquals("5", MyStatements.sumAsString(2, 3))
+    }
+
+}


### PR DESCRIPTION
Closes #283

The Kotlin source generator threw `Unrecognized statement` / `Unrecognized expression` for five constructs the Java writer renders, could not write an annotation class at all, and — the larger half — silently produced Kotlin that either does not compile or does not mean what the model says.

## Constructs that had no rendering

| Model | Kotlin now |
| --- | --- |
| `StatementDef.Try` (+ `VariableDef.ExceptionVar`) | `try { } catch (e: E) { } finally { }` |
| `StatementDef.Synchronized` | `synchronized(monitor) { }` |
| `StatementDef.PutStaticField` | `Owner.NAME = value` |
| `ExpressionDef.ArrayElement` | `array[index]` |
| `ExpressionDef.InstanceOf` | `value is String` |
| `AnnotationObjectDef` | `annotation class`, members as primary-constructor properties |

An annotation member becomes a `val` parameter and its default becomes the parameter default:

```kotlin
public annotation class MyAnnotation(
  public val string: String = "hello",
  public val floats: FloatArray,
  public val array: IntArray = intArrayOf(1, 2, 3),
)
```

## Names in scope

`RenderScope`, ported from the Java writer, replaces the nameless rendering. It gives every catch its own variable, renames a lambda parameter that would shadow an enclosing name, and lets a lambda body reference a parameter of the enclosing method — which used to fail with `Method: apply doesn't have parameter: value`, the Kotlin half of #473.

## Operator precedence

Nothing was parenthesised at all, so `a * (b + c)` came out as `a * b + c` and `(a + b).toString()` as `a + b.toString()`. The Java writer's scheme (#484) is ported, with a Kotlin precedence table — the bitwise operations are named infix functions there, all on one level *below* the arithmetic operators, so the Java table would have been wrong.

## Kotlin spelling

Each of these compiled to nothing valid, or to the wrong thing, before:

- The bitwise operators are `and` / `or` / `xor` / `shl` / `shr` / `ushr`, not `&` / `|` / `<<`
- A long literal takes an upper case `L`; a double takes no suffix but needs a fraction; a char needs its quotes; `NaN` and the infinities are constants of the type. An array constant threw `ArrayIndexOutOfBoundsException` on an `0..length` loop and emitted Java's `new T[]{}`
- A primitive array is `IntArray`, not `Array<Int>` — which is an `Integer[]` — and is built with `intArrayOf(...)` or `IntArray(size)`
- A primitive cast is a conversion function; `x as Long` throws `ClassCastException` at runtime
- A static call goes to the Java class: `kotlin.String` has no `valueOf`
- A `Class` constant is `String::class.java`; the writer was rendering the `TypeDef`'s `toString()`
- A single value for an array-typed annotation member is an array literal
- A field initializer is rendered as an expression rather than dropped when non-constant, or emitted as a bare value — a `String` initializer was losing its quotes

## Testing

20 unit tests in `sourcegen-generator-kotlin` cover the source form.

The rest is end-to-end: `@GenerateStatements` builds a class over a try/catch/finally, a synchronized block, a static field assignment, an array element, an `instanceof` and the precedence-sensitive operations, and the **Java, Kotlin and bytecode** suites each generate it, compile it and *invoke* it — the pattern #485 used for lambdas. That is what caught `String.valueOf` on `kotlin.String`, the unquoted field initializer and `Array<Int>` for an `int[]`; source-level assertions alone would have missed all three.

## Reviewer notes

One defect surfaced here belongs to another writer, so it is left alone rather than widening this PR:

- **Bytecode writer**: a `try`/`finally` whose body completes normally never runs the finally — `TryCatchStatementWriter` emits it only on the return and exception paths. The shared fixture returns from the body to stay on the supported shape, and asserts through the builder that the finally ran.

The Java-writer counterpart of the parentheses gap — `requiresMethodCallTargetParentheses` omitting the operator expressions — was split out and has since merged as #488, so this branch is rebased on top of it.

One genuine limit, confirmed against hand-written Kotlin: an annotation class with a member of a *Java* annotation type crashes kotlinc's JVM backend whatever writes the source. So `@GenerateAnnotationClass` stays out of the Kotlin suite's trigger and the annotation class is covered by a generator test instead — noted in that test's doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

