### PR TITLE
Support @Wither on individual record components

### DIFF
--- a/sourcegen-annotations/src/main/java/io/micronaut/sourcegen/annotations/Wither.java
+++ b/sourcegen-annotations/src/main/java/io/micronaut/sourcegen/annotations/Wither.java
@@ -25,11 +25,17 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * The annotation to generate an interface implementing `with` copy method for records - `MyRecord withMyProperty(MyProperty)`.
  *
+ * <p>When placed on a record type a `with` method is generated for every record component.
+ * Alternatively the annotation can be placed on individual record components, in which case
+ * a `with` method is only generated for the annotated components. Component-level annotations
+ * take precedence, so combining a type-level `@Wither` with component-level ones restricts the
+ * generation to the annotated components.</p>
+ *
  * @author Denis Stepanov
  * @since 1.0
  */
 @Documented
 @Retention(RUNTIME)
-@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE, ElementType.FIELD, ElementType.PARAMETER})
 public @interface Wither {
 }

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/WitherAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/WitherAnnotationVisitor.java
@@ -20,6 +20,9 @@ import org.jspecify.annotations.NonNull;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.Element;
+import io.micronaut.inject.ast.ElementQuery;
+import io.micronaut.inject.ast.FieldElement;
 import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.ast.PropertyElement;
 import io.micronaut.inject.processing.ProcessingException;
@@ -39,6 +42,7 @@ import io.micronaut.sourcegen.model.TypeDef;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import javax.lang.model.element.Modifier;
 import java.util.ArrayList;
@@ -54,7 +58,7 @@ import java.util.function.Consumer;
  * @since 1.0
  */
 @Internal
-public final class WitherAnnotationVisitor implements TypeElementVisitor<Wither, Object> {
+public final class WitherAnnotationVisitor implements TypeElementVisitor<Object, Object> {
 
     private final Set<String> processed = new HashSet<>();
 
@@ -69,7 +73,21 @@ public final class WitherAnnotationVisitor implements TypeElementVisitor<Wither,
     }
 
     @Override
+    public Set<String> getSupportedAnnotationNames() {
+        return Set.of(Wither.class.getName());
+    }
+
+    @Override
     public void visitClass(ClassElement recordElement, VisitorContext context) {
+        boolean annotatedType = recordElement.hasStereotype(Wither.class);
+        if (!annotatedType && !recordElement.isRecord()) {
+            // A component level @Wither is only supported on records
+            return;
+        }
+        Set<String> annotatedComponents = findAnnotatedComponents(recordElement);
+        if (!annotatedType && annotatedComponents.isEmpty()) {
+            return;
+        }
         if (processed.contains(recordElement.getName())) {
             return;
         }
@@ -78,11 +96,17 @@ public final class WitherAnnotationVisitor implements TypeElementVisitor<Wither,
                 throw new ProcessingException(recordElement, "Only records can be annotated with @Wither");
             }
             List<PropertyElement> properties = recordElement.getBeanProperties();
+            List<PropertyElement> witherProperties = annotatedComponents.isEmpty()
+                ? properties
+                : properties.stream().filter(property -> annotatedComponents.contains(property.getName())).toList();
+            if (witherProperties.isEmpty()) {
+                throw new ProcessingException(recordElement, "@Wither can only be placed on a record component, none found for: " + annotatedComponents);
+            }
             List<ParameterElement> parameters = Arrays.asList(recordElement.getPrimaryConstructor().orElseThrow().getParameters());
             boolean hasBuilder = recordElement.hasStereotype(Builder.class);
             ClassTypeDef recordType = ClassTypeDef.of(recordElement);
 
-            InterfaceDef.InterfaceDefBuilder wither = createWither(recordElement.getPackageName(), recordType, properties, parameters, hasBuilder);
+            InterfaceDef.InterfaceDefBuilder wither = createWither(recordElement.getPackageName(), recordType, properties, witherProperties, parameters, hasBuilder);
 
             SourceGenerator sourceGenerator = SourceGenerators.findByLanguage(context.getLanguage()).orElse(null);
             if (sourceGenerator == null) {
@@ -109,6 +133,42 @@ public final class WitherAnnotationVisitor implements TypeElementVisitor<Wither,
     }
 
     /**
+     * Finds the names of the record components that are directly annotated with {@link Wither}.
+     * A record component annotation is visible on the backing field and/or on the canonical
+     * constructor parameter, depending on the targets of the annotation.
+     *
+     * @param recordElement The record element
+     * @return The annotated component names, empty if none of them is annotated
+     */
+    private static Set<String> findAnnotatedComponents(ClassElement recordElement) {
+        Set<String> annotatedNames = new LinkedHashSet<>();
+        for (ParameterElement parameter : recordElement.getPrimaryConstructor()
+            .map(constructor -> Arrays.asList(constructor.getParameters()))
+            .orElse(List.of())) {
+            if (isAnnotated(parameter)) {
+                annotatedNames.add(parameter.getName());
+            }
+        }
+        for (FieldElement field : recordElement.getEnclosedElements(ElementQuery.ALL_FIELDS)) {
+            if (isAnnotated(field)) {
+                annotatedNames.add(field.getName());
+            }
+        }
+        return annotatedNames;
+    }
+
+    /**
+     * The declared metadata is checked to avoid matching a type level {@link Wither},
+     * which is included in the annotation metadata of the record components.
+     *
+     * @param element The element
+     * @return true if the element itself is annotated with {@link Wither}
+     */
+    private static boolean isAnnotated(Element element) {
+        return element.hasDeclaredStereotype(Wither.class);
+    }
+
+    /**
      * Builds a wither interface for the given arguments.
      * @param packageName The package name
      * @param recordType The record type
@@ -121,6 +181,25 @@ public final class WitherAnnotationVisitor implements TypeElementVisitor<Wither,
         String packageName,
         ClassTypeDef recordType,
         List<PropertyElement> properties,
+        List<ParameterElement> parameters, boolean hasBuilder) {
+        return createWither(packageName, recordType, properties, properties, parameters, hasBuilder);
+    }
+
+    /**
+     * Builds a wither interface for the given arguments.
+     * @param packageName The package name
+     * @param recordType The record type
+     * @param properties The properties
+     * @param witherProperties The properties that should get a `with` method
+     * @param parameters The parameters
+     * @param hasBuilder Is there a builder
+     * @return The interface
+     */
+    static InterfaceDef.InterfaceDefBuilder createWither(
+        String packageName,
+        ClassTypeDef recordType,
+        List<PropertyElement> properties,
+        List<PropertyElement> witherProperties,
         List<ParameterElement> parameters, boolean hasBuilder) {
         String localBinaryName = recordType.getName().startsWith(packageName + ".")
             ? recordType.getName().substring(packageName.isEmpty() ? 0 : packageName.length() + 1)
@@ -140,13 +219,23 @@ public final class WitherAnnotationVisitor implements TypeElementVisitor<Wither,
                 }
             }
         }
