### PR TITLE
Support staged builders

### DIFF
--- a/sourcegen-annotations/src/main/java/io/micronaut/sourcegen/annotations/StagedBuilder.java
+++ b/sourcegen-annotations/src/main/java/io/micronaut/sourcegen/annotations/StagedBuilder.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.annotations;
+
+import io.micronaut.core.annotation.Introspected;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The staged builder annotation on a bean should create a builder that initializes the required
+ * properties in stages.
+ *
+ * <p>Every required property gets its own stage interface declaring the single method that assigns it
+ * and returns the next stage, so the build method is only reachable once all of them are assigned. A
+ * property is required unless the builder can leave it unassigned: it is nullable, it declares a
+ * default value with {@link io.micronaut.core.bind.annotation.Bindable#defaultValue()} or it
+ * accumulates values with {@link Singular}. Those are assigned in any order on the final stage.
+ *
+ * @author Denis Stepanov
+ * @since 2.2
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+public @interface StagedBuilder {
+
+    /**
+     * Define what annotations should be added to the generated builder. By default,
+     * the builder will have {@link io.micronaut.core.annotation.Introspected} annotation
+     * so that introspection can be created for it.
+     *
+     * @return Array of annotations to apply on the builder
+     */
+    Class<? extends Annotation>[] annotatedWith() default Introspected.class;
+
+}

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/SignatureWriterUtils.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/SignatureWriterUtils.java
@@ -183,7 +183,7 @@ final class SignatureWriterUtils {
                 } else {
                     TypeDef bound = typeVariable.bounds().get(0);
                     signatureWriter.visitClassBound();
-                    writeSignature(signatureWriter, objectDef, bound, false);
+                    writeSignature(signatureWriter, objectDef, methodDef, bound, false);
                 }
             } else {
                 if (isVariablePartOfTheDefinition(name, objectDef, methodDef)) {
@@ -203,7 +203,7 @@ final class SignatureWriterUtils {
             if (!parameterized.typeArguments().isEmpty()) {
                 for (TypeDef typeArgument : parameterized.typeArguments()) {
                     SignatureVisitor signatureVisitor = signatureWriter.visitTypeArgument(SignatureVisitor.INSTANCEOF);
-                    writeSignature(signatureVisitor, objectDef, typeArgument, false);
+                    writeSignature(signatureVisitor, objectDef, methodDef, typeArgument, false);
                 }
                 signatureWriter.visitEnd();
             }
@@ -221,9 +221,9 @@ final class SignatureWriterUtils {
         }
         if (typeDef instanceof TypeDef.Array array) {
             if (array.dimensions() == 1) {
-                writeSignature(signatureWriter.visitArrayType(), objectDef, array.componentType(), false);
+                writeSignature(signatureWriter.visitArrayType(), objectDef, methodDef, array.componentType(), false);
             } else {
-                writeSignature(signatureWriter.visitArrayType(), objectDef, new TypeDef.Array(
+                writeSignature(signatureWriter.visitArrayType(), objectDef, methodDef, new TypeDef.Array(
                     array.componentType(),
                     array.dimensions() - 1,
                     false

--- a/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
+++ b/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
@@ -94,7 +94,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
 
     private fun getAnnotationObjectBuilder(def: AnnotationObjectDef): TypeSpec.Builder {
         val builder = TypeSpec.annotationBuilder(def.simpleName)
-        builder.addModifiers(asKModifiers(def.modifiers))
+        builder.addModifiers(asKModifiers(stripStatic(def.modifiers)))
         def.javadoc.forEach(Consumer { format: String -> builder.addKdoc(format) })
         for (annotation in def.annotations) {
             builder.addAnnotation(asAnnotationSpec(annotation))
@@ -159,7 +159,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
         if (interfaceDef.annotations.any { it.type.name.equals(FunctionalInterface::class.qualifiedName) }) {
             interfaceBuilder.addModifiers(KModifier.FUN)
         }
-        interfaceBuilder.addModifiers(asKModifiers(interfaceDef.modifiers))
+        interfaceBuilder.addModifiers(asKModifiers(stripStatic(interfaceDef.modifiers)))
         interfaceDef.typeVariables.stream().map { tv: TypeDef.TypeVariable -> asTypeVariable(tv, interfaceDef) }
             .forEach { typeVariable: TypeVariableName -> interfaceBuilder.addTypeVariable(typeVariable) }
         interfaceDef.superinterfaces.stream().map { typeDef: TypeDef -> asType(typeDef, interfaceDef) }
@@ -232,7 +232,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
 
     private fun getClassBuilder(classDef: ClassDef): TypeSpec.Builder {
         val classBuilder = TypeSpec.classBuilder(classDef.simpleName)
-        classBuilder.addModifiers(asKModifiers(classDef.modifiers))
+        classBuilder.addModifiers(asKModifiers(stripStatic(classDef.modifiers)))
         classDef.typeVariables.stream().map { tv: TypeDef.TypeVariable -> asTypeVariable(tv, classDef) }
             .forEach { typeVariable: TypeVariableName -> classBuilder.addTypeVariable(typeVariable) }
         classDef.superinterfaces.stream().map { typeDef: TypeDef -> asType(typeDef, classDef) }
@@ -351,7 +351,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
     private fun getRecordBuilder(recordDef: RecordDef): TypeSpec.Builder {
         val classBuilder = TypeSpec.classBuilder(recordDef.simpleName)
         classBuilder.addModifiers(KModifier.DATA)
-        classBuilder.addModifiers(asKModifiers(recordDef.modifiers))
+        classBuilder.addModifiers(asKModifiers(stripStatic(recordDef.modifiers)))
         recordDef.typeVariables.stream().map { tv: TypeDef.TypeVariable -> asTypeVariable(tv, recordDef) }
             .forEach { typeVariable: TypeVariableName -> classBuilder.addTypeVariable(typeVariable) }
         recordDef.superinterfaces.stream().map { typeDef: TypeDef -> asType(typeDef, recordDef) }
@@ -427,7 +427,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
 
     private fun getEnumBuilder(enumDef: EnumDef): TypeSpec.Builder {
         val enumBuilder = TypeSpec.enumBuilder(enumDef.simpleName)
-        enumBuilder.addModifiers(asKModifiers(enumDef.modifiers))
+        enumBuilder.addModifiers(asKModifiers(stripStatic(enumDef.modifiers)))
         enumDef.superinterfaces.stream().map { typeDef: TypeDef -> asType(typeDef, enumDef) }
             .forEach { it: TypeName -> enumBuilder.addSuperinterface(it) }
         enumDef.javadoc.forEach(Consumer { format: String -> enumBuilder.addKdoc(format) })

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
@@ -77,6 +77,7 @@ import static io.micronaut.sourcegen.generator.visitors.Singulars.singularize;
 public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builder, Object> {
 
     private static final String BUILDER_ANNOTATED_WITH_MEMBER = "annotatedWith";
+    private static final String CLEAR_METHOD = "clear";
 
     private final Set<String> processed = new HashSet<>();
 
@@ -499,10 +500,10 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                     self.field(field).invoke("add", TypeDef.of(boolean.class), parameterDefs.get(0)),
                     returningExpressionProvider.apply(new BuilderGenerator.BuildContext(self, field))
                 )));
-            methods.add(singularMethod("clear" + StringUtils.capitalize(propertyName), returnType, overrides)
+            methods.add(singularMethod(CLEAR_METHOD + StringUtils.capitalize(propertyName), returnType, overrides)
                 .build((self, parameterDefs) -> StatementDef.multi(
                     self.field(field).isNonNull().doIf(
-                        self.field(field).invoke("clear", TypeDef.VOID)
+                        self.field(field).invoke(CLEAR_METHOD, TypeDef.VOID)
                     ),
                     returningExpressionProvider.apply(new BuilderGenerator.BuildContext(self, field))
                 )));
@@ -549,10 +550,10 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                     ),
                     returningExpressionProvider.apply(new BuilderGenerator.BuildContext(self, field))
                 )));
-            methods.add(singularMethod("clear" + StringUtils.capitalize(propertyName), returnType, overrides)
+            methods.add(singularMethod(CLEAR_METHOD + StringUtils.capitalize(propertyName), returnType, overrides)
                 .build((self, parameterDefs) -> StatementDef.multi(
                     self.field(field).isNonNull().doIf(
-                        self.field(field).invoke("clear", TypeDef.VOID)
+                        self.field(field).invoke(CLEAR_METHOD, TypeDef.VOID)
                     ),
                     returningExpressionProvider.apply(new BuilderGenerator.BuildContext(self, field))
                 )));
@@ -592,58 +593,77 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
             .overrides(overrides)
             .returns(buildType)
             .build((self, parameterDefs) -> {
-                List<PropertyElement> beanProperties = new ArrayList<>(properties);
-                List<ExpressionDef> values = new ArrayList<>();
-                for (ParameterElement parameter : constructorParameters) {
-                    PropertyElement propertyElement = beanProperties.stream().filter(p -> p.getName().equals(parameter.getName())).findFirst().orElse(null);
-                    if (propertyElement != null) {
-                        beanProperties.remove(propertyElement);
-                    }
-                    // We need to convert it for the correct type in Kotlin
-                    TypeDef fieldType = TypeDef.of(parameter.getType());
-                    TypeDef nullableFieldType = propertyElement == null ? fieldType.makeNullable() : builderFieldType(propertyElement);
-                    VariableDef.Field field = self.field(parameter.getName(), nullableFieldType);
-                    values.add(!fieldType.isPrimitive() ?
-                        valueExpression(propertyElement, field).cast(TypeDef.of(parameter.getType())) :
-                        field.ifNull(TypeDef.Primitive.defaultValue(parameter.getType().getName()), valueExpression(propertyElement, field)).cast(TypeDef.of(parameter.getType())));
-                }
-                if (beanProperties.isEmpty()) {
+                List<PropertyElement> remainingProperties = new ArrayList<>(properties);
+                List<ExpressionDef> values = constructorValues(self, remainingProperties, constructorParameters);
+                if (remainingProperties.isEmpty()) {
                     return buildType.instantiate(values).returning();
                 }
                 // Instantiate and set properties not assigned in the constructor
                 return buildType.instantiate(values).newLocal("instance", instanceVar ->
                     StatementDef.multi(statements -> {
-                        for (PropertyElement beanProperty : beanProperties) {
-                            Optional<MethodElement> writeMethod = beanProperty.getWriteMethod();
-                            if (writeMethod.isPresent()) {
-                                String propertyName = beanProperty.getSimpleName();
-                                TypeDef propertyType = TypeDef.of(beanProperty.getType());
-                                TypeDef fieldType = propertyType.makeNullable();
-                                if (fieldType.isNullable()) {
-                                    statements.add(
-                                        self.field(propertyName, fieldType).isNonNull().doIf(
-                                            instanceVar.invoke(
-                                                writeMethod.get(),
-                                                valueExpression(beanProperty, self.field(propertyName, fieldType))
-                                                    .cast(propertyType)
-                                            )
-                                        )
-                                    );
-                                } else {
-                                    statements.add(
-                                        instanceVar.invoke(
-                                            writeMethod.get(),
-                                            valueExpression(beanProperty, self.field(propertyName, fieldType))
-                                                .cast(propertyType)
-                                        )
-                                    );
-                                }
-                            }
+                        for (PropertyElement beanProperty : remainingProperties) {
+                            beanProperty.getWriteMethod().ifPresent(writeMethod ->
+                                statements.add(assignProperty(self, instanceVar, beanProperty, writeMethod))
+                            );
                         }
                         return instanceVar.returning();
                     })
                 );
             });
+    }
+
+    /**
+     * The arguments of the constructor call the build method makes, taken from the fields the builder
+     * keeps the corresponding properties in. The properties assigned this way are removed from the
+     * given properties, leaving the ones the build method has to assign through a setter.
+     *
+     * @param self                  The builder instance
+     * @param properties            The properties, which the assigned ones are removed from
+     * @param constructorParameters The constructor parameters
+     * @return The constructor arguments
+     */
+    private static List<ExpressionDef> constructorValues(VariableDef.This self,
+                                                         List<PropertyElement> properties,
+                                                         List<ParameterElement> constructorParameters) {
+        List<ExpressionDef> values = new ArrayList<>();
+        for (ParameterElement parameter : constructorParameters) {
+            PropertyElement propertyElement = properties.stream().filter(p -> p.getName().equals(parameter.getName())).findFirst().orElse(null);
+            if (propertyElement != null) {
+                properties.remove(propertyElement);
+            }
+            // We need to convert it for the correct type in Kotlin
+            TypeDef parameterType = TypeDef.of(parameter.getType());
+            TypeDef nullableFieldType = propertyElement == null ? parameterType.makeNullable() : builderFieldType(propertyElement);
+            VariableDef.Field field = self.field(parameter.getName(), nullableFieldType);
+            values.add(!parameterType.isPrimitive() ?
+                valueExpression(propertyElement, field).cast(parameterType) :
+                field.ifNull(TypeDef.Primitive.defaultValue(parameter.getType().getName()), valueExpression(propertyElement, field)).cast(parameterType));
+        }
+        return values;
+    }
+
+    /**
+     * Assign a property the constructor does not take through its setter. A property the builder can
+     * keep unassigned is only assigned when it was, so that the value the constructor gave it is kept.
+     *
+     * @param self         The builder instance
+     * @param instanceVar  The instance being built
+     * @param beanProperty The property to assign
+     * @param writeMethod  The setter of the property
+     * @return The statement assigning it
+     */
+    private static StatementDef assignProperty(VariableDef.This self,
+                                               VariableDef instanceVar,
+                                               PropertyElement beanProperty,
+                                               MethodElement writeMethod) {
+        TypeDef propertyType = TypeDef.of(beanProperty.getType());
+        TypeDef fieldType = propertyType.makeNullable();
+        VariableDef.Field field = self.field(beanProperty.getSimpleName(), fieldType);
+        StatementDef assign = instanceVar.invoke(
+            writeMethod,
+            valueExpression(beanProperty, field).cast(propertyType)
+        );
+        return fieldType.isNullable() ? field.isNonNull().doIf(assign) : assign;
     }
 
     private static ExpressionDef valueExpression(@Nullable PropertyElement propertyElement,

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
@@ -338,34 +338,64 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
             .build();
     }
 
-    static void createModifyPropertyMethod(ClassDefBuilder classDefBuilder,
-                                           ClassTypeDef builderType, PropertyElement beanProperty,
-                                           Function<BuilderGenerator.BuildContext, StatementDef> returningExpressionProvider) {
-        if (beanProperty.hasAnnotation(Singular.class)) {
-            createSingularPropertyMethods(classDefBuilder, beanProperty, returningExpressionProvider);
-        } else {
-            createDefaultModifyPropertyMethod(classDefBuilder, builderType, beanProperty, returningExpressionProvider);
-        }
+    static List<MethodDef> createModifyPropertyMethod(ClassDefBuilder classDefBuilder,
+                                                      ClassTypeDef builderType, PropertyElement beanProperty,
+                                                      Function<BuilderGenerator.BuildContext, StatementDef> returningExpressionProvider) {
+        return createModifyPropertyMethod(classDefBuilder, builderType, null, false, beanProperty, returningExpressionProvider);
     }
 
-    private static void createDefaultModifyPropertyMethod(ClassDefBuilder classDefBuilder,
-                                                          ClassTypeDef builderType, PropertyElement beanProperty,
-                                                          Function<BuilderGenerator.BuildContext, StatementDef> returningExpressionProvider) {
+    /**
+     * Add the methods that assign the given property to the builder being created.
+     *
+     * @param classDefBuilder             The builder being created
+     * @param builderType                 The type of the builder being created
+     * @param returnType                  The type the methods should declare as their return type, or
+     *                                    null to keep the default of returning the builder itself
+     * @param overrides                   True if the methods override the declarations of a supertype
+     * @param beanProperty                The property to assign
+     * @param returningExpressionProvider The return statement of the methods
+     * @return The methods that were added
+     */
+    static List<MethodDef> createModifyPropertyMethod(ClassDefBuilder classDefBuilder,
+                                                      ClassTypeDef builderType,
+                                                      @Nullable TypeDef returnType,
+                                                      boolean overrides,
+                                                      PropertyElement beanProperty,
+                                                      Function<BuilderGenerator.BuildContext, StatementDef> returningExpressionProvider) {
+        List<MethodDef> methods;
+        if (beanProperty.hasAnnotation(Singular.class)) {
+            methods = createSingularPropertyMethods(classDefBuilder, returnType, overrides, beanProperty, returningExpressionProvider);
+        } else {
+            methods = List.of(createDefaultModifyPropertyMethod(classDefBuilder, builderType, returnType, overrides, beanProperty, returningExpressionProvider));
+        }
+        methods.forEach(classDefBuilder::addMethod);
+        return methods;
+    }
+
+    private static MethodDef createDefaultModifyPropertyMethod(ClassDefBuilder classDefBuilder,
+                                                               ClassTypeDef builderType,
+                                                               @Nullable TypeDef returnType,
+                                                               boolean overrides,
+                                                               PropertyElement beanProperty,
+                                                               Function<BuilderGenerator.BuildContext, StatementDef> returningExpressionProvider) {
         TypeDef propertyTypeDef = TypeDef.of(beanProperty.getType());
         FieldDef field = createField(beanProperty, propertyTypeDef);
         classDefBuilder.addField(field);
         String propertyName = beanProperty.getSimpleName();
         MethodDef.MethodDefBuilder methodDef = MethodDef.builder(propertyName)
             .addModifiers(Modifier.PUBLIC)
+            .overrides(overrides)
             .addParameter(propertyName, propertyTypeDef);
-        if (builderType instanceof ClassTypeDef.Parameterized) {
+        if (returnType != null) {
+            methodDef.returns(returnType);
+        } else if (builderType instanceof ClassTypeDef.Parameterized) {
             methodDef.returns(builderType);
         }
-        classDefBuilder.addMethod(methodDef
+        return methodDef
             .build((self, parameterDefs) -> StatementDef.multi(
                 self.field(field).assign(parameterDefs.get(0)),
                 returningExpressionProvider.apply(new BuilderGenerator.BuildContext(self, field))
-            )));
+            ));
     }
 
     /**
@@ -428,9 +458,11 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
         return fieldDef.build();
     }
 
-    private static void createSingularPropertyMethods(ClassDef.ClassDefBuilder classBuilder,
-                                                      PropertyElement beanProperty,
-                                                      Function<BuilderGenerator.BuildContext, StatementDef> returningExpressionProvider) {
+    private static List<MethodDef> createSingularPropertyMethods(ClassDef.ClassDefBuilder classBuilder,
+                                                                 @Nullable TypeDef returnType,
+                                                                 boolean overrides,
+                                                                 PropertyElement beanProperty,
+                                                                 Function<BuilderGenerator.BuildContext, StatementDef> returningExpressionProvider) {
         String propertyName = beanProperty.getSimpleName();
         String singularName = beanProperty.stringValue(Singular.class).orElse(null);
         if (singularName == null) {
@@ -439,12 +471,12 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                 throw new IllegalStateException("Cannot determine singular name for property: " + beanProperty.getName() + ". Please specify a singular name: @Singular(\"singularName\")");
             }
         }
+        List<MethodDef> methods = new ArrayList<>(3);
         if (beanProperty.getType().isAssignable(Iterable.class)) {
             TypeDef singularTypeDef = singularElementType(beanProperty.getType());
             FieldDef field = createField(beanProperty, singularIterableFieldType(beanProperty.getType()));
             classBuilder.addField(field);
-            classBuilder.addMethod(MethodDef.builder(propertyName)
-                .addModifiers(Modifier.PUBLIC)
+            methods.add(singularMethod(propertyName, returnType, overrides)
                 .addParameter(propertyName, TypeDef.parameterized(Collection.class, singularTypeDef))
                 .build((self, parameterDefs) -> StatementDef.multi(
                     parameterDefs.get(0).isNull().doIf(
@@ -458,8 +490,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                     self.field(field).invoke("addAll", TypeDef.primitive(boolean.class), parameterDefs.get(0)),
                     returningExpressionProvider.apply(new BuilderGenerator.BuildContext(self, field))
                 )));
-            classBuilder.addMethod(MethodDef.builder(singularName)
-                .addModifiers(Modifier.PUBLIC)
+            methods.add(singularMethod(singularName, returnType, overrides)
                 .addParameter(singularName, singularTypeDef)
                 .build((self, parameterDefs) -> StatementDef.multi(
                     self.field(field).isNull().doIf(
@@ -468,8 +499,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                     self.field(field).invoke("add", TypeDef.of(boolean.class), parameterDefs.get(0)),
                     returningExpressionProvider.apply(new BuilderGenerator.BuildContext(self, field))
                 )));
-            classBuilder.addMethod(MethodDef.builder("clear" + StringUtils.capitalize(propertyName))
-                .addModifiers(Modifier.PUBLIC)
+            methods.add(singularMethod("clear" + StringUtils.capitalize(propertyName), returnType, overrides)
                 .build((self, parameterDefs) -> StatementDef.multi(
                     self.field(field).isNonNull().doIf(
                         self.field(field).invoke("clear", TypeDef.VOID)
@@ -482,8 +512,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
             ClassTypeDef fieldType = singularMapFieldType(beanProperty.getType());
             FieldDef field = createField(beanProperty, fieldType);
             classBuilder.addField(field);
-            classBuilder.addMethod(MethodDef.builder(propertyName)
-                .addModifiers(Modifier.PUBLIC)
+            methods.add(singularMethod(propertyName, returnType, overrides)
                 .addParameter(propertyName, TypeDef.parameterized(Map.class, keyType, valueType))
                 .build((self, parameterDefs) -> StatementDef.multi(
                     parameterDefs.get(0).isNull().doIf(
@@ -501,8 +530,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                     ),
                     returningExpressionProvider.apply(new BuilderGenerator.BuildContext(self, field))
                 )));
-            classBuilder.addMethod(MethodDef.builder(singularName)
-                .addModifiers(Modifier.PUBLIC)
+            methods.add(singularMethod(singularName, returnType, overrides)
                 .addParameter("key", keyType)
                 .addParameter("value", valueType)
                 .build((self, parameterDefs) -> StatementDef.multi(
@@ -521,8 +549,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                     ),
                     returningExpressionProvider.apply(new BuilderGenerator.BuildContext(self, field))
                 )));
-            classBuilder.addMethod(MethodDef.builder("clear" + StringUtils.capitalize(propertyName))
-                .addModifiers(Modifier.PUBLIC)
+            methods.add(singularMethod("clear" + StringUtils.capitalize(propertyName), returnType, overrides)
                 .build((self, parameterDefs) -> StatementDef.multi(
                     self.field(field).isNonNull().doIf(
                         self.field(field).invoke("clear", TypeDef.VOID)
@@ -532,11 +559,37 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
         } else {
             throw new IllegalStateException("Unsupported singular collection type [" + beanProperty.getType().getName() + "] for property: " + beanProperty.getName());
         }
+        return methods;
+    }
+
+    private static MethodDef.MethodDefBuilder singularMethod(String name, @Nullable TypeDef returnType, boolean overrides) {
+        MethodDef.MethodDefBuilder methodBuilder = MethodDef.builder(name).addModifiers(Modifier.PUBLIC).overrides(overrides);
+        if (returnType != null) {
+            methodBuilder.returns(returnType);
+        }
+        return methodBuilder;
     }
 
     static MethodDef createBuildMethod(ClassTypeDef buildType, List<PropertyElement> properties, List<ParameterElement> constructorParameters) {
+        return createBuildMethod(buildType, properties, constructorParameters, false);
+    }
+
+    /**
+     * Create the build method of a builder.
+     *
+     * @param buildType             The type being built
+     * @param properties            The properties
+     * @param constructorParameters The constructor parameters
+     * @param overrides             True if the method overrides the declaration of a supertype
+     * @return The build method
+     */
+    static MethodDef createBuildMethod(ClassTypeDef buildType,
+                                       List<PropertyElement> properties,
+                                       List<ParameterElement> constructorParameters,
+                                       boolean overrides) {
         return MethodDef.builder("build")
             .addModifiers(Modifier.PUBLIC)
+            .overrides(overrides)
             .returns(buildType)
             .build((self, parameterDefs) -> {
                 List<PropertyElement> beanProperties = new ArrayList<>(properties);

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
@@ -657,7 +657,7 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                                                PropertyElement beanProperty,
                                                MethodElement writeMethod) {
         TypeDef propertyType = TypeDef.of(beanProperty.getType());
-        TypeDef fieldType = propertyType.makeNullable();
+        TypeDef fieldType = builderFieldType(beanProperty);
         VariableDef.Field field = self.field(beanProperty.getSimpleName(), fieldType);
         StatementDef assign = instanceVar.invoke(
             writeMethod,

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/StagedBuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/StagedBuilderAnnotationVisitor.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.generator.visitors;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.ast.ParameterElement;
+import io.micronaut.inject.ast.PropertyElement;
+import io.micronaut.inject.processing.ProcessingException;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+import io.micronaut.sourcegen.annotations.Singular;
+import io.micronaut.sourcegen.annotations.StagedBuilder;
+import io.micronaut.sourcegen.generator.SourceGenerator;
+import io.micronaut.sourcegen.generator.SourceGenerators;
+import io.micronaut.sourcegen.model.ClassDef;
+import io.micronaut.sourcegen.model.ClassDef.ClassDefBuilder;
+import io.micronaut.sourcegen.model.ClassTypeDef;
+import io.micronaut.sourcegen.model.InterfaceDef;
+import io.micronaut.sourcegen.model.MethodDef;
+import io.micronaut.sourcegen.model.TypeDef;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import javax.lang.model.element.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static io.micronaut.sourcegen.generator.visitors.BuilderAnnotationVisitor.addAnnotations;
+import static io.micronaut.sourcegen.generator.visitors.BuilderAnnotationVisitor.createAllPropertiesConstructor;
+import static io.micronaut.sourcegen.generator.visitors.BuilderAnnotationVisitor.createBuildMethod;
+import static io.micronaut.sourcegen.generator.visitors.BuilderAnnotationVisitor.createModifyPropertyMethod;
+
+/**
+ * The visitor that is generating a staged builder.
+ *
+ * <p>The builder assigns the required properties in stages: each of them gets a stage interface
+ * declaring the single method that assigns it and returns the next stage, so that the build method is
+ * only reachable once every required property has been assigned. The properties that are not required
+ * are declared on the final stage and can be assigned in any order.
+ *
+ * @author Denis Stepanov
+ * @since 2.2
+ */
+@Internal
+public final class StagedBuilderAnnotationVisitor implements TypeElementVisitor<StagedBuilder, Object> {
+
+    private static final String BUILD_STAGE_SUFFIX = "BuildStage";
+    private static final String FINAL_STAGE_NAME = "BuildFinal";
+    private static final String BUILDER_SUFFIX = "StagedBuilder";
+    private static final String BUILDER_IMPLEMENTATION_NAME = "Builder";
+
+    private final Set<String> processed = new HashSet<>();
+
+    @Override
+    public @NonNull VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
+    }
+
+    @Override
+    public void start(VisitorContext visitorContext) {
+        processed.clear();
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationNames() {
+        return Set.of(StagedBuilder.class.getName());
+    }
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        if (processed.contains(element.getName())) {
+            return;
+        }
+        try {
+            List<PropertyElement> properties = element.getBeanProperties();
+            ParameterElement[] constructorElement = element.getPrimaryConstructor()
+                .filter(c -> !c.isPrivate())
+                .or(element::getDefaultConstructor)
+                .map(MethodElement::getParameters).orElse(ParameterElement.ZERO_PARAMETER_ELEMENTS);
+
+            ClassDef builderDef = createStagedBuilder(
+                element.getPackageName(),
+                ClassTypeDef.of(element),
+                element.getAnnotation(StagedBuilder.class),
+                properties,
+                Arrays.asList(constructorElement)
+            );
+
+            SourceGenerator sourceGenerator = SourceGenerators.findByLanguage(context.getLanguage()).orElse(null);
+            if (sourceGenerator == null) {
+                return;
+            }
+
+            processed.add(element.getName());
+            sourceGenerator.write(builderDef, context, element);
+        } catch (ProcessingException e) {
+            throw e;
+        } catch (Exception e) {
+            SourceGenerators.handleFatalException(
+                element,
+                StagedBuilder.class,
+                e,
+                (exception -> {
+                    processed.remove(element.getName());
+                    throw exception;
+                })
+            );
+        }
+    }
+
+    /**
+     * Create a staged builder for the given arguments.
+     *
+     * <p>The generated type only holds the stages and the builder method; the builder itself is the
+     * nested {@value #BUILDER_IMPLEMENTATION_NAME} class that implements every stage. A class cannot
+     * implement an interface nested in itself, so the two cannot be the same type.
+     *
+     * @param packageName            The package name
+     * @param elementType            The element type
+     * @param builderAnnotationValue The staged builder annotation value
+     * @param properties             The properties
+     * @param constructorParameters  The constructor parameters
+     * @return The class definition of the generated type
+     */
+    static @NonNull ClassDef createStagedBuilder(
+        String packageName,
+        @NonNull ClassTypeDef elementType,
+        @Nullable AnnotationValue<StagedBuilder> builderAnnotationValue,
+        @NonNull List<PropertyElement> properties,
+        @NonNull List<ParameterElement> constructorParameters) {
+
+        String stagedBuilderClassName = stagedBuilderClassName(packageName, elementType);
+        List<TypeDef.TypeVariable> typeArguments = typeArguments(elementType);
+        ClassTypeDef builderType = nestedType(stagedBuilderClassName, BUILDER_IMPLEMENTATION_NAME, typeArguments);
+
+        List<PropertyElement> requiredProperties = properties.stream().filter(StagedBuilderAnnotationVisitor::isRequired).toList();
+        List<PropertyElement> remainingProperties = properties.stream().filter(p -> !isRequired(p)).toList();
+
+        ClassTypeDef finalStageType = nestedType(stagedBuilderClassName, FINAL_STAGE_NAME, typeArguments);
+        List<ClassTypeDef> requiredStageTypes = requiredProperties.stream()
+            .map(property -> nestedType(stagedBuilderClassName, stageName(property), typeArguments))
+            .toList();
+
+        ClassDefBuilder builder = ClassDef.builder(BUILDER_IMPLEMENTATION_NAME)
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL);
+        for (TypeDef.TypeVariable typeArgument : typeArguments) {
+            builder.addTypeVariable(typeArgument);
+        }
+        if (builderAnnotationValue != null) {
+            addAnnotations(builder, builderAnnotationValue);
+        }
+        requiredStageTypes.forEach(builder::addSuperinterface);
+        builder.addSuperinterface(finalStageType);
+
+        List<InterfaceDef> stages = new ArrayList<>(requiredStageTypes.size() + 1);
+        for (int i = 0; i < requiredProperties.size(); i++) {
+            ClassTypeDef nextStageType = i + 1 < requiredStageTypes.size() ? requiredStageTypes.get(i + 1) : finalStageType;
+            List<MethodDef> methods = createModifyPropertyMethod(
+                builder,
+                builderType,
+                nextStageType,
+                true,
+                requiredProperties.get(i),
+                buildContext -> buildContext.aThis().returning()
+            );
+            stages.add(createStage(stageName(requiredProperties.get(i)), typeArguments, methods));
+        }
+
+        List<MethodDef> finalStageMethods = new ArrayList<>();
+        for (PropertyElement property : remainingProperties) {
+            finalStageMethods.addAll(createModifyPropertyMethod(
+                builder,
+                builderType,
+                finalStageType,
+                true,
+                property,
+                buildContext -> buildContext.aThis().returning()
+            ));
+        }
+        MethodDef buildMethod = createBuildMethod(elementType, properties, constructorParameters, true);
+        builder.addMethod(buildMethod);
+        finalStageMethods.add(buildMethod);
+        stages.add(createStage(FINAL_STAGE_NAME, typeArguments, finalStageMethods));
+
+        builder.addMethod(MethodDef.constructor().build());
+        if (!properties.isEmpty()) {
+            builder.addMethod(createAllPropertiesConstructor(properties));
+        }
+
+        ClassDefBuilder stagedBuilder = ClassDef.builder(stagedBuilderClassName)
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addMethod(createBuilderMethod(
+                builderType,
+                requiredStageTypes.isEmpty() ? finalStageType : requiredStageTypes.get(0)
+            ));
+        stages.forEach(stagedBuilder::addInnerType);
+        stagedBuilder.addInnerType(builder.build());
+        return stagedBuilder.build();
+    }
+
+    /**
+     * A property is required unless the builder can leave it unassigned: a nullable property keeps its
+     * null, a property with a default value keeps that value and a {@link Singular} property
+     * accumulates into an empty collection.
+     *
+     * @param property The property
+     * @return True if the property has to be assigned before the instance can be built
+     */
+    private static boolean isRequired(PropertyElement property) {
+        return !property.hasAnnotation(Singular.class)
+            && !property.isNullable()
+            && property.stringValue(Bindable.class, "defaultValue").isEmpty();
+    }
+
+    private static String stagedBuilderClassName(String packageName, ClassTypeDef elementType) {
+        String localBinaryName = elementType.getName().startsWith(packageName + ".")
+            ? elementType.getName().substring(packageName.isEmpty() ? 0 : packageName.length() + 1)
+            : elementType.getName();
+        String baseName = elementType.isInner() ? localBinaryName.replace("$", "") : elementType.getSimpleName();
+        String builderSimpleName = baseName + BUILDER_SUFFIX;
+        return packageName.isEmpty() ? builderSimpleName : packageName + "." + builderSimpleName;
+    }
+
+    private static List<TypeDef.TypeVariable> typeArguments(ClassTypeDef elementType) {
+        if (elementType instanceof ClassTypeDef.Parameterized parameterizedType) {
+            return parameterizedType.typeArguments()
+                .stream()
+                .filter(TypeDef.TypeVariable.class::isInstance)
+                .map(TypeDef.TypeVariable.class::cast)
+                .toList();
+        }
+        return List.of();
+    }
+
+    private static ClassTypeDef withTypeArguments(ClassTypeDef type, List<TypeDef.TypeVariable> typeArguments) {
+        if (typeArguments.isEmpty()) {
+            return type;
+        }
+        return TypeDef.parameterized(type, typeArguments.toArray(TypeDef[]::new));
+    }
+
+    private static String stageName(PropertyElement property) {
+        return StringUtils.capitalize(property.getSimpleName()) + BUILD_STAGE_SUFFIX;
+    }
+
+    /**
+     * The type of one of the generated nested types. The stages and the builder are nested, so that the
+     * stages of one builder cannot be confused with the identically named stages of another.
+     *
+     * @param stagedBuilderClassName The name of the generated type they are nested in
+     * @param nestedName             The simple name of the nested type
+     * @param typeArguments          The type arguments of the built type
+     * @return The type of the nested type
+     */
+    private static ClassTypeDef nestedType(String stagedBuilderClassName, String nestedName, List<TypeDef.TypeVariable> typeArguments) {
+        return withTypeArguments(ClassTypeDef.of(stagedBuilderClassName + "$" + nestedName, true), typeArguments);
+    }
+
+    /**
+     * Create the stage interface declaring the given methods of the builder.
+     *
+     * @param stageName     The simple name of the stage
+     * @param typeArguments The type arguments of the builder, which a nested interface cannot inherit
+     *                      and has to redeclare
+     * @param methods       The methods of the builder the stage exposes
+     * @return The stage definition
+     */
+    private static InterfaceDef createStage(String stageName,
+                                            List<TypeDef.TypeVariable> typeArguments,
+                                            List<MethodDef> methods) {
+        InterfaceDef.InterfaceDefBuilder stage = InterfaceDef.builder(stageName)
+            .addModifiers(Modifier.PUBLIC);
+        for (TypeDef.TypeVariable typeArgument : typeArguments) {
+            stage.addTypeVariable(typeArgument);
+        }
+        for (MethodDef method : methods) {
+            stage.addMethod(
+                MethodDef.builder(method.getName())
+                    .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+                    .addParameters(method.getParameters())
+                    .returns(method.getReturnType())
+                    .build()
+            );
+        }
+        return stage.build();
+    }
+
+    private static MethodDef createBuilderMethod(ClassTypeDef builderType, ClassTypeDef firstStageType) {
+        ClassTypeDef erasure = builderType instanceof ClassTypeDef.Parameterized parameterized ? parameterized.rawType() : builderType;
+        MethodDef.MethodDefBuilder methodBuilder = MethodDef.builder("builder")
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addStatement(erasure.instantiate().returning());
+        if (firstStageType instanceof ClassTypeDef.Parameterized parameterized) {
+            List<TypeDef> resolvedTypeDefs = new ArrayList<>();
+            for (TypeDef typeDef : parameterized.typeArguments()) {
+                if (typeDef instanceof TypeDef.TypeVariable variable) {
+                    TypeDef.TypeVariable newTypeDef = new TypeDef.TypeVariable(
+                        variable.name() + "S",
+                        variable.bounds(),
+                        variable.nullable()
+                    );
+                    resolvedTypeDefs.add(newTypeDef);
+                    methodBuilder.addTypeVariable(newTypeDef);
+                }
+            }
+            methodBuilder.returns(TypeDef.parameterized(
+                parameterized.rawType(),
+                resolvedTypeDefs.toArray(TypeDef[]::new)
+            ));
+        } else {
+            methodBuilder.returns(firstStageType);
+        }
+        return methodBuilder.build();
+    }
+
+}

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/StagedBuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/StagedBuilderAnnotationVisitor.java
@@ -45,6 +45,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import static io.micronaut.sourcegen.generator.visitors.BuilderAnnotationVisitor.addAnnotations;
 import static io.micronaut.sourcegen.generator.visitors.BuilderAnnotationVisitor.createAllPropertiesConstructor;
@@ -154,8 +155,9 @@ public final class StagedBuilderAnnotationVisitor implements TypeElementVisitor<
         List<TypeDef.TypeVariable> typeArguments = typeArguments(elementType);
         ClassTypeDef builderType = nestedType(stagedBuilderClassName, BUILDER_IMPLEMENTATION_NAME, typeArguments);
 
-        List<PropertyElement> requiredProperties = properties.stream().filter(StagedBuilderAnnotationVisitor::isRequired).toList();
-        List<PropertyElement> remainingProperties = properties.stream().filter(p -> !isRequired(p)).toList();
+        Predicate<PropertyElement> required = property -> isRequired(property, constructorParameters);
+        List<PropertyElement> requiredProperties = properties.stream().filter(required).toList();
+        List<PropertyElement> remainingProperties = properties.stream().filter(required.negate()).toList();
 
         ClassTypeDef finalStageType = nestedType(stagedBuilderClassName, FINAL_STAGE_NAME, typeArguments);
         List<ClassTypeDef> requiredStageTypes = requiredProperties.stream()
@@ -212,7 +214,8 @@ public final class StagedBuilderAnnotationVisitor implements TypeElementVisitor<
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
             .addMethod(createBuilderMethod(
                 builderType,
-                requiredStageTypes.isEmpty() ? finalStageType : requiredStageTypes.get(0)
+                requiredStageTypes.isEmpty() ? finalStageType : requiredStageTypes.get(0),
+                typeArguments
             ));
         stages.forEach(stagedBuilder::addInnerType);
         stagedBuilder.addInnerType(builder.build());
@@ -224,13 +227,23 @@ public final class StagedBuilderAnnotationVisitor implements TypeElementVisitor<
      * null, a property with a default value keeps that value and a {@link Singular} property
      * accumulates into an empty collection.
      *
-     * @param property The property
+     * <p>A property the build method cannot assign at all - it is neither a constructor parameter nor
+     * writable - is never required: making it a stage would demand a value that is then dropped.
+     *
+     * @param property              The property
+     * @param constructorParameters The constructor parameters
      * @return True if the property has to be assigned before the instance can be built
      */
-    private static boolean isRequired(PropertyElement property) {
+    private static boolean isRequired(PropertyElement property, List<ParameterElement> constructorParameters) {
         return !property.hasAnnotation(Singular.class)
             && !property.isNullable()
-            && property.stringValue(Bindable.class, "defaultValue").isEmpty();
+            && property.stringValue(Bindable.class, "defaultValue").isEmpty()
+            && isAssignable(property, constructorParameters);
+    }
+
+    private static boolean isAssignable(PropertyElement property, List<ParameterElement> constructorParameters) {
+        return property.getWriteMethod().isPresent()
+            || constructorParameters.stream().anyMatch(parameter -> parameter.getName().equals(property.getName()));
     }
 
     private static String stagedBuilderClassName(String packageName, ClassTypeDef elementType) {
@@ -306,30 +319,26 @@ public final class StagedBuilderAnnotationVisitor implements TypeElementVisitor<
         return stage.build();
     }
 
-    private static MethodDef createBuilderMethod(ClassTypeDef builderType, ClassTypeDef firstStageType) {
+    /**
+     * Create the method that starts the builder. The type it is declared on has no type variables of
+     * its own - only the stages and the builder nested in it do - so the method can declare the ones
+     * the built type declares, which keeps a bound that refers to them resolvable.
+     *
+     * @param builderType    The type of the builder to instantiate
+     * @param firstStageType The stage the method returns
+     * @param typeArguments  The type arguments of the built type
+     * @return The builder method
+     */
+    private static MethodDef createBuilderMethod(ClassTypeDef builderType,
+                                                 ClassTypeDef firstStageType,
+                                                 List<TypeDef.TypeVariable> typeArguments) {
         ClassTypeDef erasure = builderType instanceof ClassTypeDef.Parameterized parameterized ? parameterized.rawType() : builderType;
         MethodDef.MethodDefBuilder methodBuilder = MethodDef.builder("builder")
             .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-            .addStatement(erasure.instantiate().returning());
-        if (firstStageType instanceof ClassTypeDef.Parameterized parameterized) {
-            List<TypeDef> resolvedTypeDefs = new ArrayList<>();
-            for (TypeDef typeDef : parameterized.typeArguments()) {
-                if (typeDef instanceof TypeDef.TypeVariable variable) {
-                    TypeDef.TypeVariable newTypeDef = new TypeDef.TypeVariable(
-                        variable.name() + "S",
-                        variable.bounds(),
-                        variable.nullable()
-                    );
-                    resolvedTypeDefs.add(newTypeDef);
-                    methodBuilder.addTypeVariable(newTypeDef);
-                }
-            }
-            methodBuilder.returns(TypeDef.parameterized(
-                parameterized.rawType(),
-                resolvedTypeDefs.toArray(TypeDef[]::new)
-            ));
-        } else {
-            methodBuilder.returns(firstStageType);
+            .addStatement(erasure.instantiate().returning())
+            .returns(firstStageType);
+        for (TypeDef.TypeVariable typeArgument : typeArguments) {
+            methodBuilder.addTypeVariable(typeArgument);
         }
         return methodBuilder.build();
     }

--- a/sourcegen-generator/src/main/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
+++ b/sourcegen-generator/src/main/resources/META-INF/services/io.micronaut.inject.visitor.TypeElementVisitor
@@ -1,5 +1,6 @@
 io.micronaut.sourcegen.generator.visitors.BuilderAnnotationVisitor
 io.micronaut.sourcegen.generator.visitors.WitherAnnotationVisitor
 io.micronaut.sourcegen.generator.visitors.SuperBuilderAnnotationVisitor
+io.micronaut.sourcegen.generator.visitors.StagedBuilderAnnotationVisitor
 io.micronaut.sourcegen.generator.visitors.ObjectAnnotationVisitor
 io.micronaut.sourcegen.generator.visitors.DelegateAnnotationVisitor

--- a/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/StagedBuilderAnnotationVisitorSpec.groovy
+++ b/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/StagedBuilderAnnotationVisitorSpec.groovy
@@ -184,6 +184,76 @@ class StagedBuilderAnnotationVisitorSpec extends AbstractTypeElementSpec {
         walrus.age == 1
     }
 
+    void "test staged builder of a record with a bounded type variable"() {
+        given:
+        var classLoader = buildClassLoader("test.Walrus", """
+        package test;
+        import io.micronaut.sourcegen.annotations.StagedBuilder;
+
+        @StagedBuilder(annotatedWith = {})
+        public record Walrus<I extends CharSequence>(
+              I name,
+              int age
+        ) {
+        }
+        """)
+        var stagedBuilderClass = classLoader.loadClass("test.WalrusStagedBuilder")
+
+        expect: "the builder method keeps the type variable, so that its bound stays resolvable"
+        stagedBuilderClass.getMethod("builder").typeParameters.collect { it.name } == ["I"]
+
+        when:
+        var walrus = stagedBuilderClass.builder()
+                .name("Ted the Walrus")
+                .age(1)
+                .build()
+
+        then:
+        walrus.name == "Ted the Walrus"
+        walrus.age == 1
+    }
+
+    void "test a property the build method cannot assign is not a stage"() {
+        given:
+        var classLoader = buildClassLoader("test.Walrus", """
+        package test;
+        import io.micronaut.sourcegen.annotations.StagedBuilder;
+
+        @StagedBuilder(annotatedWith = {})
+        public class Walrus {
+
+            private String name;
+
+            public String getName() {
+                return name;
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public String getDescription() {
+                return name + " the Walrus";
+            }
+        }
+        """)
+        var stagedBuilderClass = classLoader.loadClass("test.WalrusStagedBuilder")
+        var nameStage = classLoader.loadClass("test.WalrusStagedBuilder\$NameBuildStage")
+
+        expect: "the read-only property is on the final stage, since a value given for it is dropped"
+        stagedBuilderClass.getMethod("builder").returnType == nameStage
+        nameStage.declaredMethods.collect { it.name } == ["name"]
+        classLoader.loadClass("test.WalrusStagedBuilder\$BuildFinal")
+                .declaredMethods.collect { it.name }.toSorted() == ["build", "description"]
+
+        when:
+        var walrus = stagedBuilderClass.builder().name("Ted").build()
+
+        then:
+        walrus.name == "Ted"
+        walrus.description == "Ted the Walrus"
+    }
+
     void "test the builder is introspected by default"() {
         given:
         var classLoader = buildClassLoader("test.Walrus", """

--- a/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/StagedBuilderAnnotationVisitorSpec.groovy
+++ b/sourcegen-generator/src/test/groovy/io/micronaut/sourcegen/generator/visitors/StagedBuilderAnnotationVisitorSpec.groovy
@@ -1,0 +1,205 @@
+package io.micronaut.sourcegen.generator.visitors
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+
+class StagedBuilderAnnotationVisitorSpec extends AbstractTypeElementSpec {
+
+    void "test staged builder assigns the required properties in stages"() {
+        given:
+        var classLoader = buildClassLoader("test.Walrus", """
+        package test;
+        import io.micronaut.sourcegen.annotations.StagedBuilder;
+
+        @StagedBuilder(annotatedWith = {})
+        public record Walrus(
+              String name,
+              int age
+        ) {
+        }
+        """)
+        var stagedBuilderClass = classLoader.loadClass("test.WalrusStagedBuilder")
+        var nameStage = classLoader.loadClass("test.WalrusStagedBuilder\$NameBuildStage")
+        var ageStage = classLoader.loadClass("test.WalrusStagedBuilder\$AgeBuildStage")
+        var buildFinal = classLoader.loadClass("test.WalrusStagedBuilder\$BuildFinal")
+
+        when:
+        var walrus = stagedBuilderClass.builder()
+                .name("Ted the Walrus")
+                .age(1)
+                .build()
+
+        then: "each stage assigns a single property and returns the next one"
+        stagedBuilderClass.getMethod("builder").returnType == nameStage
+        nameStage.getMethod("name", String).returnType == ageStage
+        ageStage.getMethod("age", int).returnType == buildFinal
+        buildFinal.getMethod("build").returnType == classLoader.loadClass("test.Walrus")
+
+        and:
+        walrus.name == "Ted the Walrus"
+        walrus.age == 1
+    }
+
+    void "test the properties the builder can leave unassigned are on the final stage"() {
+        given:
+        var classLoader = buildClassLoader("test.Walrus", """
+        package test;
+        import io.micronaut.core.annotation.Nullable;
+        import io.micronaut.core.bind.annotation.Bindable;
+        import io.micronaut.sourcegen.annotations.Singular;
+        import io.micronaut.sourcegen.annotations.StagedBuilder;
+
+        import java.util.List;
+
+        @StagedBuilder(annotatedWith = {})
+        public record Walrus(
+              String name,
+              @Nullable String nickname,
+              @Bindable(defaultValue = "1") int age,
+              @Singular List<String> friends
+        ) {
+        }
+        """)
+        var stagedBuilderClass = classLoader.loadClass("test.WalrusStagedBuilder")
+        var nameStage = classLoader.loadClass("test.WalrusStagedBuilder\$NameBuildStage")
+        var buildFinal = classLoader.loadClass("test.WalrusStagedBuilder\$BuildFinal")
+
+        expect: "the only required property is the one that has no value when unassigned"
+        stagedBuilderClass.getMethod("builder").returnType == nameStage
+        nameStage.declaredMethods.collect { it.name } == ["name"]
+        buildFinal.declaredMethods.collect { it.name }.toSorted() ==
+                ["age", "build", "clearFriends", "friend", "friends", "nickname"]
+
+        when: "the final stage is not assigned at all"
+        var walrus = stagedBuilderClass.builder().name("Ted the Walrus").build()
+
+        then:
+        walrus.nickname() == null
+        walrus.age() == 1
+        walrus.friends() == []
+
+        when: "the final stage is assigned in any order"
+        var assigned = stagedBuilderClass.builder()
+                .name("Ted the Walrus")
+                .friend("Sam")
+                .age(2)
+                .nickname("Ted")
+                .friend("Alex")
+                .build()
+
+        then:
+        assigned.nickname() == "Ted"
+        assigned.age() == 2
+        assigned.friends() == ["Sam", "Alex"]
+    }
+
+    void "test staged builder of a record without properties"() {
+        given:
+        var classLoader = buildClassLoader("test.Walrus", """
+        package test;
+        import io.micronaut.sourcegen.annotations.StagedBuilder;
+
+        @StagedBuilder(annotatedWith = {})
+        public record Walrus() {
+        }
+        """)
+        var stagedBuilderClass = classLoader.loadClass("test.WalrusStagedBuilder")
+
+        expect: "the build method is reachable right away"
+        stagedBuilderClass.getMethod("builder").returnType ==
+                classLoader.loadClass("test.WalrusStagedBuilder\$BuildFinal")
+        stagedBuilderClass.builder().build() != null
+    }
+
+    void "test staged builder of a bean assigning the properties through setters"() {
+        given:
+        var classLoader = buildClassLoader("test.Walrus", """
+        package test;
+        import io.micronaut.sourcegen.annotations.StagedBuilder;
+
+        @StagedBuilder(annotatedWith = {})
+        public class Walrus {
+
+            private String name;
+            private int age;
+
+            public String getName() {
+                return name;
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public int getAge() {
+                return age;
+            }
+
+            public void setAge(int age) {
+                this.age = age;
+            }
+        }
+        """)
+        var stagedBuilderClass = classLoader.loadClass("test.WalrusStagedBuilder")
+
+        when:
+        var walrus = stagedBuilderClass.builder()
+                .name("Ted the Walrus")
+                .age(1)
+                .build()
+
+        then:
+        walrus.name == "Ted the Walrus"
+        walrus.age == 1
+    }
+
+    void "test staged builder with generics adds type arguments to every stage"() {
+        given:
+        var classLoader = buildClassLoader("test.Walrus", """
+        package test;
+        import io.micronaut.sourcegen.annotations.StagedBuilder;
+
+        @StagedBuilder(annotatedWith = {})
+        public record Walrus<I>(
+              I name,
+              int age
+        ) {
+        }
+        """)
+        var stagedBuilderClass = classLoader.loadClass("test.WalrusStagedBuilder")
+        var nameStage = classLoader.loadClass("test.WalrusStagedBuilder\$NameBuildStage")
+        var builderClass = classLoader.loadClass("test.WalrusStagedBuilder\$Builder")
+
+        expect: "a nested interface cannot inherit the type variables of its enclosing type"
+        nameStage.typeParameters.collect { it.name } == ["I"]
+        builderClass.typeParameters.collect { it.name } == ["I"]
+
+        when:
+        var walrus = stagedBuilderClass.builder()
+                .name("Ted the Walrus")
+                .age(1)
+                .build()
+
+        then:
+        walrus.name == "Ted the Walrus"
+        walrus.age == 1
+    }
+
+    void "test the builder is introspected by default"() {
+        given:
+        var classLoader = buildClassLoader("test.Walrus", """
+        package test;
+        import io.micronaut.sourcegen.annotations.StagedBuilder;
+
+        @StagedBuilder
+        public record Walrus(
+              String name,
+              int age
+        ) {
+        }
+        """)
+
+        expect:
+        classLoader.loadClass("test.WalrusStagedBuilder\$Builder")
+                .getAnnotation(io.micronaut.core.annotation.Introspected) != null
+    }
+}

--- a/src/main/docs/guide/annotations.adoc
+++ b/src/main/docs/guide/annotations.adoc
@@ -10,6 +10,8 @@ dependency:micronaut-sourcegen-annotations[groupId=io.micronaut.sourcegen]
 
 | api:sourcegen.annotations.Builder[]
 | Create a builder of the annotated type.
+| api:sourcegen.annotations.StagedBuilder[]
+| Create a builder of the annotated type that assigns the required properties in stages.
 | api:sourcegen.annotations.Wither[]
 | Create an interface with copy style method and possible builder style methods for a record
 | api:sourcegen.annotations.ToString[]

--- a/src/main/docs/guide/annotations/stagedBuilder.adoc
+++ b/src/main/docs/guide/annotations/stagedBuilder.adoc
@@ -1,0 +1,51 @@
+The `@StagedBuilder` annotation generates a https://immutables.github.io/immutable.html#staged-builder[staged builder]: a builder that assigns the required properties in stages, so that forgetting one of them is a compilation error instead of a missing value at runtime.
+
+If you annotate a Java Record with `@StagedBuilder`, an `EmployeeStagedBuilder` class is generated at compilation-time.
+
+[source,java]
+----
+include::test-suite-java/src/main/java/io/micronaut/sourcegen/example/Employee.java[tags=clazz,indent=0]
+----
+
+Every required property gets its own stage interface, which declares the single method that assigns that property and returns the next stage. The last of them returns `BuildFinal`, the only stage that declares the `build` method:
+
+[source,java]
+----
+public final class EmployeeStagedBuilder {
+    public static NameBuildStage builder() { ... }
+
+    public interface NameBuildStage {
+        AgeBuildStage name(String name);
+    }
+    public interface AgeBuildStage {
+        EmployedBuildStage age(int age);
+    }
+    public interface EmployedBuildStage {
+        BuildFinal employed(boolean employed);
+    }
+    public interface BuildFinal {
+        BuildFinal nickname(String nickname);
+
+        Employee build();
+    }
+
+    public static final class Builder implements NameBuildStage, AgeBuildStage, EmployedBuildStage, BuildFinal { ... }
+}
+----
+
+You can use the builder to create an `Employee` instance, assigning the required properties in the order they are declared in:
+
+[source,java]
+----
+include::test-suite-java/src/test/java/io/micronaut/sourcegen/example/EmployeeStagedBuilderTest.java[tags=test,indent=0]
+----
+
+A property is required unless the builder can leave it unassigned, which is the case for:
+
+- a nullable property, which keeps its `null`
+- a property with a `@Bindable(defaultValue = "...")` default value, which keeps that value
+- a property annotated with api:sourcegen.annotations.Singular[], which accumulates into an empty collection
+
+Those properties are declared on the `BuildFinal` stage instead and can be assigned in any order, or not at all.
+
+NOTE: The stages add generated interfaces to the compilation output, which affects the class-loading time of an application using them extensively. Use `@Builder` when the compile-time safety is not worth that.

--- a/src/main/docs/guide/annotations/stagedBuilder.adoc
+++ b/src/main/docs/guide/annotations/stagedBuilder.adoc
@@ -1,11 +1,8 @@
 The `@StagedBuilder` annotation generates a https://immutables.github.io/immutable.html#staged-builder[staged builder]: a builder that assigns the required properties in stages, so that forgetting one of them is a compilation error instead of a missing value at runtime.
 
-If you annotate a Java Record with `@StagedBuilder`, an `EmployeeStagedBuilder` class is generated at compilation-time.
+If you annotate a type with `@StagedBuilder`, an `EmployeeStagedBuilder` class is generated at compilation-time.
 
-[source,java]
-----
-include::test-suite-java/src/main/java/io/micronaut/sourcegen/example/Employee.java[tags=clazz,indent=0]
-----
+snippet::io.micronaut.sourcegen.example.Employee[project-base="test-suite", source="main", tags="clazz", indent=0]
 
 Every required property gets its own stage interface, which declares the single method that assigns that property and returns the next stage. The last of them returns `BuildFinal`, the only stage that declares the `build` method:
 
@@ -35,10 +32,7 @@ public final class EmployeeStagedBuilder {
 
 You can use the builder to create an `Employee` instance, assigning the required properties in the order they are declared in:
 
-[source,java]
-----
-include::test-suite-java/src/test/java/io/micronaut/sourcegen/example/EmployeeStagedBuilderTest.java[tags=test,indent=0]
-----
+snippet::io.micronaut.sourcegen.example.EmployeeStagedBuilderTest[project-base="test-suite", tags="test", indent=0]
 
 A property is required unless the builder can leave it unassigned, which is the case for:
 

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -6,6 +6,7 @@ generators: Writing a Source Generator
 annotations:
   title: Annotations
   builder: Builder
+  stagedBuilder: Staged Builder
   wither: Wither
   superBuilder: Super Builder
   singular: Singular

--- a/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/Cargo.java
+++ b/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/Cargo.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import io.micronaut.sourcegen.annotations.StagedBuilder;
+
+@StagedBuilder
+public record Cargo<T>(T content, int weight) {
+}

--- a/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/Employee.java
+++ b/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/Employee.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+
+//tag::clazz[]
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.sourcegen.annotations.StagedBuilder;
+
+@StagedBuilder
+public record Employee(String name, int age, boolean employed, @Nullable String nickname) {
+}
+//end::clazz[]

--- a/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/Project.java
+++ b/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/Project.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.sourcegen.annotations.Singular;
+import io.micronaut.sourcegen.annotations.StagedBuilder;
+
+import java.util.List;
+
+@StagedBuilder
+public record Project(
+    String title,
+    @Bindable(defaultValue = "10")
+    int priority,
+    @Singular List<String> tasks) {
+}

--- a/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/SingularBean.java
+++ b/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/SingularBean.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import io.micronaut.sourcegen.annotations.Builder;
+import io.micronaut.sourcegen.annotations.Singular;
+
+import java.util.List;
+
+/**
+ * A bean whose singular property the build method has to assign through its setter, rather than
+ * through a constructor.
+ */
+@Builder
+public class SingularBean {
+
+    @Singular
+    private List<String> friends;
+
+    public List<String> getFriends() {
+        return friends;
+    }
+
+    public void setFriends(List<String> friends) {
+        this.friends = friends;
+    }
+}

--- a/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/CargoStagedBuilderTest.java
+++ b/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/CargoStagedBuilderTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2003-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CargoStagedBuilderTest {
+
+    @Test
+    public void buildsGenericCargo() {
+        Cargo<String> cargo = CargoStagedBuilder.<String>builder()
+            .content("Walrus")
+            .weight(120)
+            .build();
+        assertEquals("Walrus", cargo.content());
+        assertEquals(120, cargo.weight());
+    }
+}

--- a/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/EmployeeStagedBuilderTest.java
+++ b/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/EmployeeStagedBuilderTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2003-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import io.micronaut.core.beans.BeanIntrospection;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EmployeeStagedBuilderTest {
+
+//tag::test[]
+    @Test
+    public void buildsEmployee() {
+        var employee = EmployeeStagedBuilder.builder()
+            .name("Billy Bounce")
+            .age(33)
+            .employed(false)
+            .nickname("Billy")
+            .build();
+        assertEquals("Billy Bounce", employee.name());
+        assertEquals(33, employee.age());
+        assertEquals(false, employee.employed());
+        assertEquals("Billy", employee.nickname());
+    }
+//end::test[]
+
+    @Test
+    public void buildsEmployeeWithoutTheOptionalProperties() {
+        var employee = EmployeeStagedBuilder.builder()
+            .name("Billy Bounce")
+            .age(33)
+            .employed(true)
+            .build();
+        assertEquals("Billy Bounce", employee.name());
+        assertNull(employee.nickname());
+    }
+
+    @Test
+    public void requiredPropertiesAreAssignedInStages() {
+        // Every stage only exposes the property it assigns, so the build method
+        // is not reachable until all of the required ones are assigned
+        EmployeeStagedBuilder.NameBuildStage nameStage = EmployeeStagedBuilder.builder();
+        EmployeeStagedBuilder.AgeBuildStage ageStage = nameStage.name("Billy Bounce");
+        EmployeeStagedBuilder.EmployedBuildStage employedStage = ageStage.age(33);
+        EmployeeStagedBuilder.BuildFinal buildFinal = employedStage.employed(true);
+
+        assertEquals(List.of("name"), methodNames(EmployeeStagedBuilder.NameBuildStage.class));
+        assertEquals(List.of("age"), methodNames(EmployeeStagedBuilder.AgeBuildStage.class));
+        assertEquals(List.of("employed"), methodNames(EmployeeStagedBuilder.EmployedBuildStage.class));
+        // The nullable property can be assigned in any order, on the final stage
+        assertEquals(List.of("build", "nickname"), methodNames(EmployeeStagedBuilder.BuildFinal.class));
+
+        assertEquals("Billy Bounce", buildFinal.build().name());
+    }
+
+    @Test
+    public void theBuilderMethodReturnsTheFirstStage() throws NoSuchMethodException {
+        assertEquals(
+            EmployeeStagedBuilder.NameBuildStage.class,
+            EmployeeStagedBuilder.class.getMethod("builder").getReturnType()
+        );
+        assertThrows(
+            NoSuchMethodException.class,
+            () -> EmployeeStagedBuilder.NameBuildStage.class.getMethod("nickname", String.class)
+        );
+    }
+
+    @Test
+    public void employeeIntrospection() {
+        var introspection = BeanIntrospection.getIntrospection(EmployeeStagedBuilder.Builder.class);
+        assertNotNull(introspection);
+        assertEquals(0, introspection.getBeanProperties().size());
+        assertEquals(4, introspection.getConstructorArguments().length);
+    }
+
+    private static List<String> methodNames(Class<?> stage) {
+        return java.util.Arrays.stream(stage.getDeclaredMethods()).map(java.lang.reflect.Method::getName).sorted().toList();
+    }
+}

--- a/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/ProjectStagedBuilderTest.java
+++ b/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/ProjectStagedBuilderTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2003-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ProjectStagedBuilderTest {
+
+    @Test
+    public void buildsProjectWithTheDefaultsOfTheFinalStage() {
+        var project = ProjectStagedBuilder.builder()
+            .title("Micronaut SourceGen")
+            .build();
+        assertEquals("Micronaut SourceGen", project.title());
+        assertEquals(10, project.priority());
+        assertEquals(List.of(), project.tasks());
+    }
+
+    @Test
+    public void buildsProjectAssigningTheFinalStageInAnyOrder() {
+        var project = ProjectStagedBuilder.builder()
+            .title("Micronaut SourceGen")
+            .task("Write the code")
+            .priority(1)
+            .task("Write the tests")
+            .build();
+        assertEquals(1, project.priority());
+        assertEquals(List.of("Write the code", "Write the tests"), project.tasks());
+    }
+}

--- a/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/SingularBeanTest.java
+++ b/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/SingularBeanTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2003-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SingularBeanTest {
+
+    @Test
+    public void assignsTheSingularPropertyThroughTheSetter() {
+        // The builder accumulates a singular property into an ArrayList field, so the build method
+        // has to read the field by that type, not by the type of the property
+        var bean = SingularBeanBuilder.builder()
+            .friend("Sam")
+            .friend("Alex")
+            .build();
+        assertEquals(List.of("Sam", "Alex"), bean.getFriends());
+    }
+}

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/Cargo.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/Cargo.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import io.micronaut.sourcegen.annotations.StagedBuilder;
+
+@StagedBuilder
+public record Cargo<T>(T content, int weight) {
+}

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/Employee.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/Employee.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+
+//tag::clazz[]
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.sourcegen.annotations.StagedBuilder;
+
+@StagedBuilder
+public record Employee(String name, int age, boolean employed, @Nullable String nickname) {
+}
+//end::clazz[]

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/Project.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/Project.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.sourcegen.annotations.Singular;
+import io.micronaut.sourcegen.annotations.StagedBuilder;
+
+import java.util.List;
+
+@StagedBuilder
+public record Project(
+    String title,
+    @Bindable(defaultValue = "10")
+    int priority,
+    @Singular List<String> tasks) {
+}

--- a/test-suite-java/src/main/java/io/micronaut/sourcegen/example/SingularBean.java
+++ b/test-suite-java/src/main/java/io/micronaut/sourcegen/example/SingularBean.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import io.micronaut.sourcegen.annotations.Builder;
+import io.micronaut.sourcegen.annotations.Singular;
+
+import java.util.List;
+
+/**
+ * A bean whose singular property the build method has to assign through its setter, rather than
+ * through a constructor.
+ */
+@Builder
+public class SingularBean {
+
+    @Singular
+    private List<String> friends;
+
+    public List<String> getFriends() {
+        return friends;
+    }
+
+    public void setFriends(List<String> friends) {
+        this.friends = friends;
+    }
+}

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/CargoStagedBuilderTest.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/CargoStagedBuilderTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2003-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CargoStagedBuilderTest {
+
+    @Test
+    public void buildsGenericCargo() {
+        Cargo<String> cargo = CargoStagedBuilder.<String>builder()
+            .content("Walrus")
+            .weight(120)
+            .build();
+        assertEquals("Walrus", cargo.content());
+        assertEquals(120, cargo.weight());
+    }
+}

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/EmployeeStagedBuilderTest.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/EmployeeStagedBuilderTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2003-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import io.micronaut.core.beans.BeanIntrospection;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EmployeeStagedBuilderTest {
+
+//tag::test[]
+    @Test
+    public void buildsEmployee() {
+        var employee = EmployeeStagedBuilder.builder()
+            .name("Billy Bounce")
+            .age(33)
+            .employed(false)
+            .nickname("Billy")
+            .build();
+        assertEquals("Billy Bounce", employee.name());
+        assertEquals(33, employee.age());
+        assertEquals(false, employee.employed());
+        assertEquals("Billy", employee.nickname());
+    }
+//end::test[]
+
+    @Test
+    public void buildsEmployeeWithoutTheOptionalProperties() {
+        var employee = EmployeeStagedBuilder.builder()
+            .name("Billy Bounce")
+            .age(33)
+            .employed(true)
+            .build();
+        assertEquals("Billy Bounce", employee.name());
+        assertNull(employee.nickname());
+    }
+
+    @Test
+    public void requiredPropertiesAreAssignedInStages() {
+        // Every stage only exposes the property it assigns, so the build method
+        // is not reachable until all of the required ones are assigned
+        EmployeeStagedBuilder.NameBuildStage nameStage = EmployeeStagedBuilder.builder();
+        EmployeeStagedBuilder.AgeBuildStage ageStage = nameStage.name("Billy Bounce");
+        EmployeeStagedBuilder.EmployedBuildStage employedStage = ageStage.age(33);
+        EmployeeStagedBuilder.BuildFinal buildFinal = employedStage.employed(true);
+
+        assertEquals(List.of("name"), methodNames(EmployeeStagedBuilder.NameBuildStage.class));
+        assertEquals(List.of("age"), methodNames(EmployeeStagedBuilder.AgeBuildStage.class));
+        assertEquals(List.of("employed"), methodNames(EmployeeStagedBuilder.EmployedBuildStage.class));
+        // The nullable property can be assigned in any order, on the final stage
+        assertEquals(List.of("build", "nickname"), methodNames(EmployeeStagedBuilder.BuildFinal.class));
+
+        assertEquals("Billy Bounce", buildFinal.build().name());
+    }
+
+    @Test
+    public void theBuilderMethodReturnsTheFirstStage() throws NoSuchMethodException {
+        assertEquals(
+            EmployeeStagedBuilder.NameBuildStage.class,
+            EmployeeStagedBuilder.class.getMethod("builder").getReturnType()
+        );
+        assertThrows(
+            NoSuchMethodException.class,
+            () -> EmployeeStagedBuilder.NameBuildStage.class.getMethod("nickname", String.class)
+        );
+    }
+
+    @Test
+    public void employeeIntrospection() {
+        var introspection = BeanIntrospection.getIntrospection(EmployeeStagedBuilder.Builder.class);
+        assertNotNull(introspection);
+        assertEquals(0, introspection.getBeanProperties().size());
+        assertEquals(4, introspection.getConstructorArguments().length);
+    }
+
+    private static List<String> methodNames(Class<?> stage) {
+        return java.util.Arrays.stream(stage.getDeclaredMethods()).map(java.lang.reflect.Method::getName).sorted().toList();
+    }
+}

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/ProjectStagedBuilderTest.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/ProjectStagedBuilderTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2003-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ProjectStagedBuilderTest {
+
+    @Test
+    public void buildsProjectWithTheDefaultsOfTheFinalStage() {
+        var project = ProjectStagedBuilder.builder()
+            .title("Micronaut SourceGen")
+            .build();
+        assertEquals("Micronaut SourceGen", project.title());
+        assertEquals(10, project.priority());
+        assertEquals(List.of(), project.tasks());
+    }
+
+    @Test
+    public void buildsProjectAssigningTheFinalStageInAnyOrder() {
+        var project = ProjectStagedBuilder.builder()
+            .title("Micronaut SourceGen")
+            .task("Write the code")
+            .priority(1)
+            .task("Write the tests")
+            .build();
+        assertEquals(1, project.priority());
+        assertEquals(List.of("Write the code", "Write the tests"), project.tasks());
+    }
+}

--- a/test-suite-java/src/test/java/io/micronaut/sourcegen/example/SingularBeanTest.java
+++ b/test-suite-java/src/test/java/io/micronaut/sourcegen/example/SingularBeanTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2003-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SingularBeanTest {
+
+    @Test
+    public void assignsTheSingularPropertyThroughTheSetter() {
+        // The builder accumulates a singular property into an ArrayList field, so the build method
+        // has to read the field by that type, not by the type of the property
+        var bean = SingularBeanBuilder.builder()
+            .friend("Sam")
+            .friend("Alex")
+            .build();
+        assertEquals(List.of("Sam", "Alex"), bean.getFriends());
+    }
+}

--- a/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/Employee.kt
+++ b/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/Employee.kt
@@ -15,8 +15,9 @@
  */
 package io.micronaut.sourcegen.example
 
-import io.micronaut.core.annotation.Nullable
+//tag::clazz[]
 import io.micronaut.sourcegen.annotations.StagedBuilder
 
 @StagedBuilder
-data class Employee(val name: String, val age: Int, val employed: Boolean, @Nullable val nickname: String?)
+data class Employee(val name: String, val age: Int, val employed: Boolean, val nickname: String?)
+//end::clazz[]

--- a/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/Employee.kt
+++ b/test-suite-kotlin/src/main/kotlin/io/micronaut/sourcegen/example/Employee.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example
+
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.sourcegen.annotations.StagedBuilder
+
+@StagedBuilder
+data class Employee(val name: String, val age: Int, val employed: Boolean, @Nullable val nickname: String?)

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/sourcegen/example/EmployeeStagedBuilderTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/sourcegen/example/EmployeeStagedBuilderTest.kt
@@ -1,0 +1,33 @@
+package io.micronaut.sourcegen.example
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class EmployeeStagedBuilderTest {
+    @Test
+    fun buildsEmployee() {
+        val employee: Employee = EmployeeStagedBuilder.builder()
+            .name("Billy Bounce")
+            .age(33)
+            .employed(false)
+            .nickname("Billy")
+            .build()
+        assertEquals("Billy Bounce", employee.name)
+        assertEquals(33, employee.age)
+        assertEquals(false, employee.employed)
+        assertEquals("Billy", employee.nickname)
+    }
+
+    @Test
+    fun buildsEmployeeWithoutTheOptionalProperties() {
+        val nameStage: EmployeeStagedBuilder.NameBuildStage = EmployeeStagedBuilder.builder()
+        val ageStage: EmployeeStagedBuilder.AgeBuildStage = nameStage.name("Billy Bounce")
+        val employedStage: EmployeeStagedBuilder.EmployedBuildStage = ageStage.age(33)
+        val buildFinal: EmployeeStagedBuilder.BuildFinal = employedStage.employed(true)
+
+        val employee: Employee = buildFinal.build()
+        assertEquals("Billy Bounce", employee.name)
+        assertNull(employee.nickname)
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/sourcegen/example/EmployeeStagedBuilderTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/sourcegen/example/EmployeeStagedBuilderTest.kt
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 class EmployeeStagedBuilderTest {
+
+//tag::test[]
     @Test
     fun buildsEmployee() {
         val employee: Employee = EmployeeStagedBuilder.builder()
@@ -18,6 +20,7 @@ class EmployeeStagedBuilderTest {
         assertEquals(false, employee.employed)
         assertEquals("Billy", employee.nickname)
     }
+//end::test[]
 
     @Test
     fun buildsEmployeeWithoutTheOptionalProperties() {


### PR DESCRIPTION
Adds `@StagedBuilder`, which generates a builder that assigns the required properties in stages, as described in https://immutables.github.io/immutable.html#staged-builder

Fixes #198

## The generated shape

For:

```java
@StagedBuilder
public record Employee(String name, int age, boolean employed, @Nullable String nickname) {
}
```

the generated `EmployeeStagedBuilder` is:

```java
public final class EmployeeStagedBuilder {
    public static NameBuildStage builder() { ... }

    public interface NameBuildStage {
        AgeBuildStage name(String name);
    }
    public interface AgeBuildStage {
        EmployedBuildStage age(int age);
    }
    public interface EmployedBuildStage {
        BuildFinal employed(boolean employed);
    }
    public interface BuildFinal {
        BuildFinal nickname(String nickname);

        Employee build();
    }

    public static final class Builder implements NameBuildStage, AgeBuildStage, EmployedBuildStage, BuildFinal { ... }
}
```

Every required property gets a stage interface declaring the single method that assigns it and returns the next stage, so `build()` is only reachable once all of them are assigned:

```java
var employee = EmployeeStagedBuilder.builder()
    .name("Billy Bounce")
    .age(33)
    .employed(false)
    .nickname("Billy")
    .build();
```

A property is required unless the builder can leave it unassigned with a defined value: it is nullable, it declares a `@Bindable(defaultValue = "...")` default value, or it accumulates values with `@Singular`. Those are declared on `BuildFinal` and can be assigned in any order, or not at all.

The generated type holds the stages and the `builder()` method, and the builder itself is the nested `Builder` class implementing every stage — a class cannot implement an interface nested in itself (javac reports `cyclic inheritance`), so the two cannot be the same type. This is also the shape Immutables generates. Generic types are supported: a nested interface cannot inherit the type variables of its enclosing type, so every stage redeclares them.

## Backend fixes needed for this shape

- `KotlinPoetSourceGenerator` rejected the `static` modifier of a nested type definition (`Not supported modifier: static`), which a Kotlin nested type is by default. It is now stripped from type modifiers, the way it already was for methods and fields.
- The bytecode writer erased a method type variable used as a type argument — `builder()` was written with the signature `()LContentBuildStage<Object>;` instead of `()LContentBuildStage<TS>;` — because the recursive calls of the signature writer did not pass the method being written. Covered by the generic `Cargo` test in `test-suite-bytecode`, which does not compile without the fix.

## Refactoring

`BuilderAnnotationVisitor` now returns the methods it creates for a property and accepts an explicit return type and an override flag, so the staged builder can reuse the property, singular, constructor and build method generation. `@Builder` and `@SuperBuilder` output is unchanged.

## Tests and docs

- `Employee` (required + nullable), `Project` (`@Bindable` default + `@Singular`) and `Cargo` (generic) models with tests in `test-suite-java` and `test-suite-bytecode`, and a data class with a test in `test-suite-kotlin`.
- New `Staged Builder` guide page, plus the annotations table and `toc.yml`.

Verified with `./gradlew test checkstyleMain spotlessCheck docs` and `./gradlew :test-suite-java:test :test-suite-bytecode:test :test-suite-kotlin:test --rerun-tasks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FgEP1bRJtu22ipXnFQbLtQ


---
_Generated by [Claude Code](https://claude.ai/code/session_01FgEP1bRJtu22ipXnFQbLtQ)_