### PR TITLE
Add missing parentheses around operator method call targets

### DIFF
--- a/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
+++ b/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
@@ -1283,7 +1283,10 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
 
     private static boolean requiresMethodCallTargetParentheses(ExpressionDef expressionDef) {
         return expressionDef instanceof ExpressionDef.Cast
+            || expressionDef instanceof ExpressionDef.ConditionExpressionDef
             || expressionDef instanceof ExpressionDef.IfElse
+            || expressionDef instanceof ExpressionDef.MathBinaryOperation
+            || expressionDef instanceof ExpressionDef.MathUnaryOperation
             || expressionDef instanceof ExpressionDef.StringConcatenation
             || expressionDef instanceof ExpressionDef.Switch;
     }

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/ExpressionWriteTest.java
@@ -1773,6 +1773,46 @@ public class MyClass {
         assertEquals("Lambda method apply has 1 parameter(s) but 2 name(s) were provided", e.getMessage());
     }
 
+    @Test
+    void returnMathOperationMethodCallTargetWithParentheses() throws IOException {
+        ExpressionDef expression = ExpressionDef.constant(100)
+            .math(DIVISION, new VariableDef.Local("divisor", TypeDef.Primitive.INT))
+            .invoke("toString", TypeDef.STRING);
+        String result = writeMethodWithExpression(expression);
+
+        assertEquals("(100 / divisor).toString()", result);
+    }
+
+    @Test
+    void returnNegatedValueMethodCallTargetWithParentheses() throws IOException {
+        ExpressionDef expression = new VariableDef.Local("value", TypeDef.Primitive.INT)
+            .math(NEGATE)
+            .invoke("toString", TypeDef.STRING);
+        String result = writeMethodWithExpression(expression);
+
+        assertEquals("(-value).toString()", result);
+    }
+
+    @Test
+    void returnComparisonMethodCallTargetWithParentheses() throws IOException {
+        ExpressionDef expression = ExpressionDef.constant(1)
+            .compare(LESS_THAN, ExpressionDef.constant(2))
+            .invoke("toString", TypeDef.STRING);
+        String result = writeMethodWithExpression(expression);
+
+        assertEquals("(1 < 2).toString()", result);
+    }
+
+    @Test
+    void returnInstanceOfMethodCallTargetWithParentheses() throws IOException {
+        ExpressionDef expression = new VariableDef.Local("value", TypeDef.OBJECT)
+            .instanceOf(ClassTypeDef.STRING)
+            .invoke("toString", TypeDef.STRING);
+        String result = writeMethodWithExpression(expression);
+
+        assertEquals("(value instanceof java.lang.String).toString()", result);
+    }
+
     private static ExpressionDef.SwitchYieldCase yieldWithConditionalBranch(TypeDef.Primitive intType,
                                                                             ExpressionDef conditionValue,
                                                                             int expectedValue,


### PR DESCRIPTION
## What

`JavaPoetSourceGenerator.requiresMethodCallTargetParentheses` listed only `Cast`, `IfElse`, `StringConcatenation` and `Switch`. It now also covers:

- `ExpressionDef.MathBinaryOperation`
- `ExpressionDef.MathUnaryOperation`
- `ExpressionDef.ConditionExpressionDef` (which covers `InstanceOf` and the comparisons)

## Why

The helper guards the receiver of the `ArrayElement` and `InvokeInstanceMethod` branches of `renderExpression`. A method call whose receiver was an arithmetic or condition expression rendered without parentheses, so `.` bound to the wrong operand and the generated source either failed to compile or silently meant something else:

```java
ExpressionDef.constant(100).math(DIVISION, param).invoke("toString", TypeDef.STRING)
```

rendered as `100 / divisor.toString()` instead of `(100 / divisor).toString()`.

The added cases mirror the neighbouring `requiresCastOperandParentheses`, which already handles the same expression kinds for the cast-operand position.

Property access is covered transitively — `GetPropertyValue` desugars through `JavaIdioms` into an `InvokeInstanceMethod`.

## Tests

Four regression tests in `ExpressionWriteTest`, each verified to fail without the fix with exactly the reported symptom:

| Expression | Before | After |
| --- | --- | --- |
| `100 / divisor` receiver | `100 / divisor.toString()` | `(100 / divisor).toString()` |
| `-value` receiver | `-value.toString()` | `(-value).toString()` |
| `1 < 2` receiver | `1 < 2.toString()` | `(1 < 2).toString()` |
| `value instanceof String` receiver | `value instanceof java.lang.String.toString()` | `(value instanceof java.lang.String).toString()` |

Green with no golden-output churn: `sourcegen-generator-java` (514), `sourcegen-bytecode-writer` (72, including `ByteCodeWriterTest`'s 56), `test-suite-java` (123).

## Notes for reviewers

- **`ByteCodeWriterTest` is unaffected.** The bytecode writer emits instructions directly and never goes through this source-rendering path, so its decompiled goldens do not change.
- **`KotlinPoetSourceGenerator` has the same bug and is not fixed here.** It has no equivalent helper at all — its `InvokeInstanceMethod` branch renders the receiver bare, and `MathBinaryOperation` / `ComparisonOperation` emit no parentheses. Left out to keep this change scoped to the Java generator; happy to follow up separately.
- **No `ArrayElement` regression test was added.** The only receivers that can legally precede `[` in Java are the already-covered forms (`Cast`, `IfElse`, `Switch`); a math or condition expression is never array-typed, so such a test would assert on output that cannot arise from a well-typed model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)