### PR TITLE
Implement full record support in the bytecode writer

### DIFF
--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
@@ -18,6 +18,7 @@ package io.micronaut.sourcegen.bytecode;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.naming.NameUtils;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.sourcegen.bytecode.statement.StatementWriter;
 import io.micronaut.sourcegen.model.AnnotationDef;
 import io.micronaut.sourcegen.model.ClassDef;
@@ -49,6 +50,7 @@ import org.objectweb.asm.TypeReference;
 import org.objectweb.asm.commons.GeneratorAdapter;
 import org.objectweb.asm.util.CheckClassAdapter;
 
+import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
@@ -158,24 +160,50 @@ public final class ByteCodeWriter {
      * @param member   The member the annotations are written on
      */
     private void writeTypeAnnotations(TypeDef typeDef, int typeRef, TypeAnnotatable member) {
-        for (AnnotationDef annotation : typeAnnotationsOf(typeDef)) {
+        writeTypeAnnotations(typeDef, typeRef, "", member);
+    }
+
+    /**
+     * Walk a type, writing the annotations each part of it carries against the path that reaches that part.
+     * An annotation on the type itself has no path, one on what an array holds is reached through the array,
+     * and one on a type argument through the argument it annotates - the way {@code List<@Nullable String>}
+     * annotates the argument and not the list.
+     *
+     * @param typeDef  The type to walk
+     * @param typeRef  The reference of the type within the member, from {@link TypeReference}
+     * @param typePath The path reaching this part of the type, encoded as {@link TypePath#fromString} reads it
+     * @param member   The member the annotations are written on
+     */
+    private void writeTypeAnnotations(TypeDef typeDef, int typeRef, String typePath, TypeAnnotatable member) {
+        if (typeDef instanceof TypeDef.AnnotatedTypeDef annotated) {
+            writeTypeAnnotations(annotated.annotations(), typeRef, typePath, member);
+            writeTypeAnnotations(annotated.typeDef(), typeRef, typePath, member);
+        } else if (typeDef instanceof ClassTypeDef.AnnotatedClassTypeDef annotated) {
+            writeTypeAnnotations(annotated.annotations(), typeRef, typePath, member);
+            writeTypeAnnotations(annotated.typeDef(), typeRef, typePath, member);
+        } else if (typeDef instanceof TypeDef.Array array) {
+            writeTypeAnnotations(array.componentType(), typeRef, typePath + "[".repeat(array.dimensions()), member);
+        } else if (typeDef instanceof ClassTypeDef.Parameterized parameterized) {
+            List<TypeDef> typeArguments = parameterized.typeArguments();
+            for (int i = 0; i < typeArguments.size(); i++) {
+                writeTypeAnnotations(typeArguments.get(i), typeRef, typePath + i + ";", member);
+            }
+        } else if (typeDef instanceof TypeDef.Wildcard wildcard) {
+            for (TypeDef bound : CollectionUtils.concat(wildcard.upperBounds(), wildcard.lowerBounds())) {
+                writeTypeAnnotations(bound, typeRef, typePath + "*", member);
+            }
+        }
+    }
+
+    private void writeTypeAnnotations(List<AnnotationDef> annotations, int typeRef, String typePath, TypeAnnotatable member) {
+        for (AnnotationDef annotation : annotations) {
             visitAnnotation(annotation, member.visitTypeAnnotation(
                 typeRef,
-                null,
+                TypePath.fromString(typePath),
                 TypeUtils.getType(annotation.getType(), null).getDescriptor(),
                 true
             ));
         }
-    }
-
-    private static List<AnnotationDef> typeAnnotationsOf(TypeDef typeDef) {
-        if (typeDef instanceof TypeDef.AnnotatedTypeDef annotated) {
-            return annotated.annotations();
-        }
-        if (typeDef instanceof ClassTypeDef.AnnotatedClassTypeDef annotated) {
-            return annotated.annotations();
-        }
-        return List.of();
     }
 
     private MethodDef createStaticInitializer(StatementDef statement) {
@@ -383,12 +411,48 @@ public final class ByteCodeWriter {
         if (typeDef instanceof ClassTypeDef.ClassDefType classDefType) {
             return declaredTargetsOf(classDefType.objectDef());
         }
+        if (typeDef instanceof ClassTypeDef.ClassElementType classElementType) {
+            Target target = sourceTargetOf(classElementType.classElement());
+            if (target != null) {
+                return Optional.of(Set.of(target.value()));
+            }
+        }
         Class<?> annotationType = resolveAnnotationType(typeDef);
         if (annotationType == null) {
             return Optional.empty();
         }
         Target target = annotationType.getAnnotation(Target.class);
         return target == null ? Optional.empty() : Optional.of(Set.of(target.value()));
+    }
+
+    /**
+     * The {@link Target} of an annotation type that is being compiled, read from the compiler's own element.
+     * Its class cannot be loaded, and the annotation metadata of a {@link io.micronaut.inject.ast.ClassElement}
+     * cannot answer either: {@code Target} is one of the annotations
+     * {@code io.micronaut.core.annotation.AnnotationUtil#INTERNAL_ANNOTATION_NAMES} strips while the metadata
+     * is built. The compiler's element is reached through the native type, which only a Java element carries.
+     *
+     * @param classElement The annotation type
+     * @return Its target, or {@code null} when the element is not one of a Java compilation or declares none
+     */
+    @Nullable
+    private static Target sourceTargetOf(io.micronaut.inject.ast.ClassElement classElement) {
+        Object nativeType = classElement.getNativeType();
+        Element element = null;
+        if (nativeType instanceof Element nativeElement) {
+            element = nativeElement;
+        } else if (nativeType != null) {
+            try {
+                // A JavaNativeElement wraps the compiler's element, and lives in a module this one cannot see
+                Object unwrapped = nativeType.getClass().getMethod("element").invoke(nativeType);
+                if (unwrapped instanceof Element unwrappedElement) {
+                    element = unwrappedElement;
+                }
+            } catch (ReflectiveOperationException | RuntimeException e) {
+                return null;
+            }
+        }
+        return element == null ? null : element.getAnnotation(Target.class);
     }
 
     /**
@@ -402,14 +466,36 @@ public final class ByteCodeWriter {
         return objectDef.getAnnotations().stream()
             .filter(a -> a.getType().getName().equals(Target.class.getName()))
             .findFirst()
-            .map(a -> {
-                Object value = a.getValues().get(AnnotationMetadata.VALUE_MEMBER);
-                Collection<?> values = value instanceof Collection<?> collection ? collection : List.of(value);
-                return values.stream()
-                    .filter(VariableDef.StaticField.class::isInstance)
-                    .map(v -> ElementType.valueOf(((VariableDef.StaticField) v).name()))
-                    .collect(Collectors.toSet());
-            });
+            .map(a -> toElementTypes(a.getValues().get(AnnotationMetadata.VALUE_MEMBER)))
+            // Nothing recognisable in the member leaves the annotation untargeted rather than targeting
+            // nothing at all, which would drop it from every member the component expands to
+            .filter(targets -> !targets.isEmpty());
+    }
+
+    /**
+     * @param value A member of a {@link Target}, however a definition happens to hold an enum constant: the
+     *              constant itself, a static field reference to it, its name, or several of those
+     * @return The element types it names
+     */
+    private static Set<ElementType> toElementTypes(@Nullable Object value) {
+        if (value == null) {
+            return Set.of();
+        }
+        if (value instanceof Collection<?> collection) {
+            return collection.stream().flatMap(v -> toElementTypes(v).stream()).collect(Collectors.toSet());
+        }
+        if (value instanceof Object[] array) {
+            return Arrays.stream(array).flatMap(v -> toElementTypes(v).stream()).collect(Collectors.toSet());
+        }
+        if (value instanceof ElementType elementType) {
+            return Set.of(elementType);
+        }
+        String name = value instanceof VariableDef.StaticField staticField ? staticField.name() : value.toString();
+        try {
+            return Set.of(ElementType.valueOf(name));
+        } catch (IllegalArgumentException e) {
+            return Set.of();
+        }
     }
 
     /**

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
@@ -391,6 +391,14 @@ public final class ByteCodeWriter {
      * @return The annotated type
      */
     private static TypeDef annotateComponentType(TypeDef typeDef, List<AnnotationDef> annotations) {
+        // An annotation already on the type wraps it, and only this wrapper can be hiding an array - the one
+        // for a class type cannot. Descend through it and put it back, so what it annotates stays the same
+        if (typeDef instanceof TypeDef.AnnotatedTypeDef annotated) {
+            return new TypeDef.AnnotatedTypeDef(
+                annotateComponentType(annotated.typeDef(), annotations),
+                annotated.annotations()
+            );
+        }
         if (typeDef instanceof TypeDef.Array array) {
             return new TypeDef.Array(
                 annotateComponentType(array.componentType(), annotations),

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
@@ -47,6 +47,8 @@ import org.objectweb.asm.commons.GeneratorAdapter;
 import org.objectweb.asm.util.CheckClassAdapter;
 
 import javax.lang.model.element.Modifier;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -86,6 +88,8 @@ import static org.objectweb.asm.Opcodes.V17;
  * @since 1.5
  */
 public final class ByteCodeWriter {
+
+    private static final List<Modifier> ACCESS_MODIFIERS = List.of(Modifier.PUBLIC, Modifier.PROTECTED, Modifier.PRIVATE);
 
     private final boolean checkClass;
     private final boolean visitMaxs;
@@ -269,7 +273,7 @@ public final class ByteCodeWriter {
         }
         List<TypeDef> componentTypes = components.stream().map(PropertyDef::getType).toList();
         if (!isDeclared(recordDef, MethodDef.CONSTRUCTOR, componentTypes)) {
-            writeMethod(classVisitor, recordDef, canonicalConstructor(components, componentFields), emittedBridges);
+            writeMethod(classVisitor, recordDef, canonicalConstructor(recordDef, components, componentFields), emittedBridges);
         }
         writeObjectMethods(classVisitor, recordDef, componentFields);
         for (int i = 0; i < components.size(); i++) {
@@ -281,7 +285,7 @@ public final class ByteCodeWriter {
             writeMethod(classVisitor, recordDef, MethodDef.builder(component.getName())
                 .addModifiers(Modifier.PUBLIC)
                 .returns(component.getType())
-                .addAnnotations(component.getAnnotations())
+                .addAnnotations(annotationsFor(component, ElementType.METHOD))
                 .build((aThis, methodParameters) -> aThis.field(componentField).returning()), emittedBridges);
         }
         for (MethodDef method : recordDef.getMethods()) {
@@ -292,8 +296,50 @@ public final class ByteCodeWriter {
     private static FieldDef toComponentField(PropertyDef component) {
         return FieldDef.builder(component.getName(), component.getType())
             .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
-            .addAnnotations(component.getAnnotations())
+            .addAnnotations(annotationsFor(component, ElementType.FIELD))
             .build();
+    }
+
+    /**
+     * The annotations of a record component that belong on one of the members it expands to. A compiler
+     * spreads a component's annotations over the component itself, the field backing it, its accessor and
+     * the canonical constructor's parameter, keeping each only where the annotation's {@link Target} allows
+     * it. An annotation that declares no target is applicable in every one of those contexts, and so is one
+     * whose type cannot be resolved here - it is written everywhere rather than dropped.
+     *
+     * @param component   The record component
+     * @param elementType The context the annotations are written in
+     * @return The annotations that belong there
+     */
+    private static List<AnnotationDef> annotationsFor(PropertyDef component, ElementType elementType) {
+        return component.getAnnotations().stream().filter(annotation -> {
+            Class<?> annotationType = resolveAnnotationType(annotation.getType());
+            if (annotationType == null) {
+                return true;
+            }
+            Target target = annotationType.getAnnotation(Target.class);
+            return target == null || Arrays.asList(target.value()).contains(elementType);
+        }).toList();
+    }
+
+    /**
+     * @param typeDef The annotation type
+     * @return The annotation class, or {@code null} when the definition carries no class for it and none
+     * can be loaded - a type generated in this same round, for one
+     */
+    @Nullable
+    private static Class<?> resolveAnnotationType(ClassTypeDef typeDef) {
+        if (typeDef instanceof ClassTypeDef.JavaClass javaClass) {
+            return javaClass.type();
+        }
+        if (typeDef instanceof ClassTypeDef.ClassDefType) {
+            return null;
+        }
+        try {
+            return Class.forName(typeDef.getName(), false, ByteCodeWriter.class.getClassLoader());
+        } catch (ClassNotFoundException | LinkageError e) {
+            return null;
+        }
     }
 
     private void writeRecordComponent(ClassVisitor classVisitor, RecordDef recordDef, PropertyDef component, FieldDef componentField) {
@@ -302,7 +348,7 @@ public final class ByteCodeWriter {
             TypeUtils.getType(component.getType(), recordDef).getDescriptor(),
             SignatureWriterUtils.getFieldSignature(recordDef, componentField)
         );
-        for (AnnotationDef annotation : component.getAnnotations()) {
+        for (AnnotationDef annotation : annotationsFor(component, ElementType.RECORD_COMPONENT)) {
             AnnotationVisitor annotationVisitor = recordComponentVisitor.visitAnnotation(
                 TypeUtils.getType(annotation.getType(), null).getDescriptor(),
                 true);
@@ -311,11 +357,17 @@ public final class ByteCodeWriter {
         recordComponentVisitor.visitEnd();
     }
 
-    private MethodDef canonicalConstructor(List<PropertyDef> components, List<FieldDef> componentFields) {
-        MethodDef.MethodDefBuilder builder = MethodDef.constructor().addModifiers(Modifier.PUBLIC);
+    private MethodDef canonicalConstructor(RecordDef recordDef, List<PropertyDef> components, List<FieldDef> componentFields) {
+        MethodDef.MethodDefBuilder builder = MethodDef.constructor();
+        // An implicitly declared canonical constructor has the access of the record itself (JLS 8.10.4.1)
+        for (Modifier accessModifier : ACCESS_MODIFIERS) {
+            if (recordDef.getModifiers().contains(accessModifier)) {
+                builder.addModifiers(accessModifier);
+            }
+        }
         for (PropertyDef component : components) {
             builder.addParameter(ParameterDef.builder(component.getName(), component.getType())
-                .addAnnotations(component.getAnnotations())
+                .addAnnotations(annotationsFor(component, ElementType.PARAMETER))
                 .build());
         }
         return builder.build((aThis, methodParameters) -> {

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
@@ -378,7 +378,27 @@ public final class ByteCodeWriter {
         List<AnnotationDef> typeAnnotations = component.getAnnotations().stream()
             .filter(annotation -> targetsOf(annotation).map(t -> t.contains(ElementType.TYPE_USE)).orElse(false))
             .toList();
-        return typeAnnotations.isEmpty() ? component.getType() : component.getType().annotated(typeAnnotations);
+        return typeAnnotations.isEmpty() ? component.getType() : annotateComponentType(component.getType(), typeAnnotations);
+    }
+
+    /**
+     * An annotation written before the type of a component annotates what an array holds and not the array
+     * itself - {@code @Nullable String[]} is an array of annotated strings, which is how a compiler reads it
+     * and how the source generators render it. Any other type is annotated as it stands.
+     *
+     * @param typeDef     The type of the component
+     * @param annotations The type use annotations of the component
+     * @return The annotated type
+     */
+    private static TypeDef annotateComponentType(TypeDef typeDef, List<AnnotationDef> annotations) {
+        if (typeDef instanceof TypeDef.Array array) {
+            return new TypeDef.Array(
+                annotateComponentType(array.componentType(), annotations),
+                array.dimensions(),
+                array.nullable()
+            );
+        }
+        return typeDef.annotated(annotations);
     }
 
     /**

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
@@ -37,14 +37,18 @@ import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Handle;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.RecordComponentVisitor;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
 import org.objectweb.asm.util.CheckClassAdapter;
 
 import javax.lang.model.element.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -52,6 +56,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.objectweb.asm.Opcodes.ACC_ABSTRACT;
 import static org.objectweb.asm.Opcodes.ACC_BRIDGE;
@@ -207,7 +212,7 @@ public final class ByteCodeWriter {
     }
 
     /**
-     * Write an interface.
+     * Write a record.
      *
      * @param classVisitor The class visitor
      * @param recordDef    The record definition
@@ -217,14 +222,22 @@ public final class ByteCodeWriter {
     }
 
     /**
-     * Write an interface.
+     * Write a record.
+     *
+     * <p>The components of the record are expanded the way a compiler expands them: a record component,
+     * a private final field, the canonical constructor, an accessor per component, and {@code equals},
+     * {@code hashCode} and {@code toString} linked through
+     * {@code java.lang.runtime.ObjectMethods#bootstrap}. A member the definition declares itself is kept,
+     * replacing the one that would have been generated.
      *
      * @param classVisitor The class visitor
      * @param recordDef    The record definition
      * @param outerType     The outer type
      */
     public void writeRecord(ClassVisitor classVisitor, RecordDef recordDef, @Nullable ClassTypeDef outerType) {
-        int modifiersFlag = ACC_RECORD | getModifiersFlag(recordDef.getModifiers());
+        Set<String> emittedBridges = new HashSet<>();
+        // A record is always final
+        int modifiersFlag = ACC_RECORD | ACC_FINAL | getModifiersFlag(recordDef.getModifiers());
         if (recordDef.isSynthetic()) {
             modifiersFlag |= ACC_SYNTHETIC;
         }
@@ -237,6 +250,149 @@ public final class ByteCodeWriter {
             recordDef.getSuperinterfaces().stream().map(i -> TypeUtils.getType(i, recordDef)).map(Type::getInternalName).toArray(String[]::new)
         );
         writeOuterInner(classVisitor, recordDef.asTypeDef(), recordDef, outerType);
+
+        for (AnnotationDef annotation : recordDef.getAnnotations()) {
+            AnnotationVisitor annotationVisitor = classVisitor.visitAnnotation(
+                TypeUtils.getType(annotation.getType(), null).getDescriptor(),
+                true);
+            visitAnnotation(annotation, annotationVisitor);
+        }
+
+        List<PropertyDef> components = recordDef.getProperties();
+        List<FieldDef> componentFields = components.stream().map(ByteCodeWriter::toComponentField).toList();
+
+        for (int i = 0; i < components.size(); i++) {
+            writeRecordComponent(classVisitor, recordDef, components.get(i), componentFields.get(i));
+        }
+        for (FieldDef componentField : componentFields) {
+            writeField(classVisitor, recordDef, componentField);
+        }
+        List<TypeDef> componentTypes = components.stream().map(PropertyDef::getType).toList();
+        if (!isDeclared(recordDef, MethodDef.CONSTRUCTOR, componentTypes)) {
+            writeMethod(classVisitor, recordDef, canonicalConstructor(components, componentFields), emittedBridges);
+        }
+        writeObjectMethods(classVisitor, recordDef, componentFields);
+        for (int i = 0; i < components.size(); i++) {
+            PropertyDef component = components.get(i);
+            if (isDeclared(recordDef, component.getName(), List.of())) {
+                continue;
+            }
+            FieldDef componentField = componentFields.get(i);
+            writeMethod(classVisitor, recordDef, MethodDef.builder(component.getName())
+                .addModifiers(Modifier.PUBLIC)
+                .returns(component.getType())
+                .addAnnotations(component.getAnnotations())
+                .build((aThis, methodParameters) -> aThis.field(componentField).returning()), emittedBridges);
+        }
+        for (MethodDef method : recordDef.getMethods()) {
+            writeMethod(classVisitor, recordDef, method, emittedBridges);
+        }
+    }
+
+    private static FieldDef toComponentField(PropertyDef component) {
+        return FieldDef.builder(component.getName(), component.getType())
+            .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+            .addAnnotations(component.getAnnotations())
+            .build();
+    }
+
+    private void writeRecordComponent(ClassVisitor classVisitor, RecordDef recordDef, PropertyDef component, FieldDef componentField) {
+        RecordComponentVisitor recordComponentVisitor = classVisitor.visitRecordComponent(
+            component.getName(),
+            TypeUtils.getType(component.getType(), recordDef).getDescriptor(),
+            SignatureWriterUtils.getFieldSignature(recordDef, componentField)
+        );
+        for (AnnotationDef annotation : component.getAnnotations()) {
+            AnnotationVisitor annotationVisitor = recordComponentVisitor.visitAnnotation(
+                TypeUtils.getType(annotation.getType(), null).getDescriptor(),
+                true);
+            visitAnnotation(annotation, annotationVisitor);
+        }
+        recordComponentVisitor.visitEnd();
+    }
+
+    private MethodDef canonicalConstructor(List<PropertyDef> components, List<FieldDef> componentFields) {
+        MethodDef.MethodDefBuilder builder = MethodDef.constructor().addModifiers(Modifier.PUBLIC);
+        for (PropertyDef component : components) {
+            builder.addParameter(ParameterDef.builder(component.getName(), component.getType())
+                .addAnnotations(component.getAnnotations())
+                .build());
+        }
+        return builder.build((aThis, methodParameters) -> {
+            List<StatementDef> statements = new ArrayList<>(componentFields.size() + 1);
+            statements.add(aThis.superRef().invokeSuperConstructor());
+            for (int i = 0; i < componentFields.size(); i++) {
+                statements.add(aThis.field(componentFields.get(i)).assign(methodParameters.get(i)));
+            }
+            return StatementDef.multi(statements);
+        });
+    }
+
+    /**
+     * Write the {@code equals}, {@code hashCode} and {@code toString} of a record, each of them an
+     * {@code invokedynamic} linked through {@code java.lang.runtime.ObjectMethods#bootstrap}, which
+     * derives the implementation from the components handed to it as the bootstrap arguments.
+     *
+     * @param classVisitor    The class visitor
+     * @param recordDef       The record definition
+     * @param componentFields The fields backing the record components
+     */
+    private void writeObjectMethods(ClassVisitor classVisitor, RecordDef recordDef, List<FieldDef> componentFields) {
+        Type recordType = TypeUtils.getType(recordDef.asTypeDef());
+        String internalName = recordType.getInternalName();
+        Object[] bootstrapArguments = new Object[componentFields.size() + 2];
+        bootstrapArguments[0] = recordType;
+        bootstrapArguments[1] = componentFields.stream().map(FieldDef::getName).collect(Collectors.joining(";"));
+        for (int i = 0; i < componentFields.size(); i++) {
+            FieldDef componentField = componentFields.get(i);
+            bootstrapArguments[i + 2] = new Handle(
+                Opcodes.H_GETFIELD,
+                internalName,
+                componentField.getName(),
+                TypeUtils.getType(componentField.getType(), recordDef).getDescriptor(),
+                false
+            );
+        }
+        writeObjectMethod(classVisitor, recordDef, "toString", Type.getMethodDescriptor(Type.getType(String.class)),
+            Type.getMethodDescriptor(Type.getType(String.class), recordType), bootstrapArguments);
+        writeObjectMethod(classVisitor, recordDef, "hashCode", Type.getMethodDescriptor(Type.INT_TYPE),
+            Type.getMethodDescriptor(Type.INT_TYPE, recordType), bootstrapArguments);
+        writeObjectMethod(classVisitor, recordDef, "equals", Type.getMethodDescriptor(Type.BOOLEAN_TYPE, TypeUtils.OBJECT_TYPE),
+            Type.getMethodDescriptor(Type.BOOLEAN_TYPE, recordType, TypeUtils.OBJECT_TYPE), bootstrapArguments);
+    }
+
+    private void writeObjectMethod(ClassVisitor classVisitor,
+                                   RecordDef recordDef,
+                                   String name,
+                                   String descriptor,
+                                   String callSiteDescriptor,
+                                   Object[] bootstrapArguments) {
+        if (isDeclared(recordDef, name, Type.getArgumentTypes(descriptor))) {
+            return;
+        }
+        int modifiersFlag = ACC_PUBLIC | ACC_FINAL;
+        MethodVisitor methodVisitor = classVisitor.visitMethod(modifiersFlag, name, descriptor, null, null);
+        GeneratorAdapter generatorAdapter = new GeneratorAdapter(methodVisitor, modifiersFlag, name, descriptor);
+        generatorAdapter.visitCode();
+        generatorAdapter.loadThis();
+        generatorAdapter.loadArgs();
+        generatorAdapter.visitInvokeDynamicInsn(name, callSiteDescriptor, ObjectMethodsHandle.BOOTSTRAP, bootstrapArguments);
+        generatorAdapter.returnValue();
+        if (visitMaxs) {
+            generatorAdapter.visitMaxs(20, 20);
+        }
+        generatorAdapter.visitEnd();
+    }
+
+    private boolean isDeclared(RecordDef recordDef, String name, List<TypeDef> parameterTypes) {
+        return isDeclared(recordDef, name, parameterTypes.stream().map(t -> TypeUtils.getType(t, recordDef)).toArray(Type[]::new));
+    }
+
+    private boolean isDeclared(RecordDef recordDef, String name, Type[] parameterTypes) {
+        return recordDef.getMethods().stream().anyMatch(methodDef -> methodDef.getName().equals(name)
+            && Arrays.equals(
+                methodDef.getParameters().stream().map(p -> TypeUtils.getType(p.getType(), recordDef)).toArray(Type[]::new),
+                parameterTypes));
     }
 
     /**
@@ -331,7 +487,9 @@ public final class ByteCodeWriter {
                 TypeUtils.getType(thisType).getInternalName(),
                 outerInternalName,
                 thisType.getSimpleName(),
-                getModifiersFlag(thisDef)
+                // The same flags the outer type writes for this member, so the two entries agree - without
+                // ACC_STATIC the class reads back as an inner class needing an enclosing instance
+                getModifiersFlag(thisDef) | ACC_PUBLIC | ACC_STATIC
             );
         }
         writeInnerTypes(classVisitor, thisType, thisDef.getInnerTypes());
@@ -362,7 +520,8 @@ public final class ByteCodeWriter {
             return ACC_INTERFACE | ACC_ABSTRACT | getModifiersFlag(interfaceDef.getModifiers());
         }
         if (objectDef instanceof RecordDef recordDef) {
-            return getModifiersFlag(recordDef.getModifiers());
+            // A record is always final; ACC_RECORD is not among the flags an inner class entry may carry
+            return ACC_FINAL | getModifiersFlag(recordDef.getModifiers());
         }
         return getModifiersFlag(objectDef.getModifiers());
     }
@@ -482,7 +641,7 @@ public final class ByteCodeWriter {
         );
         GeneratorAdapter generatorAdapter = new GeneratorAdapter(methodVisitor, modifiersFlag, name, methodDescriptor);
         for (AnnotationDef annotation : methodDef.getAnnotations()) {
-            generatorAdapter.visitAnnotation(TypeUtils.getType(annotation.getType(), null).getDescriptor(), true);
+            visitAnnotation(annotation, generatorAdapter.visitAnnotation(TypeUtils.getType(annotation.getType(), null).getDescriptor(), true));
         }
 
         if (methodDef.getParameters().stream().anyMatch(p -> !p.getAnnotations().isEmpty())) {
@@ -674,12 +833,15 @@ public final class ByteCodeWriter {
     }
 
     private List<StatementDef> adjustConstructorStatements(@Nullable ObjectDef objectDef, List<StatementDef> statements) {
-        if (!(objectDef instanceof ClassDef classDef)) {
+        if (!(objectDef instanceof ClassDef || objectDef instanceof RecordDef)) {
             return statements;
         }
-        List<StatementDef> fieldInitializers = classDef.getFields().stream().filter(fieldDef -> !fieldDef.getModifiers().contains(Modifier.STATIC))
+        // A record has no fields of its own, only the ones backing its components, which the canonical constructor assigns
+        List<StatementDef> fieldInitializers = objectDef instanceof ClassDef classDef
+            ? classDef.getFields().stream().filter(fieldDef -> !fieldDef.getModifiers().contains(Modifier.STATIC))
             .flatMap(fieldDef -> fieldDef.getInitializer().<StatementDef>map(initializer -> new VariableDef.This().field(fieldDef).assign(initializer)).stream())
-            .toList();
+            .toList()
+            : List.of();
         Optional<StatementDef> constructorInvocation = statements.stream().filter(this::isConstructorInvocation).findFirst();
         if (constructorInvocation.isEmpty() || !fieldInitializers.isEmpty()) {
             // Add the constructor or reshuffle the statements to have the field initializers right after the constructor call

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
@@ -91,6 +91,14 @@ public final class ByteCodeWriter {
 
     private static final List<Modifier> ACCESS_MODIFIERS = List.of(Modifier.PUBLIC, Modifier.PROTECTED, Modifier.PRIVATE);
 
+    /**
+     * The declaration contexts a record component expands to: the component, the field backing it, its
+     * accessor and the canonical constructor's parameter.
+     */
+    private static final Set<ElementType> COMPONENT_DECLARATION_TARGETS = Set.of(
+        ElementType.RECORD_COMPONENT, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER
+    );
+
     private final boolean checkClass;
     private final boolean visitMaxs;
 
@@ -191,7 +199,7 @@ public final class ByteCodeWriter {
      */
     public void writeInterface(ClassVisitor classVisitor, InterfaceDef interfaceDef, @Nullable ClassTypeDef outerType) {
         Set<String> emittedBridges = new HashSet<>();
-        int modifiersFlag = ACC_INTERFACE | ACC_ABSTRACT | getModifiersFlag(interfaceDef.getModifiers());
+        int modifiersFlag = ACC_INTERFACE | ACC_ABSTRACT | getClassModifiersFlag(interfaceDef.getModifiers());
         if (interfaceDef.isSynthetic()) {
             modifiersFlag |= ACC_SYNTHETIC;
         }
@@ -241,7 +249,7 @@ public final class ByteCodeWriter {
     public void writeRecord(ClassVisitor classVisitor, RecordDef recordDef, @Nullable ClassTypeDef outerType) {
         Set<String> emittedBridges = new HashSet<>();
         // A record is always final
-        int modifiersFlag = ACC_RECORD | ACC_FINAL | getModifiersFlag(recordDef.getModifiers());
+        int modifiersFlag = ACC_RECORD | ACC_FINAL | getClassModifiersFlag(recordDef.getModifiers());
         if (recordDef.isSynthetic()) {
             modifiersFlag |= ACC_SYNTHETIC;
         }
@@ -312,14 +320,32 @@ public final class ByteCodeWriter {
      * @return The annotations that belong there
      */
     private static List<AnnotationDef> annotationsFor(PropertyDef component, ElementType elementType) {
-        return component.getAnnotations().stream().filter(annotation -> {
-            Class<?> annotationType = resolveAnnotationType(annotation.getType());
-            if (annotationType == null) {
-                return true;
-            }
-            Target target = annotationType.getAnnotation(Target.class);
-            return target == null || Arrays.asList(target.value()).contains(elementType);
-        }).toList();
+        return component.getAnnotations().stream()
+            .filter(annotation -> declarationTargetsOf(annotation).map(t -> t.contains(elementType)).orElse(true))
+            .toList();
+    }
+
+    /**
+     * @param annotation The annotation
+     * @return The contexts a record component expands to that the annotation targets, or empty when it
+     * targets all of them - because it declares no {@link Target}, because its type cannot be resolved here,
+     * or because it targets none of them at all and would otherwise be lost
+     */
+    private static Optional<Set<ElementType>> declarationTargetsOf(AnnotationDef annotation) {
+        Class<?> annotationType = resolveAnnotationType(annotation.getType());
+        if (annotationType == null) {
+            return Optional.empty();
+        }
+        Target target = annotationType.getAnnotation(Target.class);
+        if (target == null) {
+            return Optional.empty();
+        }
+        Set<ElementType> targets = Arrays.stream(target.value())
+            .filter(COMPONENT_DECLARATION_TARGETS::contains)
+            .collect(Collectors.toSet());
+        // A type use annotation targets none of them. This writer has no RuntimeVisibleTypeAnnotations of its
+        // own, so writing it as a declaration annotation keeps it readable rather than dropping it outright
+        return targets.isEmpty() ? Optional.empty() : Optional.of(targets);
     }
 
     /**
@@ -470,7 +496,7 @@ public final class ByteCodeWriter {
         Set<String> emittedBridges = new HashSet<>();
         ClassTypeDef typeDef = classDef.asTypeDef();
 
-        int modifiersFlag = getModifiersFlag(classDef.getModifiers());
+        int modifiersFlag = getClassModifiersFlag(classDef.getModifiers());
 
         if (classDef.isSynthetic()) {
             modifiersFlag |= ACC_SYNTHETIC;
@@ -539,9 +565,7 @@ public final class ByteCodeWriter {
                 TypeUtils.getType(thisType).getInternalName(),
                 outerInternalName,
                 thisType.getSimpleName(),
-                // The same flags the outer type writes for this member, so the two entries agree - without
-                // ACC_STATIC the class reads back as an inner class needing an enclosing instance
-                getModifiersFlag(thisDef) | ACC_PUBLIC | ACC_STATIC
+                getInnerClassModifiersFlag(thisDef)
             );
         }
         writeInnerTypes(classVisitor, thisType, thisDef.getInnerTypes());
@@ -552,16 +576,35 @@ public final class ByteCodeWriter {
             String outerClassInternalName = TypeUtils.getType(outerType).getInternalName();
 
             ClassTypeDef interType = innerDef.asTypeDef();
-            int access =  getModifiersFlag(innerDef);
-            access |= ACC_PUBLIC | ACC_STATIC; // Javac always adds public and static
             outerClassVisitor.visitInnerClass(
                 TypeUtils.getType(innerDef.asTypeDef()).getInternalName(),
                 outerClassInternalName,
                 interType.getSimpleName(),
-                access
+                getInnerClassModifiersFlag(innerDef)
             );
             outerClassVisitor.visitNestMember(TypeUtils.getType(innerDef.asTypeDef()).getInternalName());
         }
+    }
+
+    /**
+     * The access flags of the {@code InnerClasses} entry of a member type. This is where its declared access
+     * lives - the class file itself cannot carry private or protected - and a member type is always static
+     * here, without which it reads back as an inner class needing an enclosing instance. The outer type and
+     * the member itself both write this entry, and the two have to agree.
+     *
+     * <p>A member that declares no access is written public: a member type of an interface is implicitly
+     * public (JLS 9.5), which is what the source generators emit for one, and the definitions nested by the
+     * generators rely on being reachable.
+     *
+     * @param objectDef The member type
+     * @return The access flags of its inner class entry
+     */
+    private int getInnerClassModifiersFlag(ObjectDef objectDef) {
+        int access = getModifiersFlag(objectDef) | ACC_STATIC;
+        if ((access & (ACC_PUBLIC | ACC_PROTECTED | ACC_PRIVATE)) == 0) {
+            access |= ACC_PUBLIC;
+        }
+        return access;
     }
 
     private int getModifiersFlag(ObjectDef objectDef) {
@@ -947,6 +990,23 @@ public final class ByteCodeWriter {
     private boolean isConstructorInvocation(StatementDef statement) {
         boolean deprecatedCall = statement instanceof ExpressionDef.InvokeInstanceMethod call && call.method().isConstructor();
         return deprecatedCall || statement instanceof StatementDef.InvokeSuperConstructor;
+    }
+
+    /**
+     * The access flags of a class file. Unlike a member, a class cannot be declared private, protected or
+     * static there - those belong to the {@code InnerClasses} entry of a member type. A member type declared
+     * protected is reachable from a subclass in another package, so its class file is public, the way a
+     * compiler writes it.
+     *
+     * @param modifiers The declared modifiers
+     * @return The access flags of the class file
+     */
+    private int getClassModifiersFlag(Set<Modifier> modifiers) {
+        int access = getModifiersFlag(modifiers) & ~(ACC_PRIVATE | ACC_PROTECTED | ACC_STATIC);
+        if (modifiers.contains(Modifier.PROTECTED)) {
+            access |= ACC_PUBLIC;
+        }
+        return access;
     }
 
     private int getModifiersFlag(Set<Modifier> modifiers) {

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
@@ -16,6 +16,7 @@
 package io.micronaut.sourcegen.bytecode;
 
 import org.jspecify.annotations.Nullable;
+import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.sourcegen.bytecode.statement.StatementWriter;
 import io.micronaut.sourcegen.model.AnnotationDef;
@@ -43,6 +44,8 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.RecordComponentVisitor;
 import org.objectweb.asm.Type;
+import org.objectweb.asm.TypePath;
+import org.objectweb.asm.TypeReference;
 import org.objectweb.asm.commons.GeneratorAdapter;
 import org.objectweb.asm.util.CheckClassAdapter;
 
@@ -90,14 +93,6 @@ import static org.objectweb.asm.Opcodes.V17;
 public final class ByteCodeWriter {
 
     private static final List<Modifier> ACCESS_MODIFIERS = List.of(Modifier.PUBLIC, Modifier.PROTECTED, Modifier.PRIVATE);
-
-    /**
-     * The declaration contexts a record component expands to: the component, the field backing it, its
-     * accessor and the canonical constructor's parameter.
-     */
-    private static final Set<ElementType> COMPONENT_DECLARATION_TARGETS = Set.of(
-        ElementType.RECORD_COMPONENT, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER
-    );
 
     private final boolean checkClass;
     private final boolean visitMaxs;
@@ -153,6 +148,36 @@ public final class ByteCodeWriter {
         }
     }
 
+    /**
+     * Write the annotations a type carries as type annotations of the member it belongs to. A type use
+     * annotation belongs there and not among the member's declaration annotations, which is where a
+     * consumer would otherwise read it as saying something about the declaration itself.
+     *
+     * @param typeDef  The type, annotated or not
+     * @param typeRef  The reference of the type within the member, from {@link TypeReference}
+     * @param member   The member the annotations are written on
+     */
+    private void writeTypeAnnotations(TypeDef typeDef, int typeRef, TypeAnnotatable member) {
+        for (AnnotationDef annotation : typeAnnotationsOf(typeDef)) {
+            visitAnnotation(annotation, member.visitTypeAnnotation(
+                typeRef,
+                null,
+                TypeUtils.getType(annotation.getType(), null).getDescriptor(),
+                true
+            ));
+        }
+    }
+
+    private static List<AnnotationDef> typeAnnotationsOf(TypeDef typeDef) {
+        if (typeDef instanceof TypeDef.AnnotatedTypeDef annotated) {
+            return annotated.annotations();
+        }
+        if (typeDef instanceof ClassTypeDef.AnnotatedClassTypeDef annotated) {
+            return annotated.annotations();
+        }
+        return List.of();
+    }
+
     private MethodDef createStaticInitializer(StatementDef statement) {
         return MethodDef.builder("<clinit>")
             .returns(TypeDef.VOID)
@@ -187,6 +212,11 @@ public final class ByteCodeWriter {
             AnnotationVisitor annotationVisitor = fieldVisitor.visitAnnotation(TypeUtils.getType(annotation.getType(), null).getDescriptor(), true);
             visitAnnotation(annotation, annotationVisitor);
         }
+        writeTypeAnnotations(
+            fieldDef.getType(),
+            TypeReference.newTypeReference(TypeReference.FIELD).getValue(),
+            fieldVisitor::visitTypeAnnotation
+        );
         fieldVisitor.visitEnd();
     }
 
@@ -199,7 +229,7 @@ public final class ByteCodeWriter {
      */
     public void writeInterface(ClassVisitor classVisitor, InterfaceDef interfaceDef, @Nullable ClassTypeDef outerType) {
         Set<String> emittedBridges = new HashSet<>();
-        int modifiersFlag = ACC_INTERFACE | ACC_ABSTRACT | getClassModifiersFlag(interfaceDef.getModifiers());
+        int modifiersFlag = ACC_INTERFACE | ACC_ABSTRACT | getClassModifiersFlag(interfaceDef.getModifiers(), outerType);
         if (interfaceDef.isSynthetic()) {
             modifiersFlag |= ACC_SYNTHETIC;
         }
@@ -249,7 +279,7 @@ public final class ByteCodeWriter {
     public void writeRecord(ClassVisitor classVisitor, RecordDef recordDef, @Nullable ClassTypeDef outerType) {
         Set<String> emittedBridges = new HashSet<>();
         // A record is always final
-        int modifiersFlag = ACC_RECORD | ACC_FINAL | getClassModifiersFlag(recordDef.getModifiers());
+        int modifiersFlag = ACC_RECORD | ACC_FINAL | getClassModifiersFlag(recordDef.getModifiers(), outerType);
         if (recordDef.isSynthetic()) {
             modifiersFlag |= ACC_SYNTHETIC;
         }
@@ -292,7 +322,7 @@ public final class ByteCodeWriter {
             FieldDef componentField = componentFields.get(i);
             writeMethod(classVisitor, recordDef, MethodDef.builder(component.getName())
                 .addModifiers(Modifier.PUBLIC)
-                .returns(component.getType())
+                .returns(componentField.getType())
                 .addAnnotations(annotationsFor(component, ElementType.METHOD))
                 .build((aThis, methodParameters) -> aThis.field(componentField).returning()), emittedBridges);
         }
@@ -302,10 +332,25 @@ public final class ByteCodeWriter {
     }
 
     private static FieldDef toComponentField(PropertyDef component) {
-        return FieldDef.builder(component.getName(), component.getType())
+        return FieldDef.builder(component.getName(), componentType(component))
             .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
             .addAnnotations(annotationsFor(component, ElementType.FIELD))
             .build();
+    }
+
+    /**
+     * The type of a record component, carrying the annotations of the component that are type use ones. A
+     * compiler writes those on the type of every member the component expands to, not on the members
+     * themselves.
+     *
+     * @param component The record component
+     * @return Its type
+     */
+    private static TypeDef componentType(PropertyDef component) {
+        List<AnnotationDef> typeAnnotations = component.getAnnotations().stream()
+            .filter(annotation -> targetsOf(annotation).map(t -> t.contains(ElementType.TYPE_USE)).orElse(false))
+            .toList();
+        return typeAnnotations.isEmpty() ? component.getType() : component.getType().annotated(typeAnnotations);
     }
 
     /**
@@ -321,45 +366,61 @@ public final class ByteCodeWriter {
      */
     private static List<AnnotationDef> annotationsFor(PropertyDef component, ElementType elementType) {
         return component.getAnnotations().stream()
-            .filter(annotation -> declarationTargetsOf(annotation).map(t -> t.contains(elementType)).orElse(true))
+            .filter(annotation -> targetsOf(annotation).map(t -> t.contains(elementType)).orElse(true))
             .toList();
     }
 
     /**
+     * The contexts an annotation declares as its targets, or empty when it declares none and is therefore
+     * applicable in all of them. The targets are read from the class the definition carries, from the
+     * definition of an annotation type being generated alongside, or from the class loaded by name.
+     *
      * @param annotation The annotation
-     * @return The contexts a record component expands to that the annotation targets, or empty when it
-     * targets all of them - because it declares no {@link Target}, because its type cannot be resolved here,
-     * or because it targets none of them at all and would otherwise be lost
+     * @return Its targets, or empty when it declares none or its type cannot be resolved here
      */
-    private static Optional<Set<ElementType>> declarationTargetsOf(AnnotationDef annotation) {
-        Class<?> annotationType = resolveAnnotationType(annotation.getType());
+    private static Optional<Set<ElementType>> targetsOf(AnnotationDef annotation) {
+        ClassTypeDef typeDef = annotation.getType();
+        if (typeDef instanceof ClassTypeDef.ClassDefType classDefType) {
+            return declaredTargetsOf(classDefType.objectDef());
+        }
+        Class<?> annotationType = resolveAnnotationType(typeDef);
         if (annotationType == null) {
             return Optional.empty();
         }
         Target target = annotationType.getAnnotation(Target.class);
-        if (target == null) {
-            return Optional.empty();
-        }
-        Set<ElementType> targets = Arrays.stream(target.value())
-            .filter(COMPONENT_DECLARATION_TARGETS::contains)
-            .collect(Collectors.toSet());
-        // A type use annotation targets none of them. This writer has no RuntimeVisibleTypeAnnotations of its
-        // own, so writing it as a declaration annotation keeps it readable rather than dropping it outright
-        return targets.isEmpty() ? Optional.empty() : Optional.of(targets);
+        return target == null ? Optional.empty() : Optional.of(Set.of(target.value()));
+    }
+
+    /**
+     * The targets of an annotation type that is itself being generated, read off its {@link Target}
+     * definition - the class is not loadable, so nothing else can answer for it.
+     *
+     * @param objectDef The definition of the annotation type
+     * @return Its targets, or empty when it declares none
+     */
+    private static Optional<Set<ElementType>> declaredTargetsOf(ObjectDef objectDef) {
+        return objectDef.getAnnotations().stream()
+            .filter(a -> a.getType().getName().equals(Target.class.getName()))
+            .findFirst()
+            .map(a -> {
+                Object value = a.getValues().get(AnnotationMetadata.VALUE_MEMBER);
+                Collection<?> values = value instanceof Collection<?> collection ? collection : List.of(value);
+                return values.stream()
+                    .filter(VariableDef.StaticField.class::isInstance)
+                    .map(v -> ElementType.valueOf(((VariableDef.StaticField) v).name()))
+                    .collect(Collectors.toSet());
+            });
     }
 
     /**
      * @param typeDef The annotation type
      * @return The annotation class, or {@code null} when the definition carries no class for it and none
-     * can be loaded - a type generated in this same round, for one
+     * can be loaded by name
      */
     @Nullable
     private static Class<?> resolveAnnotationType(ClassTypeDef typeDef) {
         if (typeDef instanceof ClassTypeDef.JavaClass javaClass) {
             return javaClass.type();
-        }
-        if (typeDef instanceof ClassTypeDef.ClassDefType) {
-            return null;
         }
         try {
             return Class.forName(typeDef.getName(), false, ByteCodeWriter.class.getClassLoader());
@@ -380,6 +441,11 @@ public final class ByteCodeWriter {
                 true);
             visitAnnotation(annotation, annotationVisitor);
         }
+        writeTypeAnnotations(
+            componentField.getType(),
+            TypeReference.newTypeReference(TypeReference.FIELD).getValue(),
+            recordComponentVisitor::visitTypeAnnotation
+        );
         recordComponentVisitor.visitEnd();
     }
 
@@ -391,8 +457,9 @@ public final class ByteCodeWriter {
                 builder.addModifiers(accessModifier);
             }
         }
-        for (PropertyDef component : components) {
-            builder.addParameter(ParameterDef.builder(component.getName(), component.getType())
+        for (int i = 0; i < components.size(); i++) {
+            PropertyDef component = components.get(i);
+            builder.addParameter(ParameterDef.builder(component.getName(), componentFields.get(i).getType())
                 .addAnnotations(annotationsFor(component, ElementType.PARAMETER))
                 .build());
         }
@@ -496,7 +563,7 @@ public final class ByteCodeWriter {
         Set<String> emittedBridges = new HashSet<>();
         ClassTypeDef typeDef = classDef.asTypeDef();
 
-        int modifiersFlag = getClassModifiersFlag(classDef.getModifiers());
+        int modifiersFlag = getClassModifiersFlag(classDef.getModifiers(), outerType);
 
         if (classDef.isSynthetic()) {
             modifiersFlag |= ACC_SYNTHETIC;
@@ -565,14 +632,14 @@ public final class ByteCodeWriter {
                 TypeUtils.getType(thisType).getInternalName(),
                 outerInternalName,
                 thisType.getSimpleName(),
-                getInnerClassModifiersFlag(thisDef)
+                getInnerClassModifiersFlag(thisDef, outerType.isInterface())
             );
         }
-        writeInnerTypes(classVisitor, thisType, thisDef.getInnerTypes());
+        writeInnerTypes(classVisitor, thisType, thisDef);
     }
 
-    private void writeInnerTypes(ClassVisitor outerClassVisitor, ClassTypeDef outerType, List<ObjectDef> innerTypes) {
-        for (ObjectDef innerDef : innerTypes) {
+    private void writeInnerTypes(ClassVisitor outerClassVisitor, ClassTypeDef outerType, ObjectDef outerDef) {
+        for (ObjectDef innerDef : outerDef.getInnerTypes()) {
             String outerClassInternalName = TypeUtils.getType(outerType).getInternalName();
 
             ClassTypeDef interType = innerDef.asTypeDef();
@@ -580,7 +647,7 @@ public final class ByteCodeWriter {
                 TypeUtils.getType(innerDef.asTypeDef()).getInternalName(),
                 outerClassInternalName,
                 interType.getSimpleName(),
-                getInnerClassModifiersFlag(innerDef)
+                getInnerClassModifiersFlag(innerDef, outerDef instanceof InterfaceDef)
             );
             outerClassVisitor.visitNestMember(TypeUtils.getType(innerDef.asTypeDef()).getInternalName());
         }
@@ -592,16 +659,16 @@ public final class ByteCodeWriter {
      * here, without which it reads back as an inner class needing an enclosing instance. The outer type and
      * the member itself both write this entry, and the two have to agree.
      *
-     * <p>A member that declares no access is written public: a member type of an interface is implicitly
-     * public (JLS 9.5), which is what the source generators emit for one, and the definitions nested by the
-     * generators rely on being reachable.
+     * <p>A member of an interface that declares no access is written public, being implicitly so (JLS 9.5).
+     * A member of a class is not: it keeps the package private access it was declared with.
      *
-     * @param objectDef The member type
+     * @param objectDef          The member type
+     * @param declaredInterface  Whether the type enclosing it is an interface
      * @return The access flags of its inner class entry
      */
-    private int getInnerClassModifiersFlag(ObjectDef objectDef) {
+    private int getInnerClassModifiersFlag(ObjectDef objectDef, boolean declaredInterface) {
         int access = getModifiersFlag(objectDef) | ACC_STATIC;
-        if ((access & (ACC_PUBLIC | ACC_PROTECTED | ACC_PRIVATE)) == 0) {
+        if (declaredInterface && (access & (ACC_PUBLIC | ACC_PROTECTED | ACC_PRIVATE)) == 0) {
             access |= ACC_PUBLIC;
         }
         return access;
@@ -739,6 +806,14 @@ public final class ByteCodeWriter {
             visitAnnotation(annotation, generatorAdapter.visitAnnotation(TypeUtils.getType(annotation.getType(), null).getDescriptor(), true));
         }
 
+        if (!methodDef.isConstructor()) {
+            writeTypeAnnotations(
+                methodDef.getReturnType(),
+                TypeReference.newTypeReference(TypeReference.METHOD_RETURN).getValue(),
+                generatorAdapter::visitTypeAnnotation
+            );
+        }
+
         if (methodDef.getParameters().stream().anyMatch(p -> !p.getAnnotations().isEmpty())) {
             generatorAdapter.visitAnnotableParameterCount(methodDef.getParameters().size(), true);
         }
@@ -794,6 +869,11 @@ public final class ByteCodeWriter {
                 AnnotationVisitor annotationVisitor = generatorAdapter.visitParameterAnnotation(parameterIndex, TypeUtils.getType(annotation.getType(), null).getDescriptor(), true);
                 visitAnnotation(annotation, annotationVisitor);
             }
+            writeTypeAnnotations(
+                parameter.getType(),
+                TypeReference.newFormalParameterReference(parameterIndex).getValue(),
+                generatorAdapter::visitTypeAnnotation
+            );
             Type parameterType = TypeUtils.getType(parameter.getType(), objectDef);
             MethodContext.LocalData prevParam = context.locals().put(parameter.getName(), new MethodContext.LocalData(
                 parameter.getName(),
@@ -1001,9 +1081,12 @@ public final class ByteCodeWriter {
      * @param modifiers The declared modifiers
      * @return The access flags of the class file
      */
-    private int getClassModifiersFlag(Set<Modifier> modifiers) {
+    private int getClassModifiersFlag(Set<Modifier> modifiers, @Nullable ClassTypeDef outerType) {
         int access = getModifiersFlag(modifiers) & ~(ACC_PRIVATE | ACC_PROTECTED | ACC_STATIC);
-        if (modifiers.contains(Modifier.PROTECTED)) {
+        boolean implicitlyPublic = outerType != null
+            && outerType.isInterface()
+            && (access & (ACC_PUBLIC | ACC_PROTECTED | ACC_PRIVATE)) == 0;
+        if (modifiers.contains(Modifier.PROTECTED) || implicitlyPublic) {
             access |= ACC_PUBLIC;
         }
         return access;
@@ -1051,6 +1134,16 @@ public final class ByteCodeWriter {
      */
     public byte[] write(ObjectDef objectDef, @Nullable ClassTypeDef outerType) {
         return createClassWriterAndWriteObject(objectDef, outerType).toByteArray();
+    }
+
+    /**
+     * A visitor of a member that a type annotation can be written on - a field, a record component or a
+     * method all take one the same way.
+     */
+    @FunctionalInterface
+    private interface TypeAnnotatable {
+
+        AnnotationVisitor visitTypeAnnotation(int typeRef, @Nullable TypePath typePath, String descriptor, boolean visible);
     }
 
 }

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ObjectMethodsHandle.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ObjectMethodsHandle.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.bytecode;
+
+import io.micronaut.core.annotation.Internal;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * The bootstrap method a record's {@code equals}, {@code hashCode} and {@code toString} are linked through.
+ *
+ * @author Denis Stepanov
+ * @since 2.2
+ */
+@Internal
+final class ObjectMethodsHandle {
+
+    static final Handle BOOTSTRAP = new Handle(
+        Opcodes.H_INVOKESTATIC,
+        "java/lang/runtime/ObjectMethods",
+        "bootstrap",
+        "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;"
+            + "Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;"
+            + "[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;",
+        false
+    );
+
+    private ObjectMethodsHandle() {
+    }
+
+}

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/SignatureWriterUtils.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/SignatureWriterUtils.java
@@ -138,7 +138,22 @@ final class SignatureWriterUtils {
     }
 
     private static boolean needsSignature(TypeDef typeDef) {
+        typeDef = unwrapAnnotated(typeDef);
         return typeDef instanceof ClassTypeDef.Parameterized || typeDef instanceof TypeDef.TypeVariable;
+    }
+
+    /**
+     * @param typeDef The type
+     * @return The type without the annotations it carries, which have no place in a signature
+     */
+    private static TypeDef unwrapAnnotated(TypeDef typeDef) {
+        if (typeDef instanceof TypeDef.AnnotatedTypeDef annotated) {
+            return unwrapAnnotated(annotated.typeDef());
+        }
+        if (typeDef instanceof ClassTypeDef.AnnotatedClassTypeDef annotated) {
+            return unwrapAnnotated(annotated.typeDef());
+        }
+        return typeDef;
     }
 
     private static void writeSignature(SignatureVisitor signatureWriter,
@@ -152,6 +167,7 @@ final class SignatureWriterUtils {
                                        @Nullable MethodDef methodDef,
                                        TypeDef typeDef, boolean isDefinition) {
         typeDef = ObjectDef.getContextualType(objectDef, typeDef);
+        typeDef = unwrapAnnotated(typeDef);
         if (typeDef instanceof TypeDef.Primitive primitive) {
             Type type = Type.getType(JavaModelUtils.NAME_TO_TYPE_MAP.get(primitive.name()));
             signatureWriter.visitBaseType(type.getDescriptor().charAt(0));

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/SignatureWriterUtils.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/SignatureWriterUtils.java
@@ -231,6 +231,10 @@ final class SignatureWriterUtils {
             return interfaceDef.getTypeVariables().stream()
                 .anyMatch(tv -> tv.name().equals(variableName));
         }
+        if (objectDef instanceof RecordDef recordDef) {
+            return recordDef.getTypeVariables().stream()
+                .anyMatch(tv -> tv.name().equals(variableName));
+        }
         return false;
     }
 

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/TypeUtils.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/TypeUtils.java
@@ -24,6 +24,7 @@ import io.micronaut.sourcegen.model.InterfaceDef;
 import io.micronaut.sourcegen.model.MethodDef;
 import io.micronaut.sourcegen.model.ObjectDef;
 import io.micronaut.sourcegen.model.ParameterDef;
+import io.micronaut.sourcegen.model.RecordDef;
 import io.micronaut.sourcegen.model.TypeDef;
 import org.objectweb.asm.Type;
 
@@ -93,6 +94,14 @@ public final class TypeUtils {
                 }
                 if (objectDef instanceof InterfaceDef interfaceDef) {
                     TypeDef.TypeVariable tvDef = interfaceDef.getTypeVariables().stream()
+                        .filter(tv -> tv.name().equals(name)).findFirst()
+                        .orElse(null);
+                    if (tvDef != null) {
+                        return getBoundsType(tvDef.bounds(), objectDef);
+                    }
+                }
+                if (objectDef instanceof RecordDef recordDef) {
+                    TypeDef.TypeVariable tvDef = recordDef.getTypeVariables().stream()
                         .filter(tv -> tv.name().equals(name)).findFirst()
                         .orElse(null);
                     if (tvDef != null) {

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/TypeUtils.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/TypeUtils.java
@@ -58,6 +58,13 @@ public final class TypeUtils {
 
     public static Type getType(TypeDef typeDef, @Nullable ObjectDef objectDef) {
         typeDef = ObjectDef.getContextualType(objectDef, typeDef);
+        // The annotations a type carries are written separately, they play no part in its erasure
+        if (typeDef instanceof TypeDef.AnnotatedTypeDef annotated) {
+            return getType(annotated.typeDef(), objectDef);
+        }
+        if (typeDef instanceof ClassTypeDef.AnnotatedClassTypeDef annotated) {
+            return getType(annotated.typeDef(), objectDef);
+        }
         if (typeDef instanceof TypeDef.Array array) {
             return Type.getType("[".repeat(array.dimensions()) + getType(array.componentType(), objectDef).getDescriptor());
         }

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/expression/InvokeInstanceMethodExpressionWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/expression/InvokeInstanceMethodExpressionWriter.java
@@ -25,6 +25,7 @@ import io.micronaut.sourcegen.model.ExpressionDef;
 import io.micronaut.sourcegen.model.MethodDef;
 import io.micronaut.sourcegen.model.ObjectDef;
 import io.micronaut.sourcegen.model.ParameterDef;
+import io.micronaut.sourcegen.model.RecordDef;
 import io.micronaut.sourcegen.model.TypeDef;
 import io.micronaut.sourcegen.model.VariableDef;
 import org.objectweb.asm.Type;
@@ -95,6 +96,8 @@ final class InvokeInstanceMethodExpressionWriter extends AbstractStatementAwareE
         if (aSuper.type() == TypeDef.SUPER) {
             if (context.objectDef() instanceof EnumDef) {
                 superClass = ClassTypeDef.of(Enum.class);
+            } else if (context.objectDef() instanceof RecordDef) {
+                superClass = ClassTypeDef.of(Record.class);
             } else if (context.objectDef() instanceof ClassDef classDef) {
                 superClass = Objects.requireNonNullElse(classDef.getSuperclass(), TypeDef.OBJECT);
             } else {

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/statement/InvokeSuperConstructorStatementWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/statement/InvokeSuperConstructorStatementWriter.java
@@ -24,6 +24,7 @@ import io.micronaut.sourcegen.model.EnumDef;
 import io.micronaut.sourcegen.model.ExpressionDef;
 import io.micronaut.sourcegen.model.MethodDef;
 import io.micronaut.sourcegen.model.ParameterDef;
+import io.micronaut.sourcegen.model.RecordDef;
 import io.micronaut.sourcegen.model.StatementDef;
 import io.micronaut.sourcegen.model.TypeDef;
 import io.micronaut.sourcegen.model.VariableDef;
@@ -62,6 +63,8 @@ final class InvokeSuperConstructorStatementWriter implements StatementWriter {
         if (aSuper.type() == TypeDef.SUPER) {
             if (context.objectDef() instanceof EnumDef) {
                 superClass = ClassTypeDef.of(Enum.class);
+            } else if (context.objectDef() instanceof RecordDef) {
+                superClass = ClassTypeDef.of(Record.class);
             } else if (context.objectDef() instanceof ClassDef classDef) {
                 superClass = Objects.requireNonNullElse(classDef.getSuperclass(), TypeDef.OBJECT);
             } else {

--- a/sourcegen-bytecode-writer/src/test/groovy/io/micronaut/sourcegen/bytecode/RecordComponentAnnotationSpec.groovy
+++ b/sourcegen-bytecode-writer/src/test/groovy/io/micronaut/sourcegen/bytecode/RecordComponentAnnotationSpec.groovy
@@ -65,6 +65,42 @@ class Holder {
         bytecode.count('@Ltest/Holder$TypeUseOnly;()\n') == 0
     }
 
+    void "targets survive the conversion of an annotation the visitor copied"() {
+        given:
+        ClassElement holder = buildClassElement('''
+package test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+class Holder {
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface FieldOnly {
+    }
+
+    @FieldOnly
+    String annotated;
+}
+''')
+        def field = holder.getEnclosedElements(ElementQuery.ALL_FIELDS).first()
+
+        when:
+        // The route a visitor takes to copy an annotation off an element it is looking at
+        AnnotationDef copied = AnnotationDef.of(field.annotationMetadata.getAnnotation('test.Holder$FieldOnly'), holder.visitorContext)
+        RecordDef recordDef = RecordDef.builder("test.MyRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(PropertyDef.builder("name").ofType(TypeDef.STRING).addAnnotation(copied).build())
+            .build()
+        String bytecode = write(recordDef)
+
+        then:
+        // Targeting a field, and known to, it is written on the field alone
+        bytecode.count('@Ltest/Holder$FieldOnly;()\n') == 1
+    }
+
     private static String write(RecordDef recordDef) {
         StringWriter stringWriter = new StringWriter()
         def classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES)

--- a/sourcegen-bytecode-writer/src/test/groovy/io/micronaut/sourcegen/bytecode/RecordComponentAnnotationSpec.groovy
+++ b/sourcegen-bytecode-writer/src/test/groovy/io/micronaut/sourcegen/bytecode/RecordComponentAnnotationSpec.groovy
@@ -1,0 +1,76 @@
+package io.micronaut.sourcegen.bytecode
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.inject.ast.ClassElement
+import io.micronaut.inject.ast.ElementQuery
+import io.micronaut.sourcegen.model.AnnotationDef
+import io.micronaut.sourcegen.model.ClassTypeDef
+import io.micronaut.sourcegen.model.PropertyDef
+import io.micronaut.sourcegen.model.RecordDef
+import io.micronaut.sourcegen.model.TypeDef
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.util.CheckClassAdapter
+import org.objectweb.asm.util.TraceClassVisitor
+
+import javax.lang.model.element.Modifier
+
+/**
+ * The targets of an annotation type that is being compiled alongside the record, taken from a javac
+ * {@link ClassElement}. Its class cannot be loaded, and Micronaut strips {@code Target} from the annotation
+ * metadata of an element, so the compiler's own element is the only thing that can answer.
+ */
+class RecordComponentAnnotationSpec extends AbstractTypeElementSpec {
+
+    void "a component annotation defined in the sources goes only where it is targeted"() {
+        given:
+        ClassElement holder = buildClassElement('''
+package test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+class Holder {
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface FieldOnly {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface TypeUseOnly {
+    }
+}
+''')
+        List<ClassElement> innerTypes = holder.getEnclosedElements(ElementQuery.ALL_INNER_CLASSES)
+        ClassElement fieldOnly = innerTypes.find { it.name.endsWith('FieldOnly') }
+        ClassElement typeUseOnly = innerTypes.find { it.name.endsWith('TypeUseOnly') }
+
+        when:
+        RecordDef recordDef = RecordDef.builder("test.MyRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(PropertyDef.builder("name").ofType(TypeDef.STRING)
+                .addAnnotation(AnnotationDef.builder(ClassTypeDef.of(fieldOnly)).build())
+                .addAnnotation(AnnotationDef.builder(ClassTypeDef.of(typeUseOnly)).build())
+                .build())
+            .build()
+        String bytecode = write(recordDef)
+
+        then:
+        // Targeting a field, it is written on the field and on nothing else
+        bytecode.count('@Ltest/Holder$FieldOnly;()\n') == 1
+        // Targeting a type use, it is written on the type of each of the four members
+        bytecode.count('@Ltest/Holder$TypeUseOnly;() :') == 4
+        bytecode.count('@Ltest/Holder$TypeUseOnly;()\n') == 0
+    }
+
+    private static String write(RecordDef recordDef) {
+        StringWriter stringWriter = new StringWriter()
+        def classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES)
+        def tcv = new TraceClassVisitor(new CheckClassAdapter(classWriter), new PrintWriter(stringWriter))
+        new ByteCodeWriter(false, false).writeObject(tcv, recordDef)
+        tcv.visitEnd()
+        return stringWriter.toString()
+    }
+}

--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
@@ -8,6 +8,7 @@ import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.sourcegen.custom.visitor.GenerateLambdaVisitor;
 import io.micronaut.sourcegen.custom.visitor.innerTypes.GenerateInnerTypeInEnumVisitor;
+import io.micronaut.sourcegen.model.AnnotationDef;
 import io.micronaut.sourcegen.model.ClassDef;
 import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.EnumDef;
@@ -16,6 +17,8 @@ import io.micronaut.sourcegen.model.FieldDef;
 import io.micronaut.sourcegen.model.JavaIdioms;
 import io.micronaut.sourcegen.model.MethodDef;
 import io.micronaut.sourcegen.model.ObjectDef;
+import io.micronaut.sourcegen.model.PropertyDef;
+import io.micronaut.sourcegen.model.RecordDef;
 import io.micronaut.sourcegen.model.StatementDef;
 import io.micronaut.sourcegen.model.TypeDef;
 import io.micronaut.sourcegen.model.VariableDef;
@@ -40,6 +43,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static io.micronaut.sourcegen.bytecode.DecompilerUtils.decompileToJava;
@@ -3838,8 +3842,8 @@ public final enum example/MyEnumWithInnerTypes extends java/lang/Enum {
   // access flags 0x4019
   public final static enum INNERCLASS example/MyEnumWithInnerTypes$InnerEnum example/MyEnumWithInnerTypes InnerEnum
   NESTMEMBER example/MyEnumWithInnerTypes$InnerEnum
-  // access flags 0x9
-  public static INNERCLASS example/MyEnumWithInnerTypes$InnerRecord example/MyEnumWithInnerTypes InnerRecord
+  // access flags 0x19
+  public final static INNERCLASS example/MyEnumWithInnerTypes$InnerRecord example/MyEnumWithInnerTypes InnerRecord
   NESTMEMBER example/MyEnumWithInnerTypes$InnerRecord
   // access flags 0x9
   public static INNERCLASS example/MyEnumWithInnerTypes$InnerClass example/MyEnumWithInnerTypes InnerClass
@@ -4859,11 +4863,15 @@ public class MyClass {
     }
 
     private byte[] generateFile(ObjectDef objectDef, StringWriter stringWriter) {
+        return generateFile(objectDef, null, stringWriter);
+    }
+
+    private byte[] generateFile(ObjectDef objectDef, ClassTypeDef outerType, StringWriter stringWriter) {
         var classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
         var checkClassAdapter = new CheckClassAdapter(classWriter);
         var tcv = new TraceClassVisitor(checkClassAdapter, new PrintWriter(stringWriter));
 
-        new ByteCodeWriter(false, false).writeObject(tcv, objectDef);
+        new ByteCodeWriter(false, false).writeObject(tcv, objectDef, outerType);
 
         tcv.visitEnd();
 
@@ -4978,6 +4986,1295 @@ class Test implements Function {
    }
 }
 """, decompileToJava(bytes));
+    }
+
+    @Test
+    void testRecord() throws Exception {
+        RecordDef recordDef = RecordDef.builder("example.MyRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(PropertyDef.builder("name").ofType(TypeDef.STRING).build())
+            .addProperty(PropertyDef.builder("age").ofType(TypeDef.Primitive.INT).build())
+            .build();
+
+        StringWriter bytecodeWriter = new StringWriter();
+        byte[] bytes = generateFile(recordDef, bytecodeWriter);
+
+        assertEquals("""
+// class version 61.0 (61)
+// RECORD
+// access flags 0x10011
+// signature Ljava/lang/Record;
+// declaration: example/MyRecord extends java.lang.Record
+public final class example/MyRecord extends java/lang/Record {
+
+  RECORDCOMPONENT   Ljava/lang/String; name
+  RECORDCOMPONENT   I age
+
+  // access flags 0x12
+  private final Ljava/lang/String; name
+
+  // access flags 0x12
+  private final I age
+
+  // access flags 0x1
+  public <init>(Ljava/lang/String;I)V
+   L0
+    ALOAD 0
+    INVOKESPECIAL java/lang/Record.<init> ()V
+    ALOAD 0
+    ALOAD 1
+    PUTFIELD example/MyRecord.name : Ljava/lang/String;
+    ALOAD 0
+    ILOAD 2
+    PUTFIELD example/MyRecord.age : I
+    RETURN
+   L1
+    LOCALVARIABLE name Ljava/lang/String; L0 L1 1
+    LOCALVARIABLE age I L0 L1 2
+
+  // access flags 0x11
+  public final toString()Ljava/lang/String;
+    ALOAD 0
+    INVOKEDYNAMIC toString(Lexample/MyRecord;)Ljava/lang/String; [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "name;age",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.name(Ljava/lang/String;),\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.age(I)
+    ]
+    ARETURN
+
+  // access flags 0x11
+  public final hashCode()I
+    ALOAD 0
+    INVOKEDYNAMIC hashCode(Lexample/MyRecord;)I [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "name;age",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.name(Ljava/lang/String;),\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.age(I)
+    ]
+    IRETURN
+
+  // access flags 0x11
+  public final equals(Ljava/lang/Object;)Z
+    ALOAD 0
+    ALOAD 1
+    INVOKEDYNAMIC equals(Lexample/MyRecord;Ljava/lang/Object;)Z [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "name;age",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.name(Ljava/lang/String;),\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.age(I)
+    ]
+    IRETURN
+
+  // access flags 0x1
+  public name()Ljava/lang/String;
+    ALOAD 0
+    GETFIELD example/MyRecord.name : Ljava/lang/String;
+    ARETURN
+
+  // access flags 0x1
+  public age()I
+    ALOAD 0
+    GETFIELD example/MyRecord.age : I
+    IRETURN
+}
+""", bytecodeWriter.toString());
+
+        assertEquals("""
+package example;
+
+public record MyRecord(String name, int age) {
+   public MyRecord(String name, int age) {
+      this.name = name;
+      this.age = age;
+   }
+}
+""", decompileToJava(bytes));
+
+        Class<?> recordClass = defineClass("example.MyRecord", bytes);
+        Object record = recordClass.getConstructors()[0].newInstance("Denis", 30);
+
+        Assertions.assertTrue(recordClass.isRecord());
+        assertEquals(2, recordClass.getRecordComponents().length);
+        assertEquals("MyRecord[name=Denis, age=30]", record.toString());
+        assertEquals("Denis", recordClass.getMethod("name").invoke(record));
+        assertEquals(30, recordClass.getMethod("age").invoke(record));
+        assertEquals(record, recordClass.getConstructors()[0].newInstance("Denis", 30));
+        assertEquals(record.hashCode(), recordClass.getConstructors()[0].newInstance("Denis", 30).hashCode());
+        Assertions.assertNotEquals(record, recordClass.getConstructors()[0].newInstance("Denis", 31));
+    }
+
+    @Test
+    void testGenericRecord() {
+        RecordDef recordDef = RecordDef.builder("example.MyRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addTypeVariable(TypeDef.variable("T"))
+            .addSuperinterface(TypeDef.parameterized(Supplier.class, TypeDef.variable("T")))
+            .addProperty(PropertyDef.builder("value").ofType(TypeDef.variable("T")).build())
+            .addMethod(MethodDef.builder("get")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(TypeDef.variable("T"))
+                .build((aThis, methodParameters) -> aThis.invoke("value", TypeDef.variable("T")).returning()))
+            .build();
+
+        StringWriter bytecodeWriter = new StringWriter();
+        generateFile(recordDef, bytecodeWriter);
+
+        assertEquals("""
+// class version 61.0 (61)
+// RECORD
+// access flags 0x10011
+// signature <T:Ljava/lang/Object;>Ljava/lang/Record;Ljava/util/function/Supplier<TT;>;
+// declaration: example/MyRecord<T> extends java.lang.Record implements java.util.function.Supplier<T>
+public final class example/MyRecord extends java/lang/Record implements java/util/function/Supplier {
+
+  RECORDCOMPONENT   // signature TT;
+  // declaration: value extends T
+  Ljava/lang/Object; value
+
+  // access flags 0x12
+  // signature TT;
+  // declaration: value extends T
+  private final Ljava/lang/Object; value
+
+  // access flags 0x1
+  // signature (TT;)V
+  // declaration: void <init>(T)
+  public <init>(Ljava/lang/Object;)V
+   L0
+    ALOAD 0
+    INVOKESPECIAL java/lang/Record.<init> ()V
+    ALOAD 0
+    ALOAD 1
+    PUTFIELD example/MyRecord.value : Ljava/lang/Object;
+    RETURN
+   L1
+    LOCALVARIABLE value Ljava/lang/Object; L0 L1 1
+
+  // access flags 0x11
+  public final toString()Ljava/lang/String;
+    ALOAD 0
+    INVOKEDYNAMIC toString(Lexample/MyRecord;)Ljava/lang/String; [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "value",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.value(Ljava/lang/Object;)
+    ]
+    ARETURN
+
+  // access flags 0x11
+  public final hashCode()I
+    ALOAD 0
+    INVOKEDYNAMIC hashCode(Lexample/MyRecord;)I [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "value",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.value(Ljava/lang/Object;)
+    ]
+    IRETURN
+
+  // access flags 0x11
+  public final equals(Ljava/lang/Object;)Z
+    ALOAD 0
+    ALOAD 1
+    INVOKEDYNAMIC equals(Lexample/MyRecord;Ljava/lang/Object;)Z [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "value",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.value(Ljava/lang/Object;)
+    ]
+    IRETURN
+
+  // access flags 0x1
+  // signature ()TT;
+  // declaration: T value()
+  public value()Ljava/lang/Object;
+    ALOAD 0
+    GETFIELD example/MyRecord.value : Ljava/lang/Object;
+    ARETURN
+
+  // access flags 0x1
+  // signature ()TT;
+  // declaration: T get()
+  public get()Ljava/lang/Object;
+    ALOAD 0
+    INVOKEVIRTUAL example/MyRecord.value ()Ljava/lang/Object;
+    ARETURN
+}
+""", bytecodeWriter.toString());
+    }
+
+    @Test
+    void testGenericRecordSelfTypeIsParameterized() {
+        RecordDef recordDef = RecordDef.builder("example.MyRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addTypeVariable(TypeDef.variable("T"))
+            .addProperty(PropertyDef.builder("value").ofType(TypeDef.variable("T")).build())
+            // TypeDef.THIS has to resolve to the record parameterized by its own variables, so the
+            // signature of a method returning it keeps them
+            .addMethod(MethodDef.builder("withValue")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(TypeDef.THIS)
+                .addParameter("value", TypeDef.variable("T"))
+                .build((aThis, methodParameters) -> TypeDef.THIS.instantiate(methodParameters.get(0)).returning()))
+            .build();
+
+        assertEquals(
+            TypeDef.parameterized(ClassTypeDef.of("example.MyRecord"), TypeDef.variable("T")),
+            recordDef.asTypeDef()
+        );
+
+        StringWriter bytecodeWriter = new StringWriter();
+        generateFile(recordDef, bytecodeWriter);
+
+        assertEquals("""
+// class version 61.0 (61)
+// RECORD
+// access flags 0x10011
+// signature <T:Ljava/lang/Object;>Ljava/lang/Record;
+// declaration: example/MyRecord<T> extends java.lang.Record
+public final class example/MyRecord extends java/lang/Record {
+
+  RECORDCOMPONENT   // signature TT;
+  // declaration: value extends T
+  Ljava/lang/Object; value
+
+  // access flags 0x12
+  // signature TT;
+  // declaration: value extends T
+  private final Ljava/lang/Object; value
+
+  // access flags 0x1
+  // signature (TT;)V
+  // declaration: void <init>(T)
+  public <init>(Ljava/lang/Object;)V
+   L0
+    ALOAD 0
+    INVOKESPECIAL java/lang/Record.<init> ()V
+    ALOAD 0
+    ALOAD 1
+    PUTFIELD example/MyRecord.value : Ljava/lang/Object;
+    RETURN
+   L1
+    LOCALVARIABLE value Ljava/lang/Object; L0 L1 1
+
+  // access flags 0x11
+  public final toString()Ljava/lang/String;
+    ALOAD 0
+    INVOKEDYNAMIC toString(Lexample/MyRecord;)Ljava/lang/String; [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "value",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.value(Ljava/lang/Object;)
+    ]
+    ARETURN
+
+  // access flags 0x11
+  public final hashCode()I
+    ALOAD 0
+    INVOKEDYNAMIC hashCode(Lexample/MyRecord;)I [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "value",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.value(Ljava/lang/Object;)
+    ]
+    IRETURN
+
+  // access flags 0x11
+  public final equals(Ljava/lang/Object;)Z
+    ALOAD 0
+    ALOAD 1
+    INVOKEDYNAMIC equals(Lexample/MyRecord;Ljava/lang/Object;)Z [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "value",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.value(Ljava/lang/Object;)
+    ]
+    IRETURN
+
+  // access flags 0x1
+  // signature ()TT;
+  // declaration: T value()
+  public value()Ljava/lang/Object;
+    ALOAD 0
+    GETFIELD example/MyRecord.value : Ljava/lang/Object;
+    ARETURN
+
+  // access flags 0x1
+  // signature (TT;)Lexample/MyRecord<TT;>;
+  // declaration: example.MyRecord<T> withValue(T)
+  public withValue(Ljava/lang/Object;)Lexample/MyRecord;
+   L0
+    NEW example/MyRecord
+    DUP
+    ALOAD 1
+    INVOKESPECIAL example/MyRecord.<init> (Ljava/lang/Object;)V
+    ARETURN
+   L1
+    LOCALVARIABLE value Ljava/lang/Object; L0 L1 1
+}
+""", bytecodeWriter.toString());
+    }
+
+    @Test
+    void testGenericRecordErasesToTheVariableBound() throws Exception {
+        RecordDef recordDef = RecordDef.builder("example.MyRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addTypeVariable(TypeDef.variable("T", TypeDef.of(Number.class)))
+            // The component refers to the variable by name only, so its bound has to be looked up on the
+            // record: a bounded variable erases to its bound, making the component a Number, not an Object
+            .addProperty(PropertyDef.builder("value").ofType(TypeDef.variable("T")).build())
+            .build();
+
+        StringWriter bytecodeWriter = new StringWriter();
+        byte[] bytes = generateFile(recordDef, bytecodeWriter);
+
+        assertEquals("""
+// class version 61.0 (61)
+// RECORD
+// access flags 0x10011
+// signature <T:Ljava/lang/Number;>Ljava/lang/Record;
+// declaration: example/MyRecord<T extends java.lang.Number> extends java.lang.Record
+public final class example/MyRecord extends java/lang/Record {
+
+  RECORDCOMPONENT   // signature TT;
+  // declaration: value extends T
+  Ljava/lang/Number; value
+
+  // access flags 0x12
+  // signature TT;
+  // declaration: value extends T
+  private final Ljava/lang/Number; value
+
+  // access flags 0x1
+  // signature (TT;)V
+  // declaration: void <init>(T)
+  public <init>(Ljava/lang/Number;)V
+   L0
+    ALOAD 0
+    INVOKESPECIAL java/lang/Record.<init> ()V
+    ALOAD 0
+    ALOAD 1
+    PUTFIELD example/MyRecord.value : Ljava/lang/Number;
+    RETURN
+   L1
+    LOCALVARIABLE value Ljava/lang/Number; L0 L1 1
+
+  // access flags 0x11
+  public final toString()Ljava/lang/String;
+    ALOAD 0
+    INVOKEDYNAMIC toString(Lexample/MyRecord;)Ljava/lang/String; [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "value",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.value(Ljava/lang/Number;)
+    ]
+    ARETURN
+
+  // access flags 0x11
+  public final hashCode()I
+    ALOAD 0
+    INVOKEDYNAMIC hashCode(Lexample/MyRecord;)I [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "value",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.value(Ljava/lang/Number;)
+    ]
+    IRETURN
+
+  // access flags 0x11
+  public final equals(Ljava/lang/Object;)Z
+    ALOAD 0
+    ALOAD 1
+    INVOKEDYNAMIC equals(Lexample/MyRecord;Ljava/lang/Object;)Z [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "value",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.value(Ljava/lang/Number;)
+    ]
+    IRETURN
+
+  // access flags 0x1
+  // signature ()TT;
+  // declaration: T value()
+  public value()Ljava/lang/Number;
+    ALOAD 0
+    GETFIELD example/MyRecord.value : Ljava/lang/Number;
+    ARETURN
+}
+""", bytecodeWriter.toString());
+
+        Class<?> recordClass = defineClass("example.MyRecord", bytes);
+
+        assertEquals(Number.class, recordClass.getDeclaredField("value").getType());
+        assertEquals(Number.class, recordClass.getMethod("value").getReturnType());
+        assertEquals(Number.class, recordClass.getRecordComponents()[0].getType());
+        assertEquals(1, recordClass.getConstructors()[0].newInstance(1).hashCode());
+    }
+
+    @Test
+    void testRecordWithAnAdditionalConstructor() throws Exception {
+        RecordDef recordDef = RecordDef.builder("example.MyRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(PropertyDef.builder("name").ofType(TypeDef.STRING).build())
+            .addProperty(PropertyDef.builder("age").ofType(TypeDef.Primitive.INT).build())
+            // A convenience constructor delegating to the canonical one, which is still generated
+            .addMethod(MethodDef.constructor()
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter("name", TypeDef.STRING)
+                .build((aThis, methodParameters) -> aThis.invokeConstructor(
+                    List.of(TypeDef.STRING, TypeDef.Primitive.INT),
+                    methodParameters.get(0),
+                    TypeDef.Primitive.INT.constant(0)
+                )))
+            .build();
+
+        StringWriter bytecodeWriter = new StringWriter();
+        byte[] bytes = generateFile(recordDef, bytecodeWriter);
+
+        assertEquals("""
+// class version 61.0 (61)
+// RECORD
+// access flags 0x10011
+// signature Ljava/lang/Record;
+// declaration: example/MyRecord extends java.lang.Record
+public final class example/MyRecord extends java/lang/Record {
+
+  RECORDCOMPONENT   Ljava/lang/String; name
+  RECORDCOMPONENT   I age
+
+  // access flags 0x12
+  private final Ljava/lang/String; name
+
+  // access flags 0x12
+  private final I age
+
+  // access flags 0x1
+  public <init>(Ljava/lang/String;I)V
+   L0
+    ALOAD 0
+    INVOKESPECIAL java/lang/Record.<init> ()V
+    ALOAD 0
+    ALOAD 1
+    PUTFIELD example/MyRecord.name : Ljava/lang/String;
+    ALOAD 0
+    ILOAD 2
+    PUTFIELD example/MyRecord.age : I
+    RETURN
+   L1
+    LOCALVARIABLE name Ljava/lang/String; L0 L1 1
+    LOCALVARIABLE age I L0 L1 2
+
+  // access flags 0x11
+  public final toString()Ljava/lang/String;
+    ALOAD 0
+    INVOKEDYNAMIC toString(Lexample/MyRecord;)Ljava/lang/String; [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "name;age",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.name(Ljava/lang/String;),\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.age(I)
+    ]
+    ARETURN
+
+  // access flags 0x11
+  public final hashCode()I
+    ALOAD 0
+    INVOKEDYNAMIC hashCode(Lexample/MyRecord;)I [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "name;age",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.name(Ljava/lang/String;),\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.age(I)
+    ]
+    IRETURN
+
+  // access flags 0x11
+  public final equals(Ljava/lang/Object;)Z
+    ALOAD 0
+    ALOAD 1
+    INVOKEDYNAMIC equals(Lexample/MyRecord;Ljava/lang/Object;)Z [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "name;age",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.name(Ljava/lang/String;),\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.age(I)
+    ]
+    IRETURN
+
+  // access flags 0x1
+  public name()Ljava/lang/String;
+    ALOAD 0
+    GETFIELD example/MyRecord.name : Ljava/lang/String;
+    ARETURN
+
+  // access flags 0x1
+  public age()I
+    ALOAD 0
+    GETFIELD example/MyRecord.age : I
+    IRETURN
+
+  // access flags 0x1
+  public <init>(Ljava/lang/String;)V
+   L0
+    ALOAD 0
+    ALOAD 1
+    ICONST_0
+    INVOKESPECIAL example/MyRecord.<init> (Ljava/lang/String;I)V
+    RETURN
+   L1
+    LOCALVARIABLE name Ljava/lang/String; L0 L1 1
+}
+""", bytecodeWriter.toString());
+
+        Class<?> recordClass = defineClass("example.MyRecord", bytes);
+
+        assertEquals(2, recordClass.getConstructors().length);
+        assertEquals("MyRecord[name=Denis, age=0]", recordClass.getConstructor(String.class).newInstance("Denis").toString());
+        assertEquals(
+            recordClass.getConstructor(String.class).newInstance("Denis"),
+            recordClass.getConstructor(String.class, int.class).newInstance("Denis", 0)
+        );
+    }
+
+    @Test
+    void testRecordWithoutComponents() throws Exception {
+        RecordDef recordDef = RecordDef.builder("example.MyRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .build();
+
+        StringWriter bytecodeWriter = new StringWriter();
+        byte[] bytes = generateFile(recordDef, bytecodeWriter);
+
+        assertEquals("""
+// class version 61.0 (61)
+// RECORD
+// access flags 0x10011
+// signature Ljava/lang/Record;
+// declaration: example/MyRecord extends java.lang.Record
+public final class example/MyRecord extends java/lang/Record {
+
+
+  // access flags 0x1
+  public <init>()V
+    ALOAD 0
+    INVOKESPECIAL java/lang/Record.<init> ()V
+    RETURN
+
+  // access flags 0x11
+  public final toString()Ljava/lang/String;
+    ALOAD 0
+    INVOKEDYNAMIC toString(Lexample/MyRecord;)Ljava/lang/String; [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      ""
+    ]
+    ARETURN
+
+  // access flags 0x11
+  public final hashCode()I
+    ALOAD 0
+    INVOKEDYNAMIC hashCode(Lexample/MyRecord;)I [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      ""
+    ]
+    IRETURN
+
+  // access flags 0x11
+  public final equals(Ljava/lang/Object;)Z
+    ALOAD 0
+    ALOAD 1
+    INVOKEDYNAMIC equals(Lexample/MyRecord;Ljava/lang/Object;)Z [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      ""
+    ]
+    IRETURN
+}
+""", bytecodeWriter.toString());
+
+        Class<?> recordClass = defineClass("example.MyRecord", bytes);
+        Object record = recordClass.getConstructor().newInstance();
+
+        assertEquals(0, recordClass.getRecordComponents().length);
+        assertEquals("MyRecord[]", record.toString());
+        assertEquals(record, recordClass.getConstructor().newInstance());
+        assertEquals(0, record.hashCode());
+    }
+
+    @Test
+    void testRecordWithWideAndArrayComponents() throws Exception {
+        RecordDef recordDef = RecordDef.builder("example.MyRecord")
+            .addModifiers(Modifier.PUBLIC)
+            // A long and a double take two slots each, so the canonical constructor has to skip a slot for them
+            .addProperty(PropertyDef.builder("id").ofType(TypeDef.Primitive.LONG).build())
+            .addProperty(PropertyDef.builder("weight").ofType(TypeDef.Primitive.DOUBLE).build())
+            .addProperty(PropertyDef.builder("tags").ofType(TypeDef.STRING.array()).build())
+            .build();
+
+        StringWriter bytecodeWriter = new StringWriter();
+        byte[] bytes = generateFile(recordDef, bytecodeWriter);
+
+        assertEquals("""
+// class version 61.0 (61)
+// RECORD
+// access flags 0x10011
+// signature Ljava/lang/Record;
+// declaration: example/MyRecord extends java.lang.Record
+public final class example/MyRecord extends java/lang/Record {
+
+  RECORDCOMPONENT   J id
+  RECORDCOMPONENT   D weight
+  RECORDCOMPONENT   [Ljava/lang/String; tags
+
+  // access flags 0x12
+  private final J id
+
+  // access flags 0x12
+  private final D weight
+
+  // access flags 0x12
+  private final [Ljava/lang/String; tags
+
+  // access flags 0x1
+  public <init>(JD[Ljava/lang/String;)V
+   L0
+    ALOAD 0
+    INVOKESPECIAL java/lang/Record.<init> ()V
+    ALOAD 0
+    LLOAD 1
+    PUTFIELD example/MyRecord.id : J
+    ALOAD 0
+    DLOAD 3
+    PUTFIELD example/MyRecord.weight : D
+    ALOAD 0
+    ALOAD 5
+    PUTFIELD example/MyRecord.tags : [Ljava/lang/String;
+    RETURN
+   L1
+    LOCALVARIABLE id J L0 L1 1
+    LOCALVARIABLE weight D L0 L1 3
+    LOCALVARIABLE tags [Ljava/lang/String; L0 L1 5
+
+  // access flags 0x11
+  public final toString()Ljava/lang/String;
+    ALOAD 0
+    INVOKEDYNAMIC toString(Lexample/MyRecord;)Ljava/lang/String; [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "id;weight;tags",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.id(J),\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.weight(D),\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.tags([Ljava/lang/String;)
+    ]
+    ARETURN
+
+  // access flags 0x11
+  public final hashCode()I
+    ALOAD 0
+    INVOKEDYNAMIC hashCode(Lexample/MyRecord;)I [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "id;weight;tags",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.id(J),\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.weight(D),\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.tags([Ljava/lang/String;)
+    ]
+    IRETURN
+
+  // access flags 0x11
+  public final equals(Ljava/lang/Object;)Z
+    ALOAD 0
+    ALOAD 1
+    INVOKEDYNAMIC equals(Lexample/MyRecord;Ljava/lang/Object;)Z [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "id;weight;tags",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.id(J),\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.weight(D),\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.tags([Ljava/lang/String;)
+    ]
+    IRETURN
+
+  // access flags 0x1
+  public id()J
+    ALOAD 0
+    GETFIELD example/MyRecord.id : J
+    LRETURN
+
+  // access flags 0x1
+  public weight()D
+    ALOAD 0
+    GETFIELD example/MyRecord.weight : D
+    DRETURN
+
+  // access flags 0x1
+  public tags()[Ljava/lang/String;
+    ALOAD 0
+    GETFIELD example/MyRecord.tags : [Ljava/lang/String;
+    ARETURN
+}
+""", bytecodeWriter.toString());
+
+        Class<?> recordClass = defineClass("example.MyRecord", bytes);
+        String[] tags = {"a", "b"};
+        Object record = recordClass.getConstructor(long.class, double.class, String[].class).newInstance(7L, 1.5d, tags);
+
+        assertEquals(7L, recordClass.getMethod("id").invoke(record));
+        assertEquals(1.5d, recordClass.getMethod("weight").invoke(record));
+        Assertions.assertArrayEquals(tags, (String[]) recordClass.getMethod("tags").invoke(record));
+    }
+
+    @Test
+    void testRecordWithAStaticFactory() throws Exception {
+        ClassTypeDef recordType = ClassTypeDef.of("example.MyRecord");
+        RecordDef recordDef = RecordDef.builder("example.MyRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(PropertyDef.builder("name").ofType(TypeDef.STRING).build())
+            .addMethod(MethodDef.builder("of")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .returns(recordType)
+                .addParameter("name", TypeDef.STRING)
+                .build((aThis, methodParameters) -> recordType.instantiate(methodParameters.get(0)).returning()))
+            .build();
+
+        StringWriter bytecodeWriter = new StringWriter();
+        byte[] bytes = generateFile(recordDef, bytecodeWriter);
+
+        assertEquals("""
+// class version 61.0 (61)
+// RECORD
+// access flags 0x10011
+// signature Ljava/lang/Record;
+// declaration: example/MyRecord extends java.lang.Record
+public final class example/MyRecord extends java/lang/Record {
+
+  RECORDCOMPONENT   Ljava/lang/String; name
+
+  // access flags 0x12
+  private final Ljava/lang/String; name
+
+  // access flags 0x1
+  public <init>(Ljava/lang/String;)V
+   L0
+    ALOAD 0
+    INVOKESPECIAL java/lang/Record.<init> ()V
+    ALOAD 0
+    ALOAD 1
+    PUTFIELD example/MyRecord.name : Ljava/lang/String;
+    RETURN
+   L1
+    LOCALVARIABLE name Ljava/lang/String; L0 L1 1
+
+  // access flags 0x11
+  public final toString()Ljava/lang/String;
+    ALOAD 0
+    INVOKEDYNAMIC toString(Lexample/MyRecord;)Ljava/lang/String; [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "name",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.name(Ljava/lang/String;)
+    ]
+    ARETURN
+
+  // access flags 0x11
+  public final hashCode()I
+    ALOAD 0
+    INVOKEDYNAMIC hashCode(Lexample/MyRecord;)I [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "name",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.name(Ljava/lang/String;)
+    ]
+    IRETURN
+
+  // access flags 0x11
+  public final equals(Ljava/lang/Object;)Z
+    ALOAD 0
+    ALOAD 1
+    INVOKEDYNAMIC equals(Lexample/MyRecord;Ljava/lang/Object;)Z [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "name",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.name(Ljava/lang/String;)
+    ]
+    IRETURN
+
+  // access flags 0x1
+  public name()Ljava/lang/String;
+    ALOAD 0
+    GETFIELD example/MyRecord.name : Ljava/lang/String;
+    ARETURN
+
+  // access flags 0x9
+  public static of(Ljava/lang/String;)Lexample/MyRecord;
+   L0
+    NEW example/MyRecord
+    DUP
+    ALOAD 0
+    INVOKESPECIAL example/MyRecord.<init> (Ljava/lang/String;)V
+    ARETURN
+   L1
+    LOCALVARIABLE name Ljava/lang/String; L0 L1 0
+}
+""", bytecodeWriter.toString());
+
+        Class<?> recordClass = defineClass("example.MyRecord", bytes);
+
+        assertEquals("MyRecord[name=Denis]", recordClass.getMethod("of", String.class).invoke(null, "Denis").toString());
+    }
+
+    @Test
+    void testRecordBridgesAnAccessorInheritedAsGeneric() throws Exception {
+        RecordDef recordDef = RecordDef.builder("example.MyRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addSuperinterface(TypeDef.parameterized(Supplier.class, TypeDef.STRING))
+            // The accessor implements Supplier.get(), whose erasure returns Object, so it needs a bridge
+            .addProperty(PropertyDef.builder("get").ofType(TypeDef.STRING).build())
+            .build();
+
+        StringWriter bytecodeWriter = new StringWriter();
+        byte[] bytes = generateFile(recordDef, bytecodeWriter);
+
+        assertEquals("""
+// class version 61.0 (61)
+// RECORD
+// access flags 0x10011
+// signature Ljava/lang/Record;Ljava/util/function/Supplier<Ljava/lang/String;>;
+// declaration: example/MyRecord extends java.lang.Record implements java.util.function.Supplier<java.lang.String>
+public final class example/MyRecord extends java/lang/Record implements java/util/function/Supplier {
+
+  RECORDCOMPONENT   Ljava/lang/String; get
+
+  // access flags 0x12
+  private final Ljava/lang/String; get
+
+  // access flags 0x1
+  public <init>(Ljava/lang/String;)V
+   L0
+    ALOAD 0
+    INVOKESPECIAL java/lang/Record.<init> ()V
+    ALOAD 0
+    ALOAD 1
+    PUTFIELD example/MyRecord.get : Ljava/lang/String;
+    RETURN
+   L1
+    LOCALVARIABLE get Ljava/lang/String; L0 L1 1
+
+  // access flags 0x11
+  public final toString()Ljava/lang/String;
+    ALOAD 0
+    INVOKEDYNAMIC toString(Lexample/MyRecord;)Ljava/lang/String; [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "get",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.get(Ljava/lang/String;)
+    ]
+    ARETURN
+
+  // access flags 0x11
+  public final hashCode()I
+    ALOAD 0
+    INVOKEDYNAMIC hashCode(Lexample/MyRecord;)I [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "get",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.get(Ljava/lang/String;)
+    ]
+    IRETURN
+
+  // access flags 0x11
+  public final equals(Ljava/lang/Object;)Z
+    ALOAD 0
+    ALOAD 1
+    INVOKEDYNAMIC equals(Lexample/MyRecord;Ljava/lang/Object;)Z [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "get",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.get(Ljava/lang/String;)
+    ]
+    IRETURN
+
+  // access flags 0x1
+  public get()Ljava/lang/String;
+    ALOAD 0
+    GETFIELD example/MyRecord.get : Ljava/lang/String;
+    ARETURN
+
+  // access flags 0x1041
+  public synthetic bridge get()Ljava/lang/Object;
+    ALOAD 0
+    INVOKEVIRTUAL example/MyRecord.get ()Ljava/lang/String;
+    ARETURN
+}
+""", bytecodeWriter.toString());
+
+        Class<?> recordClass = defineClass("example.MyRecord", bytes);
+        Supplier<?> record = (Supplier<?>) recordClass.getConstructor(String.class).newInstance("Denis");
+
+        assertEquals("Denis", record.get());
+    }
+
+    @Test
+    void testInnerRecord() throws Exception {
+        RecordDef innerRecordDef = RecordDef.builder("Inner")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(PropertyDef.builder("id").ofType(TypeDef.Primitive.INT).build())
+            .build();
+        ClassDef outerClassDef = ClassDef.builder("example.Outer")
+            .addModifiers(Modifier.PUBLIC)
+            .addInnerType(innerRecordDef)
+            .build();
+
+        StringWriter outerBytecodeWriter = new StringWriter();
+        generateFile(outerClassDef, outerBytecodeWriter);
+
+        assertEquals("""
+// class version 61.0 (61)
+// access flags 0x1
+// signature Ljava/lang/Object;
+// declaration: example/Outer
+public class example/Outer {
+
+  // access flags 0x19
+  public final static INNERCLASS example/Outer$Inner example/Outer Inner
+  NESTMEMBER example/Outer$Inner
+
+  // access flags 0x1
+  public <init>()V
+    ALOAD 0
+    INVOKESPECIAL java/lang/Object.<init> ()V
+    RETURN
+}
+""", outerBytecodeWriter.toString());
+
+        StringWriter innerBytecodeWriter = new StringWriter();
+        byte[] innerBytes = generateFile(outerClassDef.getInnerTypes().get(0), outerClassDef.asTypeDef(), innerBytecodeWriter);
+
+        assertEquals("""
+// class version 61.0 (61)
+// RECORD
+// access flags 0x10011
+// signature Ljava/lang/Record;
+// declaration: example/Outer$Inner extends java.lang.Record
+public final class example/Outer$Inner extends java/lang/Record {
+
+  NESTHOST example/Outer
+  // access flags 0x19
+  public final static INNERCLASS example/Outer$Inner example/Outer Inner
+  RECORDCOMPONENT   I id
+
+  // access flags 0x12
+  private final I id
+
+  // access flags 0x1
+  public <init>(I)V
+   L0
+    ALOAD 0
+    INVOKESPECIAL java/lang/Record.<init> ()V
+    ALOAD 0
+    ILOAD 1
+    PUTFIELD example/Outer$Inner.id : I
+    RETURN
+   L1
+    LOCALVARIABLE id I L0 L1 1
+
+  // access flags 0x11
+  public final toString()Ljava/lang/String;
+    ALOAD 0
+    INVOKEDYNAMIC toString(Lexample/Outer$Inner;)Ljava/lang/String; [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.Outer$Inner.class,\s
+      "id",\s
+      // handle kind 0x1 : GETFIELD
+      example/Outer$Inner.id(I)
+    ]
+    ARETURN
+
+  // access flags 0x11
+  public final hashCode()I
+    ALOAD 0
+    INVOKEDYNAMIC hashCode(Lexample/Outer$Inner;)I [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.Outer$Inner.class,\s
+      "id",\s
+      // handle kind 0x1 : GETFIELD
+      example/Outer$Inner.id(I)
+    ]
+    IRETURN
+
+  // access flags 0x11
+  public final equals(Ljava/lang/Object;)Z
+    ALOAD 0
+    ALOAD 1
+    INVOKEDYNAMIC equals(Lexample/Outer$Inner;Ljava/lang/Object;)Z [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.Outer$Inner.class,\s
+      "id",\s
+      // handle kind 0x1 : GETFIELD
+      example/Outer$Inner.id(I)
+    ]
+    IRETURN
+
+  // access flags 0x1
+  public id()I
+    ALOAD 0
+    GETFIELD example/Outer$Inner.id : I
+    IRETURN
+}
+""", innerBytecodeWriter.toString());
+
+        Class<?> innerRecordClass = defineClass("example.Outer$Inner", innerBytes);
+
+        Assertions.assertTrue(innerRecordClass.isRecord());
+        // A nested record is static: without that it reads back as an inner class needing an enclosing instance
+        Assertions.assertTrue(java.lang.reflect.Modifier.isStatic(innerRecordClass.getModifiers()));
+        Assertions.assertTrue(java.lang.reflect.Modifier.isFinal(innerRecordClass.getModifiers()));
+        assertEquals(3, innerRecordClass.getConstructors()[0].newInstance(3).hashCode());
+    }
+
+    @Test
+    void testRecordComponentAnnotationsReachEveryMember() throws Exception {
+        RecordDef recordDef = RecordDef.builder("example.MyRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(PropertyDef.builder("name").ofType(TypeDef.STRING)
+                .addAnnotation(AnnotationDef.builder(ClassTypeDef.of(Deprecated.class))
+                    .addMember("since", "1.0")
+                    .build())
+                .build())
+            .build();
+
+        StringWriter bytecodeWriter = new StringWriter();
+        Class<?> recordClass = defineClass("example.MyRecord", generateFile(recordDef, bytecodeWriter));
+
+        // A compiler spreads a component's annotation over every member it produces
+        assertEquals("1.0", recordClass.getRecordComponents()[0].getAnnotation(Deprecated.class).since());
+        assertEquals("1.0", recordClass.getDeclaredField("name").getAnnotation(Deprecated.class).since());
+        assertEquals("1.0", recordClass.getMethod("name").getAnnotation(Deprecated.class).since());
+        assertEquals("1.0", ((Deprecated) recordClass.getConstructors()[0].getParameterAnnotations()[0][0]).since());
+    }
+
+    @Test
+    void testRecordKeepsItsDeclaredMembers() throws Exception {
+        RecordDef recordDef = RecordDef.builder("example.MyRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(PropertyDef.builder("name").ofType(TypeDef.STRING).build())
+            // The canonical constructor, validating its argument
+            .addMethod(MethodDef.constructor()
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter("name", TypeDef.STRING)
+                .build((aThis, methodParameters) -> StatementDef.multi(
+                    aThis.superRef().invokeSuperConstructor(),
+                    aThis.field("name", TypeDef.STRING).put(
+                        methodParameters.get(0).isNull().doIfElse(
+                            ExpressionDef.constant("unnamed"),
+                            methodParameters.get(0)
+                        )
+                    )
+                )))
+            // An accessor and a toString of its own
+            .addMethod(MethodDef.builder("name")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(TypeDef.STRING)
+                .build((aThis, methodParameters) -> aThis.field("name", TypeDef.STRING).invoke("toUpperCase", TypeDef.STRING).returning()))
+            .addMethod(MethodDef.builder("toString")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(TypeDef.STRING)
+                .build((aThis, methodParameters) -> ExpressionDef.constant("my record").returning()))
+            .build();
+
+        StringWriter bytecodeWriter = new StringWriter();
+        byte[] bytes = generateFile(recordDef, bytecodeWriter);
+
+        assertEquals("""
+// class version 61.0 (61)
+// RECORD
+// access flags 0x10011
+// signature Ljava/lang/Record;
+// declaration: example/MyRecord extends java.lang.Record
+public final class example/MyRecord extends java/lang/Record {
+
+  RECORDCOMPONENT   Ljava/lang/String; name
+
+  // access flags 0x12
+  private final Ljava/lang/String; name
+
+  // access flags 0x11
+  public final hashCode()I
+    ALOAD 0
+    INVOKEDYNAMIC hashCode(Lexample/MyRecord;)I [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "name",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.name(Ljava/lang/String;)
+    ]
+    IRETURN
+
+  // access flags 0x11
+  public final equals(Ljava/lang/Object;)Z
+    ALOAD 0
+    ALOAD 1
+    INVOKEDYNAMIC equals(Lexample/MyRecord;Ljava/lang/Object;)Z [
+      // handle kind 0x6 : INVOKESTATIC
+      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
+      // arguments:
+      example.MyRecord.class,\s
+      "name",\s
+      // handle kind 0x1 : GETFIELD
+      example/MyRecord.name(Ljava/lang/String;)
+    ]
+    IRETURN
+
+  // access flags 0x1
+  public <init>(Ljava/lang/String;)V
+   L0
+    ALOAD 0
+    INVOKESPECIAL java/lang/Record.<init> ()V
+    ALOAD 0
+    ALOAD 1
+    IFNONNULL L1
+    LDC "unnamed"
+    GOTO L2
+   L1
+    ALOAD 1
+   L2
+    PUTFIELD example/MyRecord.name : Ljava/lang/String;
+    RETURN
+   L3
+    LOCALVARIABLE name Ljava/lang/String; L0 L3 1
+
+  // access flags 0x1
+  public name()Ljava/lang/String;
+    ALOAD 0
+    GETFIELD example/MyRecord.name : Ljava/lang/String;
+    INVOKEVIRTUAL java/lang/String.toUpperCase ()Ljava/lang/String;
+    ARETURN
+
+  // access flags 0x1
+  public toString()Ljava/lang/String;
+    LDC "my record"
+    ARETURN
+}
+""", bytecodeWriter.toString());
+
+        Class<?> recordClass = defineClass("example.MyRecord", bytes);
+        Object record = recordClass.getConstructors()[0].newInstance((Object) null);
+
+        assertEquals("UNNAMED", recordClass.getMethod("name").invoke(record));
+        assertEquals("my record", record.toString());
+        // equals and hashCode are still the ones derived from the components
+        assertEquals(record, recordClass.getConstructors()[0].newInstance("unnamed"));
+    }
+
+    private Class<?> defineClass(String name, byte[] bytes) {
+        return new ClassLoader(getClass().getClassLoader()) {
+            Class<?> define() {
+                return defineClass(name, bytes, 0, bytes.length);
+            }
+        }.define();
     }
 
     static class MyAbstractClass {

--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
@@ -30,6 +30,10 @@ import org.objectweb.asm.util.TraceClassVisitor;
 
 import javax.lang.model.element.Modifier;
 import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -37,6 +41,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Type;
 import java.lang.reflect.Method;
 import java.util.AbstractList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -68,6 +73,9 @@ import static io.micronaut.sourcegen.model.ExpressionDef.MathUnaryOperation.OpTy
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ByteCodeWriterTest {
+
+    private static final int ACCESS_MODIFIERS_MASK =
+        java.lang.reflect.Modifier.PUBLIC | java.lang.reflect.Modifier.PROTECTED | java.lang.reflect.Modifier.PRIVATE;
 
     @Test
     void testSuperCall() throws Exception {
@@ -5592,6 +5600,26 @@ public final class example/MyRecord extends java/lang/Record {
     }
 
     @Test
+    void testCanonicalConstructorHasTheAccessOfTheRecord() throws Exception {
+        // Only the access a top level class can carry: protected and private belong to a nested one
+        for (Modifier[] modifiers : List.of(new Modifier[]{Modifier.PUBLIC}, new Modifier[]{})) {
+            RecordDef recordDef = RecordDef.builder("example.MyRecord")
+                .addModifiers(modifiers)
+                .addProperty(PropertyDef.builder("name").ofType(TypeDef.STRING).build())
+                .build();
+
+            Class<?> recordClass = defineClass("example.MyRecord", generateFile(recordDef, new StringWriter()));
+            var constructor = recordClass.getDeclaredConstructors()[0];
+
+            assertEquals(
+                java.lang.reflect.Modifier.toString(recordClass.getModifiers() & ACCESS_MODIFIERS_MASK),
+                java.lang.reflect.Modifier.toString(constructor.getModifiers() & ACCESS_MODIFIERS_MASK),
+                "The canonical constructor of a " + Arrays.toString(modifiers) + " record"
+            );
+        }
+    }
+
+    @Test
     void testRecordWithoutComponents() throws Exception {
         RecordDef recordDef = RecordDef.builder("example.MyRecord")
             .addModifiers(Modifier.PUBLIC)
@@ -6134,24 +6162,66 @@ public final class example/Outer$Inner extends java/lang/Record {
     }
 
     @Test
-    void testRecordComponentAnnotationsReachEveryMember() throws Exception {
+    void testRecordComponentAnnotationsGoWhereTheyAreTargeted() throws Exception {
         RecordDef recordDef = RecordDef.builder("example.MyRecord")
             .addModifiers(Modifier.PUBLIC)
             .addProperty(PropertyDef.builder("name").ofType(TypeDef.STRING)
+                .addAnnotation(ComponentOnly.class)
+                .addAnnotation(FieldOnly.class)
+                .addAnnotation(Untargeted.class)
                 .addAnnotation(AnnotationDef.builder(ClassTypeDef.of(Deprecated.class))
                     .addMember("since", "1.0")
                     .build())
                 .build())
             .build();
 
-        StringWriter bytecodeWriter = new StringWriter();
-        Class<?> recordClass = defineClass("example.MyRecord", generateFile(recordDef, bytecodeWriter));
+        Class<?> recordClass = defineClass("example.MyRecord", generateFile(recordDef, new StringWriter()));
+        var component = recordClass.getRecordComponents()[0];
+        var field = recordClass.getDeclaredField("name");
+        var accessor = recordClass.getMethod("name");
+        var parameterAnnotations = recordClass.getConstructors()[0].getParameterAnnotations()[0];
 
-        // A compiler spreads a component's annotation over every member it produces
-        assertEquals("1.0", recordClass.getRecordComponents()[0].getAnnotation(Deprecated.class).since());
-        assertEquals("1.0", recordClass.getDeclaredField("name").getAnnotation(Deprecated.class).since());
-        assertEquals("1.0", recordClass.getMethod("name").getAnnotation(Deprecated.class).since());
-        assertEquals("1.0", ((Deprecated) recordClass.getConstructors()[0].getParameterAnnotations()[0][0]).since());
+        // A component's annotation is spread over the members it expands to, but only where it is targeted
+        Assertions.assertNotNull(component.getAnnotation(ComponentOnly.class));
+        Assertions.assertNull(field.getAnnotation(ComponentOnly.class));
+        Assertions.assertNull(accessor.getAnnotation(ComponentOnly.class));
+        Assertions.assertFalse(Stream.of(parameterAnnotations).anyMatch(ComponentOnly.class::isInstance));
+
+        Assertions.assertNull(component.getAnnotation(FieldOnly.class));
+        Assertions.assertNotNull(field.getAnnotation(FieldOnly.class));
+        Assertions.assertNull(accessor.getAnnotation(FieldOnly.class));
+        Assertions.assertFalse(Stream.of(parameterAnnotations).anyMatch(FieldOnly.class::isInstance));
+
+        // An annotation declaring no target is applicable in all of them
+        Assertions.assertNotNull(component.getAnnotation(Untargeted.class));
+        Assertions.assertNotNull(field.getAnnotation(Untargeted.class));
+        Assertions.assertNotNull(accessor.getAnnotation(Untargeted.class));
+        Assertions.assertTrue(Stream.of(parameterAnnotations).anyMatch(Untargeted.class::isInstance));
+
+        // Deprecated targets everything a component expands to except the component itself
+        Assertions.assertNull(component.getAnnotation(Deprecated.class));
+        assertEquals("1.0", field.getAnnotation(Deprecated.class).since());
+        assertEquals("1.0", accessor.getAnnotation(Deprecated.class).since());
+        assertEquals("1.0", Stream.of(parameterAnnotations)
+            .filter(Deprecated.class::isInstance).map(Deprecated.class::cast).findFirst().orElseThrow().since());
+    }
+
+    @Test
+    void testRecordComponentAnnotationOfAnUnresolvableTypeGoesEverywhere() throws Exception {
+        RecordDef recordDef = RecordDef.builder("example.MyRecord")
+            .addModifiers(Modifier.PUBLIC)
+            // Nothing here can say where an annotation type that is only named belongs, so rather than
+            // dropping it the annotation is written wherever a component expands to
+            .addProperty(PropertyDef.builder("name").ofType(TypeDef.STRING)
+                .addAnnotation("example.NotOnTheClasspath")
+                .build())
+            .build();
+
+        StringWriter bytecodeWriter = new StringWriter();
+        generateFile(recordDef, bytecodeWriter);
+        String bytecode = bytecodeWriter.toString();
+
+        assertEquals(4, bytecode.split("@Lexample/NotOnTheClasspath;", -1).length - 1);
     }
 
     @Test
@@ -6275,6 +6345,20 @@ public final class example/MyRecord extends java/lang/Record {
                 return defineClass(name, bytes, 0, bytes.length);
             }
         }.define();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.RECORD_COMPONENT)
+    @interface ComponentOnly {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface FieldOnly {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Untargeted {
     }
 
     static class MyAbstractClass {

--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
@@ -6263,6 +6263,27 @@ public final class example/Outer$Inner extends java/lang/Record {
     }
 
     @Test
+    void testATypeUseAnnotationReachesTheElementOfAnAlreadyAnnotatedArray() throws Exception {
+        RecordDef recordDef = RecordDef.builder("example.MyRecord")
+            .addModifiers(Modifier.PUBLIC)
+            // The array itself is annotated by the type it was given, the component by its declaration:
+            // `@TypeUseOnly String @TypeUseAndField []`
+            .addProperty(PropertyDef.builder("names")
+                .ofType(TypeDef.STRING.array().annotated(AnnotationDef.builder(ClassTypeDef.of(TypeUseAndField.class)).build()))
+                .addAnnotation(TypeUseOnly.class)
+                .build())
+            .build();
+
+        Class<?> recordClass = defineClass("example.MyRecord", generateFile(recordDef, new StringWriter()));
+        var names = (AnnotatedArrayType) recordClass.getDeclaredField("names").getAnnotatedType();
+
+        Assertions.assertNotNull(names.getAnnotation(TypeUseAndField.class));
+        Assertions.assertNull(names.getAnnotation(TypeUseOnly.class));
+        Assertions.assertNotNull(names.getAnnotatedGenericComponentType().getAnnotation(TypeUseOnly.class));
+        Assertions.assertNull(names.getAnnotatedGenericComponentType().getAnnotation(TypeUseAndField.class));
+    }
+
+    @Test
     void testTypeUseAnnotationsAreWrittenAgainstThePathThatReachesThem() throws Exception {
         AnnotationDef annotation = AnnotationDef.builder(ClassTypeDef.of(TypeUseOnly.class)).build();
         RecordDef recordDef = RecordDef.builder("example.MyRecord")

--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
@@ -38,6 +38,8 @@ import java.lang.annotation.Target;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.lang.reflect.AnnotatedArrayType;
+import java.lang.reflect.AnnotatedParameterizedType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Type;
 import java.lang.reflect.Method;
@@ -6225,6 +6227,45 @@ public final class example/Outer$Inner extends java/lang/Record {
         Assertions.assertNull(field.getAnnotation(TypeUseOnly.class));
         Assertions.assertNull(accessor.getAnnotation(TypeUseOnly.class));
         Assertions.assertEquals(0, constructor.getParameterAnnotations()[0].length);
+    }
+
+    @Test
+    void testTypeUseAnnotationsAreWrittenAgainstThePathThatReachesThem() throws Exception {
+        AnnotationDef annotation = AnnotationDef.builder(ClassTypeDef.of(TypeUseOnly.class)).build();
+        RecordDef recordDef = RecordDef.builder("example.MyRecord")
+            .addModifiers(Modifier.PUBLIC)
+            // What the array holds, not the array
+            .addProperty(PropertyDef.builder("elementAnnotated")
+                .ofType(new TypeDef.Array(TypeDef.STRING.annotated(annotation), 1, false)).build())
+            // The array itself
+            .addProperty(PropertyDef.builder("arrayAnnotated")
+                .ofType(TypeDef.STRING.array().annotated(annotation)).build())
+            .addProperty(PropertyDef.builder("argumentAnnotated")
+                .ofType(TypeDef.parameterized(ClassTypeDef.of(List.class), TypeDef.STRING.annotated(annotation))).build())
+            .addProperty(PropertyDef.builder("nestedArgumentAnnotated")
+                .ofType(TypeDef.parameterized(ClassTypeDef.of(Map.class), TypeDef.STRING,
+                    TypeDef.parameterized(ClassTypeDef.of(List.class), TypeDef.STRING.annotated(annotation)))).build())
+            .build();
+
+        Class<?> recordClass = defineClass("example.MyRecord", generateFile(recordDef, new StringWriter()));
+
+        // The paths a compiler writes: ARRAY, none, TYPE_ARGUMENT(0), and TYPE_ARGUMENT(1) TYPE_ARGUMENT(0)
+        var elementAnnotated = (AnnotatedArrayType) recordClass.getDeclaredField("elementAnnotated").getAnnotatedType();
+        Assertions.assertNull(elementAnnotated.getAnnotation(TypeUseOnly.class));
+        Assertions.assertNotNull(elementAnnotated.getAnnotatedGenericComponentType().getAnnotation(TypeUseOnly.class));
+
+        var arrayAnnotated = (AnnotatedArrayType) recordClass.getDeclaredField("arrayAnnotated").getAnnotatedType();
+        Assertions.assertNotNull(arrayAnnotated.getAnnotation(TypeUseOnly.class));
+        Assertions.assertNull(arrayAnnotated.getAnnotatedGenericComponentType().getAnnotation(TypeUseOnly.class));
+
+        var argumentAnnotated = (AnnotatedParameterizedType) recordClass.getDeclaredField("argumentAnnotated").getAnnotatedType();
+        Assertions.assertNull(argumentAnnotated.getAnnotation(TypeUseOnly.class));
+        Assertions.assertNotNull(argumentAnnotated.getAnnotatedActualTypeArguments()[0].getAnnotation(TypeUseOnly.class));
+
+        var nested = (AnnotatedParameterizedType) recordClass.getDeclaredField("nestedArgumentAnnotated").getAnnotatedType();
+        var innerList = (AnnotatedParameterizedType) nested.getAnnotatedActualTypeArguments()[1];
+        Assertions.assertNull(nested.getAnnotatedActualTypeArguments()[0].getAnnotation(TypeUseOnly.class));
+        Assertions.assertNotNull(innerList.getAnnotatedActualTypeArguments()[0].getAnnotation(TypeUseOnly.class));
     }
 
     @Test

--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
@@ -6230,6 +6230,39 @@ public final class example/Outer$Inner extends java/lang/Record {
     }
 
     @Test
+    void testATypeUseAnnotationOnAnArrayComponentAnnotatesWhatItHolds() throws Exception {
+        RecordDef recordDef = RecordDef.builder("example.MyRecord")
+            .addModifiers(Modifier.PUBLIC)
+            // Declared on the component, the way a generator writes `@Nullable String[] names`
+            .addProperty(PropertyDef.builder("names").ofType(TypeDef.STRING.array())
+                .addAnnotation(TypeUseOnly.class)
+                .build())
+            .addProperty(PropertyDef.builder("grid").ofType(new TypeDef.Array(TypeDef.STRING, 2, false))
+                .addAnnotation(TypeUseOnly.class)
+                .build())
+            .build();
+
+        Class<?> recordClass = defineClass("example.MyRecord", generateFile(recordDef, new StringWriter()));
+
+        // A compiler puts it on what the array holds, not on the array
+        var names = (AnnotatedArrayType) recordClass.getDeclaredField("names").getAnnotatedType();
+        Assertions.assertNull(names.getAnnotation(TypeUseOnly.class));
+        Assertions.assertNotNull(names.getAnnotatedGenericComponentType().getAnnotation(TypeUseOnly.class));
+
+        var grid = (AnnotatedArrayType) recordClass.getDeclaredField("grid").getAnnotatedType();
+        var row = (AnnotatedArrayType) grid.getAnnotatedGenericComponentType();
+        Assertions.assertNull(grid.getAnnotation(TypeUseOnly.class));
+        Assertions.assertNull(row.getAnnotation(TypeUseOnly.class));
+        Assertions.assertNotNull(row.getAnnotatedGenericComponentType().getAnnotation(TypeUseOnly.class));
+
+        // The accessor and the constructor parameter say the same
+        Assertions.assertNotNull(((AnnotatedArrayType) recordClass.getMethod("names").getAnnotatedReturnType())
+            .getAnnotatedGenericComponentType().getAnnotation(TypeUseOnly.class));
+        Assertions.assertNotNull(((AnnotatedArrayType) recordClass.getConstructors()[0].getAnnotatedParameterTypes()[0])
+            .getAnnotatedGenericComponentType().getAnnotation(TypeUseOnly.class));
+    }
+
+    @Test
     void testTypeUseAnnotationsAreWrittenAgainstThePathThatReachesThem() throws Exception {
         AnnotationDef annotation = AnnotationDef.builder(ClassTypeDef.of(TypeUseOnly.class)).build();
         RecordDef recordDef = RecordDef.builder("example.MyRecord")

--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
@@ -9,6 +9,7 @@ import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.sourcegen.custom.visitor.GenerateLambdaVisitor;
 import io.micronaut.sourcegen.custom.visitor.innerTypes.GenerateInnerTypeInEnumVisitor;
 import io.micronaut.sourcegen.model.AnnotationDef;
+import io.micronaut.sourcegen.model.AnnotationObjectDef;
 import io.micronaut.sourcegen.model.ClassDef;
 import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.EnumDef;
@@ -3804,8 +3805,8 @@ class MyClass {
 // declaration: test/MyClass
 class test/MyClass {
 
-  // access flags 0x9
-  public static INNERCLASS test/MyClass$Inner test/MyClass Inner
+  // access flags 0x8
+  static INNERCLASS test/MyClass$Inner test/MyClass Inner
   NESTMEMBER test/MyClass$Inner
 
   // access flags 0x0
@@ -3847,8 +3848,8 @@ class MyClass {
 // declaration: example/MyEnumWithInnerTypes extends java.lang.Enum<example.MyEnumWithInnerTypes>
 public final enum example/MyEnumWithInnerTypes extends java/lang/Enum {
 
-  // access flags 0x4019
-  public final static enum INNERCLASS example/MyEnumWithInnerTypes$InnerEnum example/MyEnumWithInnerTypes InnerEnum
+  // access flags 0x4018
+  final static enum INNERCLASS example/MyEnumWithInnerTypes$InnerEnum example/MyEnumWithInnerTypes InnerEnum
   NESTMEMBER example/MyEnumWithInnerTypes$InnerEnum
   // access flags 0x19
   public final static INNERCLASS example/MyEnumWithInnerTypes$InnerRecord example/MyEnumWithInnerTypes InnerRecord
@@ -6200,7 +6201,7 @@ public final class example/Outer$Inner extends java/lang/Record {
     }
 
     @Test
-    void testTypeUseComponentAnnotationsAreNotDropped() throws Exception {
+    void testTypeUseComponentAnnotationsAreWrittenOnTheType() throws Exception {
         RecordDef recordDef = RecordDef.builder("example.MyRecord")
             .addModifiers(Modifier.PUBLIC)
             .addProperty(PropertyDef.builder("name").ofType(TypeDef.STRING)
@@ -6209,14 +6210,21 @@ public final class example/Outer$Inner extends java/lang/Record {
             .build();
 
         Class<?> recordClass = defineClass("example.MyRecord", generateFile(recordDef, new StringWriter()));
+        var field = recordClass.getDeclaredField("name");
+        var accessor = recordClass.getMethod("name");
+        var constructor = recordClass.getConstructors()[0];
 
-        // This writer has no type annotations of its own, so a type use annotation is kept as a declaration
-        // annotation on everything the component expands to rather than being lost
-        Assertions.assertNotNull(recordClass.getRecordComponents()[0].getAnnotation(TypeUseOnly.class));
-        Assertions.assertNotNull(recordClass.getDeclaredField("name").getAnnotation(TypeUseOnly.class));
-        Assertions.assertNotNull(recordClass.getMethod("name").getAnnotation(TypeUseOnly.class));
-        Assertions.assertTrue(Stream.of(recordClass.getConstructors()[0].getParameterAnnotations()[0])
-            .anyMatch(TypeUseOnly.class::isInstance));
+        // A type use annotation belongs to the type of each member the component expands to
+        Assertions.assertNotNull(recordClass.getRecordComponents()[0].getAnnotatedType().getAnnotation(TypeUseOnly.class));
+        Assertions.assertNotNull(field.getAnnotatedType().getAnnotation(TypeUseOnly.class));
+        Assertions.assertNotNull(accessor.getAnnotatedReturnType().getAnnotation(TypeUseOnly.class));
+        Assertions.assertNotNull(constructor.getAnnotatedParameterTypes()[0].getAnnotation(TypeUseOnly.class));
+
+        // and to none of the declarations themselves
+        Assertions.assertNull(recordClass.getRecordComponents()[0].getAnnotation(TypeUseOnly.class));
+        Assertions.assertNull(field.getAnnotation(TypeUseOnly.class));
+        Assertions.assertNull(accessor.getAnnotation(TypeUseOnly.class));
+        Assertions.assertEquals(0, constructor.getParameterAnnotations()[0].length);
     }
 
     @Test
@@ -6230,12 +6238,17 @@ public final class example/Outer$Inner extends java/lang/Record {
 
         Class<?> recordClass = defineClass("example.MyRecord", generateFile(recordDef, new StringWriter()));
 
-        // It does target a declaration context, so it goes there and nowhere else
+        // The declaration context it targets is the field, so that is the only declaration it goes on
         Assertions.assertNotNull(recordClass.getDeclaredField("name").getAnnotation(TypeUseAndField.class));
         Assertions.assertNull(recordClass.getRecordComponents()[0].getAnnotation(TypeUseAndField.class));
         Assertions.assertNull(recordClass.getMethod("name").getAnnotation(TypeUseAndField.class));
         Assertions.assertFalse(Stream.of(recordClass.getConstructors()[0].getParameterAnnotations()[0])
             .anyMatch(TypeUseAndField.class::isInstance));
+
+        // Targeting a type use as well, it goes on every type too
+        Assertions.assertNotNull(recordClass.getDeclaredField("name").getAnnotatedType().getAnnotation(TypeUseAndField.class));
+        Assertions.assertNotNull(recordClass.getMethod("name").getAnnotatedReturnType().getAnnotation(TypeUseAndField.class));
+        Assertions.assertNotNull(recordClass.getConstructors()[0].getAnnotatedParameterTypes()[0].getAnnotation(TypeUseAndField.class));
     }
 
     @Test
@@ -6281,6 +6294,31 @@ public final class example/Outer$Inner extends java/lang/Record {
         assertEquals("1.0", accessor.getAnnotation(Deprecated.class).since());
         assertEquals("1.0", Stream.of(parameterAnnotations)
             .filter(Deprecated.class::isInstance).map(Deprecated.class::cast).findFirst().orElseThrow().since());
+    }
+
+    @Test
+    void testTargetsOfAnAnnotationTypeGeneratedAlongsideAreRead() throws Exception {
+        // The annotation type is written in this same round, so its class cannot be loaded to be asked
+        AnnotationObjectDef annotationDef = AnnotationObjectDef.builder("example.FieldOnly")
+            .addAnnotation(AnnotationDef.builder(ClassTypeDef.of(Target.class))
+                .addMember("value", new VariableDef.StaticField(
+                    ClassTypeDef.of(ElementType.class), ElementType.FIELD.name(), ClassTypeDef.of(ElementType.class)
+                ))
+                .build())
+            .build();
+        RecordDef recordDef = RecordDef.builder("example.MyRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(PropertyDef.builder("name").ofType(TypeDef.STRING)
+                .addAnnotation(AnnotationDef.builder(ClassTypeDef.of(annotationDef)).build())
+                .build())
+            .build();
+
+        StringWriter bytecodeWriter = new StringWriter();
+        generateFile(recordDef, bytecodeWriter);
+        String bytecode = bytecodeWriter.toString();
+
+        // Its definition says it targets a field, so the field is the only place it is written
+        assertEquals(1, bytecode.split("@Lexample/FieldOnly;", -1).length - 1, bytecode);
     }
 
     @Test

--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
@@ -6162,6 +6162,83 @@ public final class example/Outer$Inner extends java/lang/Record {
     }
 
     @Test
+    void testMemberRecordAccessIsWrittenWhereItBelongs() throws Exception {
+        // A class file cannot carry private or protected: the access of a member type lives in its
+        // InnerClasses entry, and its class file is public only when it is reachable from another package
+        for (var expected : List.of(
+            Map.entry(Modifier.PRIVATE, "  // access flags 0x1A\n  private final static INNERCLASS example/Outer$Inner example/Outer Inner"),
+            Map.entry(Modifier.PROTECTED, "  // access flags 0x1C\n  protected final static INNERCLASS example/Outer$Inner example/Outer Inner"),
+            Map.entry(Modifier.PUBLIC, "  // access flags 0x19\n  public final static INNERCLASS example/Outer$Inner example/Outer Inner")
+        )) {
+            RecordDef innerRecordDef = RecordDef.builder("Inner")
+                .addModifiers(expected.getKey())
+                .addProperty(PropertyDef.builder("id").ofType(TypeDef.Primitive.INT).build())
+                .build();
+            ClassDef outerClassDef = ClassDef.builder("example.Outer")
+                .addModifiers(Modifier.PUBLIC)
+                .addInnerType(innerRecordDef)
+                .build();
+
+            StringWriter bytecodeWriter = new StringWriter();
+            byte[] bytes = generateFile(outerClassDef.getInnerTypes().get(0), outerClassDef.asTypeDef(), bytecodeWriter);
+            String bytecode = bytecodeWriter.toString();
+
+            Assertions.assertTrue(bytecode.contains(expected.getValue()), bytecode);
+            // Only protected reaches beyond the package, so only it makes the class file itself public
+            assertEquals(
+                expected.getKey() == Modifier.PUBLIC || expected.getKey() == Modifier.PROTECTED,
+                bytecode.contains("public final class example/Outer$Inner"),
+                bytecode
+            );
+
+            Class<?> innerRecordClass = defineClass("example.Outer$Inner", bytes);
+            // The canonical constructor took the access of the record, so it is private here too
+            var constructor = innerRecordClass.getDeclaredConstructors()[0];
+            constructor.setAccessible(true);
+            assertEquals(3, constructor.newInstance(3).hashCode());
+        }
+    }
+
+    @Test
+    void testTypeUseComponentAnnotationsAreNotDropped() throws Exception {
+        RecordDef recordDef = RecordDef.builder("example.MyRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(PropertyDef.builder("name").ofType(TypeDef.STRING)
+                .addAnnotation(TypeUseOnly.class)
+                .build())
+            .build();
+
+        Class<?> recordClass = defineClass("example.MyRecord", generateFile(recordDef, new StringWriter()));
+
+        // This writer has no type annotations of its own, so a type use annotation is kept as a declaration
+        // annotation on everything the component expands to rather than being lost
+        Assertions.assertNotNull(recordClass.getRecordComponents()[0].getAnnotation(TypeUseOnly.class));
+        Assertions.assertNotNull(recordClass.getDeclaredField("name").getAnnotation(TypeUseOnly.class));
+        Assertions.assertNotNull(recordClass.getMethod("name").getAnnotation(TypeUseOnly.class));
+        Assertions.assertTrue(Stream.of(recordClass.getConstructors()[0].getParameterAnnotations()[0])
+            .anyMatch(TypeUseOnly.class::isInstance));
+    }
+
+    @Test
+    void testAnAnnotationTargetingBothATypeUseAndADeclarationIsStillFiltered() throws Exception {
+        RecordDef recordDef = RecordDef.builder("example.MyRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(PropertyDef.builder("name").ofType(TypeDef.STRING)
+                .addAnnotation(TypeUseAndField.class)
+                .build())
+            .build();
+
+        Class<?> recordClass = defineClass("example.MyRecord", generateFile(recordDef, new StringWriter()));
+
+        // It does target a declaration context, so it goes there and nowhere else
+        Assertions.assertNotNull(recordClass.getDeclaredField("name").getAnnotation(TypeUseAndField.class));
+        Assertions.assertNull(recordClass.getRecordComponents()[0].getAnnotation(TypeUseAndField.class));
+        Assertions.assertNull(recordClass.getMethod("name").getAnnotation(TypeUseAndField.class));
+        Assertions.assertFalse(Stream.of(recordClass.getConstructors()[0].getParameterAnnotations()[0])
+            .anyMatch(TypeUseAndField.class::isInstance));
+    }
+
+    @Test
     void testRecordComponentAnnotationsGoWhereTheyAreTargeted() throws Exception {
         RecordDef recordDef = RecordDef.builder("example.MyRecord")
             .addModifiers(Modifier.PUBLIC)
@@ -6359,6 +6436,16 @@ public final class example/MyRecord extends java/lang/Record {
 
     @Retention(RetentionPolicy.RUNTIME)
     @interface Untargeted {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface TypeUseOnly {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE_USE, ElementType.FIELD})
+    @interface TypeUseAndField {
     }
 
     static class MyAbstractClass {

--- a/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
+++ b/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
@@ -498,7 +498,8 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
             if (objectDef == null) {
                 throw new IllegalStateException("This type is used outside of the instance scope!");
             }
-            return asType(objectDef.asTypeDef(), null);
+            // The scope is kept: the self type of a generic definition carries the variables it declares
+            return asType(objectDef.asTypeDef(), objectDef, methodDef);
         }
         if (typeDef.equals(TypeDef.SUPER)) {
             if (objectDef == null) {
@@ -590,6 +591,8 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
             case ClassDef classDef -> classDef.getTypeVariables().stream()
                 .anyMatch(tv -> tv.name().equals(variableName));
             case InterfaceDef interfaceDef -> interfaceDef.getTypeVariables().stream()
+                .anyMatch(tv -> tv.name().equals(variableName));
+            case RecordDef recordDef -> recordDef.getTypeVariables().stream()
                 .anyMatch(tv -> tv.name().equals(variableName));
             case null, default -> false;
         };

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/RecordWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/RecordWriteTest.java
@@ -4,11 +4,15 @@ import io.micronaut.sourcegen.JavaPoetSourceGenerator;
 import io.micronaut.sourcegen.model.AnnotationDef;
 import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.PropertyDef;
+import io.micronaut.sourcegen.model.MethodDef;
 import io.micronaut.sourcegen.model.RecordDef;
+import io.micronaut.sourcegen.model.TypeDef;
 import org.junit.jupiter.api.Test;
 
+import javax.lang.model.element.Modifier;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -142,6 +146,42 @@ public class RecordWriteTest {
         return matcher.group(1);
     }
 
+
+    @Test
+    public void writeGenericRecord() throws IOException {
+        RecordDef recordDef = RecordDef.builder("test.TestRecord")
+            .addTypeVariable(TypeDef.variable("K"))
+            .addTypeVariable(TypeDef.variable("V", TypeDef.of(Number.class)))
+            .addSuperinterface(TypeDef.parameterized(
+                ClassTypeDef.of("java.util.function.Supplier"),
+                TypeDef.variable("V")
+            ))
+            .addProperty(PropertyDef.builder("key").ofType(TypeDef.variable("K")).build())
+            .addProperty(PropertyDef.builder("value").ofType(TypeDef.variable("V")).build())
+            .addProperty(PropertyDef.builder("values").ofType(
+                TypeDef.parameterized(ClassTypeDef.of(List.class), TypeDef.variable("V"))
+            ).build())
+            // TypeDef.THIS renders as the record parameterized by its own variables
+            .addMethod(MethodDef.builder("self")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(TypeDef.THIS)
+                .build((aThis, methodParameters) -> aThis.returning()))
+            .build();
+        var result = writeRecord(recordDef);
+
+        var expected = """
+        record TestRecord<K, V extends Number>(
+            K key,
+            V value,
+            List<V> values
+        ) implements Supplier<V> {
+          public TestRecord<K, V> self() {
+            return this;
+          }
+        }
+        """;
+        assertEquals(expected.strip(), result.strip());
+    }
 
     @Test
     public void annotationClassValue() throws IOException {

--- a/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
+++ b/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
@@ -845,7 +845,8 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 if (objectDef == null) {
                     throw java.lang.IllegalStateException("This type is used outside of the instance scope!")
                 }
-                asType(objectDef.asTypeDef(), null)
+                // The scope is kept: the self type of a generic definition carries the variables it declares
+                asType(objectDef.asTypeDef(), objectDef, methodDef)
             } else if (typeDef is TypeDef.Array) {
                 asArray(typeDef, objectDef)
             } else if (typeDef is ClassTypeDef.Parameterized) {
@@ -926,6 +927,10 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                         .anyMatch { tv: TypeDef.TypeVariable -> tv.name == variableName }
                 }
                 if (objectDef is InterfaceDef) {
+                    return objectDef.typeVariables.stream()
+                        .anyMatch { tv: TypeDef.TypeVariable -> tv.name == variableName }
+                }
+                if (objectDef is RecordDef) {
                     return objectDef.typeVariables.stream()
                         .anyMatch { tv: TypeDef.TypeVariable -> tv.name == variableName }
                 }

--- a/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/RecordWriteTest.kt
+++ b/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/RecordWriteTest.kt
@@ -1,0 +1,87 @@
+package io.micronaut.sourcegen
+
+import io.micronaut.sourcegen.model.ClassTypeDef
+import io.micronaut.sourcegen.model.MethodDef
+import io.micronaut.sourcegen.model.PropertyDef
+import io.micronaut.sourcegen.model.RecordDef
+import io.micronaut.sourcegen.model.TypeDef
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.io.StringWriter
+import javax.lang.model.element.Modifier
+
+class RecordWriteTest {
+
+    @Test
+    fun writeSimpleRecord() {
+        val recordDef = RecordDef.builder("test.TestRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(PropertyDef.builder("name").ofType(TypeDef.STRING).build())
+            .addProperty(PropertyDef.builder("age").ofType(TypeDef.Primitive.INT).build())
+            .build()
+
+        val expected = """
+        package test
+
+        import kotlin.Int
+        import kotlin.String
+
+        public data class TestRecord public constructor(
+          public final val name: String,
+          public final val age: Int,
+        )
+
+        """.trimIndent()
+        Assertions.assertEquals(expected.trim(), write(recordDef).trim())
+    }
+
+    @Test
+    fun writeGenericRecord() {
+        val recordDef = RecordDef.builder("test.TestRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addTypeVariable(TypeDef.variable("K"))
+            .addTypeVariable(TypeDef.variable("V", TypeDef.of(Number::class.java)))
+            .addSuperinterface(
+                TypeDef.parameterized(
+                    ClassTypeDef.of("java.util.function.Supplier"),
+                    TypeDef.variable("V")
+                )
+            )
+            .addProperty(PropertyDef.builder("key").ofType(TypeDef.variable("K")).build())
+            .addProperty(PropertyDef.builder("value").ofType(TypeDef.variable("V")).build())
+            // TypeDef.THIS renders as the record parameterized by its own variables
+            .addMethod(
+                MethodDef.builder("self")
+                    .addModifiers(Modifier.PUBLIC)
+                    .returns(TypeDef.THIS)
+                    .build { aThis, _ -> aThis.returning() }
+            )
+            .build()
+
+        val expected = """
+        package test
+
+        import java.lang.Number
+        import java.util.function.Supplier
+
+        public data class TestRecord<K, V : Number> public constructor(
+          public final val key: K,
+          public final val `value`: V,
+        ) : Supplier<V> {
+          public fun self(): TestRecord<K, V> {
+            return this
+          }
+        }
+
+        """.trimIndent()
+        Assertions.assertEquals(expected.trim(), write(recordDef).trim())
+    }
+
+    private fun write(recordDef: RecordDef): String {
+        val generator = KotlinPoetSourceGenerator()
+        StringWriter().use { writer ->
+            generator.write(recordDef, writer)
+            return writer.toString()
+        }
+    }
+}

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
@@ -257,7 +257,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
             builder.addParameter(ParameterDef.of(parameter.getName(), TypeDef.of(parameter.getType())));
             builder.addStatement((aThis, methodParameters) -> {
                 VariableDef.MethodParameter methodParameter = methodParameters.get(parameterIndex);
-                VariableDef.Field propertyField = aThis.field(methodParameter.name(), methodParameter.type());
+                VariableDef.Field propertyField = aThis.field(methodParameter.name(), builderFieldType(parameter));
                 if (parameter.hasAnnotation(Singular.class)) {
                     if (parameter.getType().getName().equals(Iterable.class.getName())) {
                         return iterableToArrayListStatement(propertyField, methodParameter);
@@ -368,6 +368,48 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
             )));
     }
 
+    /**
+     * The type of the field the builder keeps a property in. It is nullable, so a property that was never set
+     * can be told apart from one set to the type's default, and an {@link ArrayList} for a singular property,
+     * which the builder accumulates into. A field has to be referred to by this type: a field access carries
+     * its descriptor, so referring to the field by the property's own type writes one that cannot be resolved.
+     *
+     * @param beanProperty The property
+     * @return The type of the field backing it
+     */
+    static TypeDef builderFieldType(PropertyElement beanProperty) {
+        if (beanProperty.hasAnnotation(Singular.class)) {
+            ClassElement propertyType = beanProperty.getType();
+            if (propertyType.isAssignable(Iterable.class)) {
+                return singularIterableFieldType(propertyType).makeNullable();
+            }
+            if (propertyType.isAssignable(Map.class)) {
+                return singularMapFieldType(propertyType).makeNullable();
+            }
+        }
+        return TypeDef.of(beanProperty.getType()).makeNullable();
+    }
+
+    private static ClassTypeDef singularIterableFieldType(ClassElement propertyType) {
+        return TypeDef.parameterized(ArrayList.class, singularElementType(propertyType));
+    }
+
+    private static ClassTypeDef singularMapFieldType(ClassElement propertyType) {
+        return TypeDef.parameterized(ArrayList.class, singularMapEntryType(propertyType));
+    }
+
+    private static TypeDef singularElementType(ClassElement propertyType) {
+        return propertyType.getFirstTypeArgument().<TypeDef>map(ClassTypeDef::of).orElse(TypeDef.OBJECT);
+    }
+
+    private static ClassTypeDef singularMapEntryType(ClassElement propertyType) {
+        return TypeDef.parameterized(
+            Map.Entry.class,
+            singularElementType(propertyType),
+            propertyType.getTypeArguments().values().stream().skip(1).findFirst().<TypeDef>map(ClassTypeDef::of).orElse(TypeDef.OBJECT)
+        );
+    }
+
     private static FieldDef createField(PropertyElement beanProperty, TypeDef type) {
         TypeDef fieldType = type.makeNullable();
         if (!fieldType.isNullable()) {
@@ -398,9 +440,8 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
             }
         }
         if (beanProperty.getType().isAssignable(Iterable.class)) {
-            TypeDef singularTypeDef = beanProperty.getType().getFirstTypeArgument().<TypeDef>map(ClassTypeDef::of).orElse(TypeDef.OBJECT);
-            TypeDef fieldType = TypeDef.parameterized(ArrayList.class, singularTypeDef);
-            FieldDef field = createField(beanProperty, fieldType);
+            TypeDef singularTypeDef = singularElementType(beanProperty.getType());
+            FieldDef field = createField(beanProperty, singularIterableFieldType(beanProperty.getType()));
             classBuilder.addField(field);
             classBuilder.addMethod(MethodDef.builder(propertyName)
                 .addModifiers(Modifier.PUBLIC)
@@ -436,14 +477,9 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                     returningExpressionProvider.apply(new BuilderGenerator.BuildContext(self, field))
                 )));
         } else if (beanProperty.getType().isAssignable(Map.class)) {
-            TypeDef keyType = beanProperty.getType().getFirstTypeArgument().<TypeDef>map(ClassTypeDef::of).orElse(TypeDef.OBJECT);
+            TypeDef keyType = singularElementType(beanProperty.getType());
             TypeDef valueType = beanProperty.getType().getTypeArguments().values().stream().skip(1).findFirst().<TypeDef>map(ClassTypeDef::of).orElse(TypeDef.OBJECT);
-            ClassTypeDef mapEntryType = TypeDef.parameterized(
-                Map.Entry.class,
-                keyType,
-                valueType
-            );
-            ClassTypeDef fieldType = TypeDef.parameterized(ArrayList.class, mapEntryType);
+            ClassTypeDef fieldType = singularMapFieldType(beanProperty.getType());
             FieldDef field = createField(beanProperty, fieldType);
             classBuilder.addField(field);
             classBuilder.addMethod(MethodDef.builder(propertyName)
@@ -512,7 +548,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                     }
                     // We need to convert it for the correct type in Kotlin
                     TypeDef fieldType = TypeDef.of(parameter.getType());
-                    TypeDef nullableFieldType = fieldType.makeNullable();
+                    TypeDef nullableFieldType = propertyElement == null ? fieldType.makeNullable() : builderFieldType(propertyElement);
                     VariableDef.Field field = self.field(parameter.getName(), nullableFieldType);
                     values.add(!fieldType.isPrimitive() ?
                         valueExpression(propertyElement, field).cast(TypeDef.of(parameter.getType())) :

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/AnnotationDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/AnnotationDef.java
@@ -95,8 +95,9 @@ public final class AnnotationDef {
                 .collect(Collectors.toMap(FieldElement::getName, FieldElement::getType));
         }
 
-        // The other way to determine if the annotation is inner would be use the context to get the class element
-        ClassTypeDef annotationType = ClassTypeDef.of(annotation.getAnnotationName(), annotation.getAnnotationName().contains("$"));
+        // The element is kept rather than reduced to a name: it is the only thing that can answer for an
+        // annotation type being compiled alongside, whose class cannot be loaded
+        ClassTypeDef annotationType = ClassTypeDef.of(annotationElement);
         AnnotationDefBuilder builder = AnnotationDef.builder(annotationType);
         Map<String, ClassElement> finalFieldTypes = fieldTypes;
         annotation.getConvertibleValues().asMap().forEach((key, value) -> {

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/RecordDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/RecordDef.java
@@ -58,6 +58,14 @@ public final class RecordDef extends ObjectDef {
     }
 
     @Override
+    public ClassTypeDef asTypeDef() {
+        if (typeVariables.isEmpty()) {
+            return super.asTypeDef();
+        }
+        return TypeDef.parameterized(super.asTypeDef(), typeVariables.toArray(new TypeDef.TypeVariable[0]));
+    }
+
+    @Override
     public RecordDef withClassName(ClassTypeDef.ClassName className) {
         return new RecordDef(className, modifiers, methods, properties, annotations, javadoc, typeVariables, superinterfaces, innerTypes, synthetic);
     }

--- a/sourcegen-model/src/test/groovy/io/micronaut/sourcegen/model/RecordDefTest.java
+++ b/sourcegen-model/src/test/groovy/io/micronaut/sourcegen/model/RecordDefTest.java
@@ -31,4 +31,37 @@ class RecordDefTest {
         Assertions.assertEquals(String.class.getName(), properties.get(0).getType().getName());
     }
 
+    @Test
+    public void testSelfTypeOfARecordWithoutVariables() {
+        RecordDef recordDef = RecordDef.builder("com.example.Test").build();
+
+        Assertions.assertEquals(ClassTypeDef.of("com.example.Test"), recordDef.asTypeDef());
+    }
+
+    @Test
+    public void testSelfTypeOfAGenericRecordIsParameterized() {
+        RecordDef recordDef = RecordDef.builder("com.example.Test")
+            .addTypeVariable(TypeDef.variable("K"))
+            .addTypeVariable(TypeDef.variable("V", TypeDef.of(Number.class)))
+            .build();
+
+        Assertions.assertEquals(
+            TypeDef.parameterized(
+                ClassTypeDef.of("com.example.Test"),
+                TypeDef.variable("K"),
+                TypeDef.variable("V", TypeDef.of(Number.class))
+            ),
+            recordDef.asTypeDef()
+        );
+    }
+
+    @Test
+    public void testTheSelfTypeIsWhatTypeDefThisResolvesTo() {
+        RecordDef recordDef = RecordDef.builder("com.example.Test")
+            .addTypeVariable(TypeDef.variable("T"))
+            .build();
+
+        Assertions.assertEquals(recordDef.asTypeDef(), recordDef.getContextualType(TypeDef.THIS));
+    }
+
 }

--- a/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/Trigger.java
+++ b/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/Trigger.java
@@ -30,7 +30,6 @@ import io.micronaut.sourcegen.custom.example.GenerateMyBean3;
 import io.micronaut.sourcegen.custom.example.GenerateMyEnum1;
 import io.micronaut.sourcegen.custom.example.GenerateInterface;
 import io.micronaut.sourcegen.custom.example.GenerateMyEnum2;
-import io.micronaut.sourcegen.custom.example.GenerateMyRecord1;
 import io.micronaut.sourcegen.custom.example.GenerateMyRecord3;
 import io.micronaut.sourcegen.custom.example.GenerateMyRepository1;
 import io.micronaut.sourcegen.custom.example.GenerateSwitch;
@@ -38,8 +37,10 @@ import io.micronaut.sourcegen.custom.example.GenerateSwitch;
 @GenerateMyBean1
 @GenerateMyBean2
 @GenerateMyBean3
-//@GenerateMyRecord1
-//@GenerateMyRecord3
+// @GenerateMyRecord1 is left out: the record it generates declares a static `builder()` returning its own
+// generated builder, and that cycle cannot be resolved while the builder's introspection is written. It is
+// unrelated to records - a class definition with the same cycle fails the same way.
+@GenerateMyRecord3
 @GenerateInterface
 @GenerateMyRepository1
 @GenerateMyEnum1

--- a/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/InnerTypesTest.java
+++ b/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/InnerTypesTest.java
@@ -35,32 +35,32 @@ public class InnerTypesTest {
 
         innerInterfaceTest();
 
-//        MyEnumWithInnerTypes.InnerRecord innerRecord = MyEnumWithInnerTypes$InnerRecordBuilder.builder().id(3).build();
-//        assertEquals(3, innerRecord.id());
+        MyEnumWithInnerTypes.InnerRecord innerRecord = MyEnumWithInnerTypesInnerRecordBuilder.builder().id(3).build();
+        assertEquals(3, innerRecord.id());
 
         MyEnumWithInnerTypes.InnerClass innerClass = new MyEnumWithInnerTypes.InnerClass("name");
         assertEquals("name", innerClass.getName());
     }
 
-//    @Test
-//    public void recordTest() {
-//        RecordWithInnerTypes myRecord = new RecordWithInnerTypes(0, "name");
-//        assertEquals(0, myRecord.id());
-//        assertEquals("name", myRecord.name());
-//
-//        innerEnumTest(
-//            RecordWithInnerTypes.InnerEnum.values().length,
-//            RecordWithInnerTypes.InnerEnum.SINGLE.myName(),
-//            RecordWithInnerTypes.InnerEnum.MARRIED.myName());
-//
-//        innerInterfaceTest();
-//
-//        RecordWithInnerTypes.InnerRecord innerRecord = RecordWithInnerTypes$InnerRecordBuilder.builder().id(3).build();
-//        assertEquals(3, innerRecord.id());
-//
-//        RecordWithInnerTypes.InnerClass innerClass = new RecordWithInnerTypes.InnerClass("name");
-//        assertEquals("name", innerClass.getName());
-//    }
+    @Test
+    public void recordTest() {
+        RecordWithInnerTypes myRecord = new RecordWithInnerTypes(0, "name");
+        assertEquals(0, myRecord.id());
+        assertEquals("name", myRecord.name());
+
+        innerEnumTest(
+            RecordWithInnerTypes.InnerEnum.values().length,
+            RecordWithInnerTypes.InnerEnum.SINGLE.myName(),
+            RecordWithInnerTypes.InnerEnum.MARRIED.myName());
+
+        innerInterfaceTest();
+
+        RecordWithInnerTypes.InnerRecord innerRecord = RecordWithInnerTypesInnerRecordBuilder.builder().id(3).build();
+        assertEquals(3, innerRecord.id());
+
+        RecordWithInnerTypes.InnerClass innerClass = new RecordWithInnerTypes.InnerClass("name");
+        assertEquals("name", innerClass.getName());
+    }
 
     @Test
     public void classTest() {
@@ -77,8 +77,8 @@ public class InnerTypesTest {
 
         innerInterfaceTest();
 
-//        ClassWithInnerTypes.InnerRecord innerRecord = ClassWithInnerTypes$InnerRecordBuilder.builder().id(3).build();
-//        assertEquals(3, innerRecord.id());
+        ClassWithInnerTypes.InnerRecord innerRecord = ClassWithInnerTypesInnerRecordBuilder.builder().id(3).build();
+        assertEquals(3, innerRecord.id());
 
         ClassWithInnerTypes.InnerClass innerClass = new ClassWithInnerTypes.InnerClass("name");
         assertEquals("name", innerClass.getName());
@@ -95,8 +95,8 @@ public class InnerTypesTest {
 
         innerInterfaceTest();
 
-//        InterfaceWithInnerTypes.InnerRecord innerRecord = InterfaceWithInnerTypes$InnerRecordBuilder.builder().id(3).build();
-//        assertEquals(3, innerRecord.id());
+        InterfaceWithInnerTypes.InnerRecord innerRecord = InterfaceWithInnerTypesInnerRecordBuilder.builder().id(3).build();
+        assertEquals(3, innerRecord.id());
 
         InterfaceWithInnerTypes.InnerClass innerClass = new InterfaceWithInnerTypes.InnerClass("name");
         assertEquals("name", innerClass.getName());

--- a/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/MyRecord3Test.java
+++ b/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/MyRecord3Test.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Modifier;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MyRecord3Test {
+    @Test
+    public void test() throws Exception {
+        Trigger$MyRecord3 bean = new Trigger$MyRecord3(123, "TheName", 55, List.of("Address 1"), List.of("X", "Y"));
+
+        assertEquals("TheName", bean.name());
+        assertEquals(123, bean.id());
+        assertEquals(55, bean.age());
+        assertEquals(List.of("Address 1"), bean.addresses());
+        assertEquals(List.of("X", "Y"), bean.tags());
+
+        assertTrue(Modifier.isPrivate(
+            bean.getClass().getDeclaredField("id").getModifiers()
+        ));
+        assertInstanceOf(Deprecated.class, bean.getClass().getDeclaredField("id").getDeclaredAnnotations()[0]);
+        assertTrue(Modifier.isPublic(
+            bean.getClass().getDeclaredMethod("id").getModifiers()
+        ));
+        Deprecated deprecated = (Deprecated) bean.getClass().getDeclaredField("age").getDeclaredAnnotations()[0];
+        assertEquals("xyz", deprecated.since());
+        assertTrue(deprecated.forRemoval());
+    }
+
+    @Test
+    public void testBuilder() throws Exception {
+        Trigger$MyRecord3 bean = Trigger$MyRecord3Builder.builder()
+            .id(123)
+            .name("TheName")
+            .age(55)
+            .addresses(List.of("Address 1"))
+            .tags(List.of("X", "Y"))
+            .build();
+
+        assertEquals("TheName", bean.name());
+        assertEquals(123, bean.id());
+        assertEquals(55, bean.age());
+        assertEquals(List.of("Address 1"), bean.addresses());
+        assertEquals(List.of("X", "Y"), bean.tags());
+
+        assertTrue(Modifier.isPrivate(
+            bean.getClass().getDeclaredField("id").getModifiers()
+        ));
+        assertInstanceOf(Deprecated.class, bean.getClass().getDeclaredField("id").getDeclaredAnnotations()[0]);
+        assertTrue(Modifier.isPublic(
+            bean.getClass().getDeclaredMethod("id").getModifiers()
+        ));
+        Deprecated deprecated = (Deprecated) bean.getClass().getDeclaredField("age").getDeclaredAnnotations()[0];
+        assertEquals("xyz", deprecated.since());
+        assertTrue(deprecated.forRemoval());
+    }
+
+    @Test
+    public void testWithers() throws Exception {
+        Trigger$MyRecord3 bean = Trigger$MyRecord3Builder.builder()
+            .id(123)
+            .name("TheName")
+            .age(55)
+            .addresses(List.of("Address 1"))
+            .tags(List.of("X", "Y"))
+            .build();
+
+        assertEquals("TheName", bean.name());
+        assertEquals(123, bean.id());
+        assertEquals(55, bean.age());
+        assertEquals(List.of("Address 1"), bean.addresses());
+        assertEquals(List.of("X", "Y"), bean.tags());
+
+        bean = bean.withName("Xyz");
+
+        assertEquals("Xyz", bean.name());
+        assertEquals(123, bean.id());
+        assertEquals(55, bean.age());
+        assertEquals(List.of("Address 1"), bean.addresses());
+        assertEquals(List.of("X", "Y"), bean.tags());
+
+        bean = bean.with(b -> b.name("Denis").tags(List.of(1, 2, 3)));
+
+        assertEquals("Denis", bean.name());
+        assertEquals(123, bean.id());
+        assertEquals(55, bean.age());
+        assertEquals(List.of("Address 1"), bean.addresses());
+        assertEquals(List.of(1, 2, 3), bean.tags());
+    }
+}


### PR DESCRIPTION
`ByteCodeWriter.writeRecord` emitted only a record's class header — no components, fields, constructor, accessors, `equals`/`hashCode`/`toString`, annotations or declared methods. Records were consequently disabled in the bytecode test suite: `@GenerateMyRecord1`/`@GenerateMyRecord3` were commented out of its `Trigger`, and every inner-record assertion in `InnerTypesTest` was commented out.

## What a record now writes

`writeRecord` expands a `RecordDef` the way a compiler does: `ACC_RECORD | ACC_FINAL` over `java/lang/Record`, a record component and a `private final` field per property, the canonical constructor, a public accessor each, and `equals`/`hashCode`/`toString` as `invokedynamic` through `java.lang.runtime.ObjectMethods#bootstrap`. A member the definition declares itself replaces the generated one, and the canonical constructor is matched on the component types so a record declaring only a convenience constructor still gets one. Its access is the record's own (JLS 8.10.4.1).

The generated `Trigger$MyRecord3` was diffed against javac's for the same definition; they agree member for member and in annotation placement. The one remaining difference is unrelated to records: wildcards erase to `Object` in generic signatures (`List<?>` becomes `List<Object>`), which predates this branch and affects classes equally.

## Annotations on a record component

A compiler spreads a component's annotations over the component, the field, the accessor and the constructor parameter, keeping each only where its `@Target` allows, and writes a type-use annotation on the *type* of each rather than on the declaration. Both are now reproduced:

- Declaration annotations are filtered by `@Target`. The targets are read from the class the definition carries, from the definition of an annotation type generated alongside, or from the compiler's own element for one being compiled — Micronaut strips `Target` from an element's annotation metadata, so the native element is the only thing that can answer. An annotation whose type cannot be resolved at all is treated as untargeted, which is what a compiler does for one declaring no `@Target`.
- Type-use annotations are emitted as `RuntimeVisibleTypeAnnotations` against the path that reaches them: `[` into an array, `N;` into a type argument, `*` into a wildcard bound. `List<@Nullable String>` annotates the argument, and `@Nullable String[]` annotates what the array holds.

## Supporting fixes

Each of these was reached from the record work and is covered by a test that fails without it:

- `super()` in a record resolved to `Object` rather than `Record`.
- A record's type variables were not in scope for signatures, so `List<T>` erased to `List<Object>`, and a bare `T` never found its bound.
- `RecordDef` did not override `asTypeDef`, so `TypeDef.THIS` in a generic record resolved to the raw self type. Both source generators had the same variable-scoping gap for records, and `asType` dropped the object scope when resolving `THIS`, which erased the variables of a generic `ClassDef` or `InterfaceDef` too.
- Method annotations were written without their members.
- `TypeUtils` and the signature writer threw on `TypeDef.AnnotatedTypeDef`, so an annotated type could not be written at all.
- `AnnotationDef.of` resolved the annotation type's element and then reduced it to a name, losing the only thing that can report the targets of an annotation being compiled alongside.
- `@Builder` addressed its fields by the property's type rather than the field's, so `@Wither`'s `with(...)` threw `NoSuchFieldError` on a primitive component.
- A class file's access flags cannot carry `private`, `protected` or `static`, so a private or protected member record produced flags the verifier rejects. Those now live in the `InnerClasses` entry, where a member also keeps its declared access instead of a forced public one — only a member of an interface is implicitly public (JLS 9.5).

The last two are not record-specific and change behaviour for other object kinds: the `InnerClasses` entry of a package-private member of a class or enum now reads `static` rather than `public static`, matching javac, which moved two existing expectations in `ByteCodeWriterTest`.

## Tests

`@GenerateMyRecord3` and every inner-record assertion are enabled in `test-suite-bytecode`, with `MyRecord3Test` brought over from the Java suite. `ByteCodeWriterTest` gains coverage of the constructor shapes (generated canonical, declared canonical, an additional constructor delegating with `this(...)`, a component-less record, and wide and array components), generics, static factories, bridged accessors, member records at each access level, and annotation placement; `RecordComponentAnnotationSpec` drives the annotation paths through a real javac compilation. `RecordDefTest`, the Java `RecordWriteTest` and a new Kotlin `RecordWriteTest` cover the model and both source generators.

Full build green: 1162 tests.

## Not included

`@GenerateMyRecord1` stays disabled in the bytecode `Trigger`, noted in the file. The record it generates declares a static `builder()` returning its own generated builder, and that cycle cannot be resolved while the builder's introspection is written. It is unrelated to records — a class definition with the same cycle fails the same way — and fixing it means changing micronaut-core, not this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)