-        weaveWithMethodsInternal(recordType, properties, parameters, hasBuilder, wither);
+        weaveWithMethodsInternal(recordType, properties, witherProperties, parameters, hasBuilder, wither);
         return wither;
     }
 
     static void weaveWithMethodsInternal(
         ClassTypeDef recordType,
         List<PropertyElement> properties,
+        List<ParameterElement> parameters,
+        boolean hasBuilder,
+        ObjectDefBuilder<?> wither) {
+        weaveWithMethodsInternal(recordType, properties, properties, parameters, hasBuilder, wither);
+    }
+
+    static void weaveWithMethodsInternal(
+        ClassTypeDef recordType,
+        List<PropertyElement> properties,
+        List<PropertyElement> witherProperties,
         List<ParameterElement> parameters,
         boolean hasBuilder,
         ObjectDefBuilder<?> wither) {
@@ -169,7 +258,7 @@ public final class WitherAnnotationVisitor implements TypeElementVisitor<Wither,
             }
             propertyAccessMethods.put(beanProperty.getName(), methodDef);
         }
-        for (PropertyElement beanProperty : properties) {
+        for (PropertyElement beanProperty : witherProperties) {
             wither.addMethod(
                 withMethod(wither, parameters, beanProperty, recordType, propertyAccessMethods)
             );

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/WitherGenerator.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/WitherGenerator.java
@@ -44,6 +44,26 @@ public class WitherGenerator {
         ClassTypeDef recordType,
         List<PropertyElement> properties,
         List<ParameterElement> parameters, boolean hasBuilder) {
+        return createWither(packageName, recordType, properties, properties, parameters, hasBuilder);
+    }
+
+    /**
+     * Builds a wither interface for the given arguments.
+     * @param packageName The package name
+     * @param recordType The record type
+     * @param properties The properties
+     * @param witherProperties The subset of the properties that should get a `with` method
+     * @param parameters The parameters
+     * @param hasBuilder Is there a builder
+     * @return The interface
+     * @since 2.2
+     */
+    public static InterfaceDef.InterfaceDefBuilder createWither(
+        String packageName,
+        ClassTypeDef recordType,
+        List<PropertyElement> properties,
+        List<PropertyElement> witherProperties,
+        List<ParameterElement> parameters, boolean hasBuilder) {
         String localBinaryName = recordType.getName().startsWith(packageName + ".")
             ? recordType.getName().substring(packageName.isEmpty() ? 0 : packageName.length() + 1)
             : recordType.getName();
@@ -53,7 +73,7 @@ public class WitherGenerator {
         InterfaceDef.InterfaceDefBuilder wither = InterfaceDef.builder(witherClassName)
             .addModifiers(Modifier.PUBLIC);
 
-        WitherAnnotationVisitor.weaveWithMethodsInternal(recordType, properties, parameters, hasBuilder, wither);
+        WitherAnnotationVisitor.weaveWithMethodsInternal(recordType, properties, witherProperties, parameters, hasBuilder, wither);
         return wither;
     }
 
@@ -72,9 +92,31 @@ public class WitherGenerator {
         List<PropertyElement> properties,
         List<ParameterElement> parameters,
         boolean hasBuilder) {
+        weaveWithMethods(recordType, recordBuilder, properties, properties, parameters, hasBuilder);
+    }
+
+    /**
+     * Add with methods to an existing record type being generated.
+     *
+     * @param recordType       The record type
+     * @param recordBuilder    The record builder
+     * @param properties       The properties
+     * @param witherProperties The subset of the properties that should get a `with` method
+     * @param parameters       The parameters
+     * @param hasBuilder       Whether a builder is present
+     * @since 2.2
+     */
+    public static void weaveWithMethods(
+        ClassTypeDef recordType,
+        RecordDef.RecordDefBuilder recordBuilder,
+        List<PropertyElement> properties,
+        List<PropertyElement> witherProperties,
+        List<ParameterElement> parameters,
+        boolean hasBuilder) {
         WitherAnnotationVisitor.weaveWithMethodsInternal(
             recordType,
             properties,
+            witherProperties,
             parameters,
             hasBuilder,
             recordBuilder

--- a/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/WitherAnnotationVisitorSpec.groovy
+++ b/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/WitherAnnotationVisitorSpec.groovy
@@ -62,4 +62,91 @@ class WitherAnnotationVisitorSpec extends AbstractTypeElementSpec {
         withConsumer != null
         withConsumer.parameterTypes[0].typeName.contains("java.util.function.Consumer")
     }
+
+    void "component level @Wither only generates with methods for the annotated components"() {
+        given:
+        var classLoader = buildClassLoader("demo.test.Cat", """
+        package demo.test;
+        import io.micronaut.sourcegen.annotations.Wither;
+        public record Cat(
+            @Wither String name,
+            int age,
+            @Wither String color
+        ) implements CatWither {
+        }
+        """)
+
+        when:
+        def witherInterface = classLoader.loadClass('demo.test.CatWither')
+        def recordClass = classLoader.loadClass('demo.test.Cat')
+
+        then: "only the annotated components have a with method"
+        witherInterface.methods*.name.toSorted() == ['age', 'color', 'name', 'withColor', 'withName']
+
+        and: "accessors are declared for every component so the copy can be created"
+        witherInterface.getMethod("age").returnType == int.class
+
+        when:
+        def instance = recordClass.getConstructor(String, int, String).newInstance("Tom", 3, "grey")
+        def mutated = witherInterface.getMethod("withColor", String).invoke(instance, "black")
+
+        then:
+        mutated.name() == "Tom"
+        mutated.age() == 3
+        mutated.color() == "black"
+    }
+
+    void "component level @Wither restricts a type level @Wither"() {
+        given:
+        var classLoader = buildClassLoader("demo.test.Dog", """
+        package demo.test;
+        import io.micronaut.sourcegen.annotations.Wither;
+        @Wither
+        public record Dog(
+            @Wither String name,
+            int age
+        ) implements DogWither {
+        }
+        """)
+
+        when:
+        def witherInterface = classLoader.loadClass('demo.test.DogWither')
+
+        then:
+        witherInterface.methods*.name.toSorted() == ['age', 'name', 'withName']
+    }
+
+    void "type level @Wither still generates with methods for all the components"() {
+        given:
+        var classLoader = buildClassLoader("demo.test.Fish", """
+        package demo.test;
+        import io.micronaut.sourcegen.annotations.Wither;
+        @Wither
+        public record Fish(String name, int age) implements FishWither {
+        }
+        """)
+
+        when:
+        def witherInterface = classLoader.loadClass('demo.test.FishWither')
+
+        then:
+        witherInterface.methods*.name.toSorted() == ['age', 'name', 'withAge', 'withName']
+    }
+
+    void "records without any @Wither annotation do not generate a wither"() {
+        given:
+        var classLoader = buildClassLoader("demo.test.Bird", """
+        package demo.test;
+        import io.micronaut.sourcegen.annotations.Builder;
+        @Builder
+        public record Bird(String name, int age) {
+        }
+        """)
+
+        when:
+        classLoader.loadClass('demo.test.BirdWither')
+
+        then:
+        thrown(ClassNotFoundException)
+    }
 }

--- a/src/main/docs/guide/annotations/wither.adoc
+++ b/src/main/docs/guide/annotations/wither.adoc
@@ -29,3 +29,19 @@ Example of different ways to use the copy and builder methods:
 ----
 include::test-suite-java/src/test/java/io/micronaut/sourcegen/example/Walrus2Test.java[tags=test,indent=0]
 ----
+
+=== Selecting the properties
+
+The `@Wither` annotation can also be placed directly on the record components, in that case a `with` method is only generated for the annotated components. This is useful when only a subset of the record should be copy-modifiable. Placing `@Wither` on a component also works when the record itself is annotated with `@Wither`, the component level annotations then restrict the generation to the annotated components.
+
+[source,java]
+----
+include::test-suite-java/src/main/java/io/micronaut/sourcegen/example/Walrus4.java[tags=clazz,indent=0]
+----
+
+[source,java]
+----
+include::test-suite-java/src/test/java/io/micronaut/sourcegen/example/Walrus4Test.java[tags=test,indent=0]
+----
+
+NOTE: The generated interface still declares the accessors of every record component, because all of them are required to create the modified copy.

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/Walrus4.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/Walrus4.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import io.micronaut.sourcegen.annotations.Wither;
+
+//tag::clazz[]
+public record Walrus4(
+    @Wither
+    String name,
+    int age,
+    @Wither
+    byte[] chipInfo
+) implements Walrus4Wither {
+}
+//end::clazz[]

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/Walrus4Test.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/Walrus4Test.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Walrus4Test {
+
+//tag::test[]
+    @Test
+    public void test() {
+        Walrus4 walrus = new Walrus4("Abc", 123, new byte[]{56});
+
+        walrus = walrus.withName("Xyz").withChipInfo(new byte[]{1, 2, 3});
+
+        assertEquals("Xyz", walrus.name());
+        assertEquals(123, walrus.age());
+        assertArrayEquals(new byte[]{1, 2, 3}, walrus.chipInfo());
+    }
+
+    @Test
+    public void testOnlyAnnotatedComponentsHaveWithMethods() {
+        // `age` is not annotated with @Wither, so no `withAge` method is generated
+        assertTrue(Arrays.stream(Walrus4Wither.class.getMethods()).noneMatch(m -> m.getName().equals("withAge")));
+    }
+//end::test[]
+}


### PR DESCRIPTION
Fixes #493

`@Wither` could only be placed on a record type, which generated a `with` method for every component with no way to opt out. It can now also be placed directly on individual record components, so that `with` methods are only generated for the annotated ones — the same control Lombok's `@With` offers.

## Changes

- **`Wither`** now also targets `FIELD` and `PARAMETER`. A record component annotation ends up on the backing field and/or on the canonical constructor parameter depending on the annotation targets, so both placements are covered.
- **`WitherAnnotationVisitor`** collects the annotated components and restricts the generated `with` methods to them:
  - type level only → a `with` method per component (unchanged behaviour),
  - component level only → the wither interface is generated with `with` methods for the annotated components,
  - both → the component level annotations win and restrict the generation.

  Since a record whose *component* is annotated does not carry the stereotype itself, the visitor is declared as `TypeElementVisitor<Object, Object>` with `getSupportedAnnotationNames()` limited to `@Wither`, matching what `ObjectAnnotationVisitor` already does, and it returns early for anything that is neither an annotated type nor a record with annotated components.

  The component lookup uses `hasDeclaredStereotype`, because a type level `@Wither` is also visible in the annotation metadata of the record components and would otherwise match all of them.
- The generated interface still declares the accessors of **every** component, as all of them are required to create the modified copy.
- **`WitherGenerator`** gets `createWither(...)` / `weaveWithMethods(...)` overloads accepting the subset of the properties that should get a `with` method. The existing signatures delegate to them unchanged.

Generated output for the new example:

```java
public interface Walrus4Wither {
  String name();
  int age();
  byte[] chipInfo();

  default Walrus4 withName(String name) { ... }

  default Walrus4 withChipInfo(byte[] chipInfo) { ... }
}
```

## Docs and tests

- New `Walrus4` / `Walrus4Test` example pair and a "Selecting the properties" section in `wither.adoc`.
- Four new specs in `WitherAnnotationVisitorSpec` covering component level only, component level restricting a type level annotation, the unchanged type level behaviour, and that no wither is generated for a record without any `@Wither`.

## Verification

Run on JDK 25 (required by the build):

- `:sourcegen-generator:test` — 10/10
- `:test-suite-java:test` — 147/147
- `:test-suite-bytecode:test` — 128/128
- `:test-suite-kotlin:test` — 65/65
- `:sourcegen-generator:checkstyleMain`, `:sourcegen-annotations:checkstyleMain` — clean (the two remaining warnings are pre-existing, in generated module-info sources)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ly4buDHzBmnpaqJ15jMtzS)_