### PR TITLE
Fix source generation metadata edge cases

### DIFF
--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
@@ -519,13 +519,42 @@ public final class ByteCodeWriter {
      * definition - the class is not loadable, so nothing else can answer for it.
      *
      * @param objectDef The definition of the annotation type
-     * @return Its targets, or empty when it declares none
+     * @return Its targets, empty when it declares no {@link Target} or nothing in the member is
+     * recognisable, and an empty set when it explicitly targets nothing
      */
     private static Optional<Set<ElementType>> declaredTargetsOf(ObjectDef objectDef) {
         return objectDef.getAnnotations().stream()
             .filter(a -> a.getType().getName().equals(Target.class.getName()))
             .findFirst()
-            .map(a -> toElementTypes(a.getValues().get(AnnotationMetadata.VALUE_MEMBER)));
+            .flatMap(a -> declaredTargets(a.getValues().get(AnnotationMetadata.VALUE_MEMBER)));
+    }
+
+    /**
+     * The targets a {@link Target} member names. An explicitly empty member targets nothing and drops the
+     * annotation from every context, but nothing recognisable in a member that is not empty leaves the
+     * annotation untargeted rather than targeting nothing at all, which would drop it from every member a
+     * record component expands to.
+     *
+     * @param value The member of the {@link Target}
+     * @return The targets it names, or empty when it names none that can be recognised
+     */
+    private static Optional<Set<ElementType>> declaredTargets(@Nullable Object value) {
+        if (isEmptyMember(value)) {
+            return Optional.of(Set.of());
+        }
+        Set<ElementType> targets = toElementTypes(value);
+        return targets.isEmpty() ? Optional.empty() : Optional.of(targets);
+    }
+
+    /**
+     * @param value An annotation member
+     * @return True when the member is an array that holds nothing
+     */
+    private static boolean isEmptyMember(@Nullable Object value) {
+        if (value instanceof Collection<?> collection) {
+            return collection.isEmpty();
+        }
+        return value instanceof Object[] array && array.length == 0;
     }
 
     private static Optional<RetentionPolicy> declaredRetentionOf(ObjectDef objectDef) {
@@ -793,6 +822,19 @@ public final class ByteCodeWriter {
         writeInnerTypes(classVisitor, thisType, thisDef, outerType == null);
     }
 
+    /**
+     * The {@code InnerClasses} entries of the member types of a definition, and, when the definition hosts
+     * the nest, the {@code NestMembers} entry of every one of them. The nest is flat - a member of a member
+     * belongs to the same host - while the entries are not: each one names the type it is declared in, so
+     * both are written by descending through the levels rather than only over the direct members. A class
+     * file has to carry an entry for every nested class it names, which the deeper members it lists as nest
+     * members are.
+     *
+     * @param outerClassVisitor The visitor of the class being written
+     * @param outerType         The type the members are declared in
+     * @param outerDef          Its definition
+     * @param nestHost          Whether the class being written hosts the nest
+     */
     private void writeInnerTypes(ClassVisitor outerClassVisitor,
                                  ClassTypeDef outerType,
                                  ObjectDef outerDef,
@@ -801,22 +843,17 @@ public final class ByteCodeWriter {
             String outerClassInternalName = TypeUtils.getType(outerType).getInternalName();
 
             ClassTypeDef interType = innerDef.asTypeDef();
+            String innerClassInternalName = TypeUtils.getType(interType).getInternalName();
             outerClassVisitor.visitInnerClass(
-                TypeUtils.getType(innerDef.asTypeDef()).getInternalName(),
+                innerClassInternalName,
                 outerClassInternalName,
                 interType.getSimpleName(),
                 getInnerClassModifiersFlag(innerDef, outerDef instanceof InterfaceDef)
             );
             if (nestHost) {
-                writeNestMember(outerClassVisitor, innerDef);
+                outerClassVisitor.visitNestMember(innerClassInternalName);
+                writeInnerTypes(outerClassVisitor, interType, innerDef, true);
             }
-        }
-    }
-
-    private void writeNestMember(ClassVisitor nestHostVisitor, ObjectDef member) {
-        nestHostVisitor.visitNestMember(TypeUtils.getType(member.asTypeDef()).getInternalName());
-        for (ObjectDef innerType : member.getInnerTypes()) {
-            writeNestMember(nestHostVisitor, innerType);
         }
     }
 

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
@@ -471,7 +471,10 @@ public final class ByteCodeWriter {
             if (typeDef instanceof ClassTypeDef.ClassElementType) {
                 return RetentionPolicy.CLASS;
             }
-            // Preserve annotations whose definitions are unavailable to the generator.
+            // The annotation type is not on the generator's own class path, which is the normal case for
+            // an annotation processor writing annotations of the project it is processing. Nothing here can
+            // read its retention, so keep the runtime visibility every annotation had before retention was
+            // honoured at all - downgrading to CLASS would hide these from the frameworks that read them.
             return RetentionPolicy.RUNTIME;
         }
         Retention retention = annotationType.getAnnotation(Retention.class);
@@ -944,29 +947,22 @@ public final class ByteCodeWriter {
                 annotationVisitor.visitAnnotation(name, TypeUtils.getType(nestedAnnotation.getType(), null).getDescriptor())
             );
         } else if (value instanceof AnnotationDef[] annotations) {
-            AnnotationVisitor arrayVisitor = annotationVisitor.visitArray(name);
-            for (AnnotationDef annotationDef : annotations) {
-                visitAnnotation(
-                    annotationDef,
-                    arrayVisitor.visitAnnotation(null, TypeUtils.getType(annotationDef.getType(), null).getDescriptor())
-                );
-            }
-            arrayVisitor.visitEnd();
+            visitAnnotationArray(annotationVisitor, name, Arrays.asList(annotations));
         } else if (value instanceof Collection<?> coll) {
-            AnnotationVisitor arrayVisitor = annotationVisitor.visitArray(name);
-            for (Object object : coll) {
-                visitAnnotation(arrayVisitor, null, object);
-            }
-            arrayVisitor.visitEnd();
+            visitAnnotationArray(annotationVisitor, name, coll);
         } else if (value instanceof Object[] array) {
-            AnnotationVisitor arrayVisitor = annotationVisitor.visitArray(name);
-            for (Object object : array) {
-                visitAnnotation(arrayVisitor, null, object);
-            }
-            arrayVisitor.visitEnd();
+            visitAnnotationArray(annotationVisitor, name, Arrays.asList(array));
         } else {
             annotationVisitor.visit(name, value);
         }
+    }
+
+    private void visitAnnotationArray(AnnotationVisitor annotationVisitor, @Nullable String name, Collection<?> values) {
+        AnnotationVisitor arrayVisitor = annotationVisitor.visitArray(name);
+        for (Object value : values) {
+            visitAnnotation(arrayVisitor, null, value);
+        }
+        arrayVisitor.visitEnd();
     }
 
     private void writeProperty(ClassVisitor classWriter, ObjectDef objectDef, PropertyDef property, Set<String> emittedBridges) {
@@ -1024,42 +1020,9 @@ public final class ByteCodeWriter {
         if (methodDef.isSynthetic()) {
             modifiersFlag |= ACC_SYNTHETIC;
         }
-        String[] exceptions = methodDef.getThrowTypes().isEmpty() ? null : methodDef.getThrowTypes().stream()
-            .map(t -> TypeUtils.getType(t, objectDef).getClassName().replace(".", "/"))
-            .toArray(String[]::new);
-        MethodVisitor methodVisitor = classVisitor.visitMethod(
-            modifiersFlag,
-            name,
-            methodDescriptor,
-            // A bridge carries an erased signature, it never gets a Signature attribute
-            (modifiersFlag & ACC_BRIDGE) == 0 ? SignatureWriterUtils.getMethodSignature(objectDef, methodDef) : null,
-            exceptions
-        );
-        if (objectDef instanceof RecordDef recordDef && isCanonicalRecordConstructor(recordDef, methodDef)) {
-            for (ParameterDef parameter : methodDef.getParameters()) {
-                int parameterModifiers = parameter.getModifiers().contains(Modifier.FINAL) ? ACC_FINAL : 0;
-                if (parameter.isSynthetic()) {
-                    parameterModifiers |= ACC_SYNTHETIC;
-                }
-                methodVisitor.visitParameter(parameter.getName(), parameterModifiers);
-            }
-        }
+        MethodVisitor methodVisitor = visitMethodHeader(classVisitor, objectDef, methodDef, modifiersFlag, name, methodDescriptor);
         GeneratorAdapter generatorAdapter = new GeneratorAdapter(methodVisitor, modifiersFlag, name, methodDescriptor);
-        for (AnnotationDef annotation : methodDef.getAnnotations()) {
-            writeAnnotation(annotation, generatorAdapter::visitAnnotation);
-        }
-
-        if (!methodDef.isConstructor()) {
-            writeTypeAnnotations(
-                methodDef.getReturnType(),
-                TypeReference.newTypeReference(TypeReference.METHOD_RETURN).getValue(),
-                generatorAdapter::visitTypeAnnotation
-            );
-        }
-
-        if (methodDef.getParameters().stream().anyMatch(p -> !p.getAnnotations().isEmpty())) {
-            generatorAdapter.visitAnnotableParameterCount(methodDef.getParameters().size(), true);
-        }
+        writeMethodAnnotations(generatorAdapter, methodDef);
 
         MethodContext context = new MethodContext(objectDef, methodDef, isLambda);
         Label startMethod = writeParameters(generatorAdapter, objectDef, methodDef, context);
@@ -1083,6 +1046,75 @@ public final class ByteCodeWriter {
 
         if (!isLambda && (extraModifiersFlag & ACC_BRIDGE) == 0) {
             writeBridgeMethods(classVisitor, objectDef, methodDef, emittedBridges);
+        }
+    }
+
+    /**
+     * Declare the method and everything that belongs to its declaration rather than its body: the throws
+     * clause, the generic signature - which a bridge never carries - and, for a record's canonical
+     * constructor, the component names.
+     *
+     * @param classVisitor     The class visitor
+     * @param objectDef        The object definition
+     * @param methodDef        The method definition
+     * @param modifiersFlag    The access flags
+     * @param name             The method name
+     * @param methodDescriptor The method descriptor
+     * @return The visitor of the declared method
+     */
+    private static MethodVisitor visitMethodHeader(ClassVisitor classVisitor,
+                                                   @Nullable ObjectDef objectDef,
+                                                   MethodDef methodDef,
+                                                   int modifiersFlag,
+                                                   String name,
+                                                   String methodDescriptor) {
+        String[] exceptions = methodDef.getThrowTypes().isEmpty() ? null : methodDef.getThrowTypes().stream()
+            .map(t -> TypeUtils.getType(t, objectDef).getClassName().replace(".", "/"))
+            .toArray(String[]::new);
+        MethodVisitor methodVisitor = classVisitor.visitMethod(
+            modifiersFlag,
+            name,
+            methodDescriptor,
+            // A bridge carries an erased signature, it never gets a Signature attribute
+            (modifiersFlag & ACC_BRIDGE) == 0 ? SignatureWriterUtils.getMethodSignature(objectDef, methodDef) : null,
+            exceptions
+        );
+        if (objectDef instanceof RecordDef recordDef && isCanonicalRecordConstructor(recordDef, methodDef)) {
+            writeCanonicalRecordParameters(methodVisitor, methodDef);
+        }
+        return methodVisitor;
+    }
+
+    private void writeMethodAnnotations(GeneratorAdapter generatorAdapter, MethodDef methodDef) {
+        for (AnnotationDef annotation : methodDef.getAnnotations()) {
+            writeAnnotation(annotation, generatorAdapter::visitAnnotation);
+        }
+        if (!methodDef.isConstructor()) {
+            writeTypeAnnotations(
+                methodDef.getReturnType(),
+                TypeReference.newTypeReference(TypeReference.METHOD_RETURN).getValue(),
+                generatorAdapter::visitTypeAnnotation
+            );
+        }
+        if (methodDef.getParameters().stream().anyMatch(p -> !p.getAnnotations().isEmpty())) {
+            generatorAdapter.visitAnnotableParameterCount(methodDef.getParameters().size(), true);
+        }
+    }
+
+    /**
+     * Write the MethodParameters attribute of a record's canonical constructor, so the component names
+     * survive into the class file and reflection can recover them.
+     *
+     * @param methodVisitor The method visitor
+     * @param methodDef     The canonical constructor
+     */
+    private static void writeCanonicalRecordParameters(MethodVisitor methodVisitor, MethodDef methodDef) {
+        for (ParameterDef parameter : methodDef.getParameters()) {
+            int parameterModifiers = parameter.getModifiers().contains(Modifier.FINAL) ? ACC_FINAL : 0;
+            if (parameter.isSynthetic()) {
+                parameterModifiers |= ACC_SYNTHETIC;
+            }
+            methodVisitor.visitParameter(parameter.getName(), parameterModifiers);
         }
     }
 

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
@@ -52,7 +52,10 @@ import org.objectweb.asm.util.CheckClassAdapter;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
+import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -197,11 +200,15 @@ public final class ByteCodeWriter {
 
     private void writeTypeAnnotations(List<AnnotationDef> annotations, int typeRef, String typePath, TypeAnnotatable member) {
         for (AnnotationDef annotation : annotations) {
+            RetentionPolicy retention = retentionOf(annotation);
+            if (retention == RetentionPolicy.SOURCE) {
+                continue;
+            }
             visitAnnotation(annotation, member.visitTypeAnnotation(
                 typeRef,
                 TypePath.fromString(typePath),
                 TypeUtils.getType(annotation.getType(), null).getDescriptor(),
-                true
+                retention == RetentionPolicy.RUNTIME
             ));
         }
     }
@@ -237,8 +244,7 @@ public final class ByteCodeWriter {
             null
         );
         for (AnnotationDef annotation : fieldDef.getAnnotations()) {
-            AnnotationVisitor annotationVisitor = fieldVisitor.visitAnnotation(TypeUtils.getType(annotation.getType(), null).getDescriptor(), true);
-            visitAnnotation(annotation, annotationVisitor);
+            writeAnnotation(annotation, fieldVisitor::visitAnnotation);
         }
         writeTypeAnnotations(
             fieldDef.getType(),
@@ -270,8 +276,7 @@ public final class ByteCodeWriter {
         );
         writeOuterInner(classVisitor, interfaceDef.asTypeDef(), interfaceDef, outerType);
         for (AnnotationDef annotation : interfaceDef.getAnnotations()) {
-            AnnotationVisitor annotationVisitor = classVisitor.visitAnnotation(TypeUtils.getType(annotation.getType(), null).getDescriptor(), true);
-            visitAnnotation(annotation, annotationVisitor);
+            writeAnnotation(annotation, classVisitor::visitAnnotation);
         }
         for (MethodDef method : interfaceDef.getMethods()) {
             writeMethod(classVisitor, interfaceDef, method, emittedBridges);
@@ -322,10 +327,7 @@ public final class ByteCodeWriter {
         writeOuterInner(classVisitor, recordDef.asTypeDef(), recordDef, outerType);
 
         for (AnnotationDef annotation : recordDef.getAnnotations()) {
-            AnnotationVisitor annotationVisitor = classVisitor.visitAnnotation(
-                TypeUtils.getType(annotation.getType(), null).getDescriptor(),
-                true);
-            visitAnnotation(annotation, annotationVisitor);
+            writeAnnotation(annotation, classVisitor::visitAnnotation);
         }
 
         List<PropertyDef> components = recordDef.getProperties();
@@ -453,6 +455,29 @@ public final class ByteCodeWriter {
         return target == null ? Optional.empty() : Optional.of(Set.of(target.value()));
     }
 
+    private static RetentionPolicy retentionOf(AnnotationDef annotation) {
+        ClassTypeDef typeDef = annotation.getType();
+        if (typeDef instanceof ClassTypeDef.ClassDefType classDefType) {
+            return declaredRetentionOf(classDefType.objectDef()).orElse(RetentionPolicy.CLASS);
+        }
+        if (typeDef instanceof ClassTypeDef.ClassElementType classElementType) {
+            Retention retention = sourceAnnotation(classElementType.classElement(), Retention.class);
+            if (retention != null) {
+                return retention.value();
+            }
+        }
+        Class<?> annotationType = resolveAnnotationType(typeDef);
+        if (annotationType == null) {
+            if (typeDef instanceof ClassTypeDef.ClassElementType) {
+                return RetentionPolicy.CLASS;
+            }
+            // Preserve annotations whose definitions are unavailable to the generator.
+            return RetentionPolicy.RUNTIME;
+        }
+        Retention retention = annotationType.getAnnotation(Retention.class);
+        return retention == null ? RetentionPolicy.CLASS : retention.value();
+    }
+
     /**
      * The {@link Target} of an annotation type that is being compiled, read from the compiler's own element.
      * Its class cannot be loaded, and the annotation metadata of a {@link io.micronaut.inject.ast.ClassElement}
@@ -465,6 +490,12 @@ public final class ByteCodeWriter {
      */
     @Nullable
     private static Target sourceTargetOf(io.micronaut.inject.ast.ClassElement classElement) {
+        return sourceAnnotation(classElement, Target.class);
+    }
+
+    @Nullable
+    private static <A extends Annotation> A sourceAnnotation(io.micronaut.inject.ast.ClassElement classElement,
+                                                             Class<A> annotationType) {
         Object nativeType = classElement.getNativeType();
         Element element = null;
         if (nativeType instanceof Element nativeElement) {
@@ -480,7 +511,7 @@ public final class ByteCodeWriter {
                 return null;
             }
         }
-        return element == null ? null : element.getAnnotation(Target.class);
+        return element == null ? null : element.getAnnotation(annotationType);
     }
 
     /**
@@ -494,10 +525,26 @@ public final class ByteCodeWriter {
         return objectDef.getAnnotations().stream()
             .filter(a -> a.getType().getName().equals(Target.class.getName()))
             .findFirst()
-            .map(a -> toElementTypes(a.getValues().get(AnnotationMetadata.VALUE_MEMBER)))
-            // Nothing recognisable in the member leaves the annotation untargeted rather than targeting
-            // nothing at all, which would drop it from every member the component expands to
-            .filter(targets -> !targets.isEmpty());
+            .map(a -> toElementTypes(a.getValues().get(AnnotationMetadata.VALUE_MEMBER)));
+    }
+
+    private static Optional<RetentionPolicy> declaredRetentionOf(ObjectDef objectDef) {
+        return objectDef.getAnnotations().stream()
+            .filter(a -> a.getType().getName().equals(Retention.class.getName()))
+            .findFirst()
+            .flatMap(a -> toRetentionPolicy(a.getValues().get(AnnotationMetadata.VALUE_MEMBER)));
+    }
+
+    private static Optional<RetentionPolicy> toRetentionPolicy(@Nullable Object value) {
+        if (value instanceof RetentionPolicy retentionPolicy) {
+            return Optional.of(retentionPolicy);
+        }
+        String name = value instanceof VariableDef.StaticField staticField ? staticField.name() : Objects.toString(value, "");
+        try {
+            return Optional.of(RetentionPolicy.valueOf(name));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
     }
 
     /**
@@ -550,10 +597,7 @@ public final class ByteCodeWriter {
             SignatureWriterUtils.getFieldSignature(recordDef, componentField)
         );
         for (AnnotationDef annotation : annotationsFor(component, ElementType.RECORD_COMPONENT)) {
-            AnnotationVisitor annotationVisitor = recordComponentVisitor.visitAnnotation(
-                TypeUtils.getType(annotation.getType(), null).getDescriptor(),
-                true);
-            visitAnnotation(annotation, annotationVisitor);
+            writeAnnotation(annotation, recordComponentVisitor::visitAnnotation);
         }
         writeTypeAnnotations(
             componentField.getType(),
@@ -696,10 +740,7 @@ public final class ByteCodeWriter {
         writeOuterInner(classVisitor, classDef.asTypeDef(), classDef, outerType);
 
         for (AnnotationDef annotation : classDef.getAnnotations()) {
-            AnnotationVisitor annotationVisitor = classVisitor.visitAnnotation(
-                TypeUtils.getType(annotation.getType(), null).getDescriptor(),
-                true);
-            visitAnnotation(annotation, annotationVisitor);
+            writeAnnotation(annotation, classVisitor::visitAnnotation);
         }
 
         List<StatementDef> staticInitStatements = new ArrayList<>();
@@ -741,7 +782,7 @@ public final class ByteCodeWriter {
     private void writeOuterInner(ClassVisitor classVisitor, ClassTypeDef thisType, ObjectDef thisDef, @Nullable ClassTypeDef outerType) {
         if (outerType != null) {
             String outerInternalName = TypeUtils.getType(outerType).getInternalName();
-            classVisitor.visitNestHost(outerInternalName);
+            classVisitor.visitNestHost(nestHostInternalName(outerType));
             classVisitor.visitInnerClass(
                 TypeUtils.getType(thisType).getInternalName(),
                 outerInternalName,
@@ -749,10 +790,13 @@ public final class ByteCodeWriter {
                 getInnerClassModifiersFlag(thisDef, outerType.isInterface())
             );
         }
-        writeInnerTypes(classVisitor, thisType, thisDef);
+        writeInnerTypes(classVisitor, thisType, thisDef, outerType == null);
     }
 
-    private void writeInnerTypes(ClassVisitor outerClassVisitor, ClassTypeDef outerType, ObjectDef outerDef) {
+    private void writeInnerTypes(ClassVisitor outerClassVisitor,
+                                 ClassTypeDef outerType,
+                                 ObjectDef outerDef,
+                                 boolean nestHost) {
         for (ObjectDef innerDef : outerDef.getInnerTypes()) {
             String outerClassInternalName = TypeUtils.getType(outerType).getInternalName();
 
@@ -763,8 +807,25 @@ public final class ByteCodeWriter {
                 interType.getSimpleName(),
                 getInnerClassModifiersFlag(innerDef, outerDef instanceof InterfaceDef)
             );
-            outerClassVisitor.visitNestMember(TypeUtils.getType(innerDef.asTypeDef()).getInternalName());
+            if (nestHost) {
+                writeNestMember(outerClassVisitor, innerDef);
+            }
         }
+    }
+
+    private void writeNestMember(ClassVisitor nestHostVisitor, ObjectDef member) {
+        nestHostVisitor.visitNestMember(TypeUtils.getType(member.asTypeDef()).getInternalName());
+        for (ObjectDef innerType : member.getInnerTypes()) {
+            writeNestMember(nestHostVisitor, innerType);
+        }
+    }
+
+    private String nestHostInternalName(ClassTypeDef memberType) {
+        String name = memberType.getName();
+        int simpleNameStart = name.lastIndexOf('.') + 1;
+        int separator = name.indexOf('$', simpleNameStart + 1);
+        String hostName = separator == -1 ? name : name.substring(0, separator);
+        return TypeUtils.getType(hostName).getInternalName();
     }
 
     /**
@@ -802,7 +863,21 @@ public final class ByteCodeWriter {
         return getModifiersFlag(objectDef.getModifiers());
     }
 
-    private void visitAnnotation(AnnotationDef annotation, AnnotationVisitor annotationVisitor) {
+    private void writeAnnotation(AnnotationDef annotation, Annotatable member) {
+        RetentionPolicy retention = retentionOf(annotation);
+        if (retention == RetentionPolicy.SOURCE) {
+            return;
+        }
+        visitAnnotation(annotation, member.visitAnnotation(
+            TypeUtils.getType(annotation.getType(), null).getDescriptor(),
+            retention == RetentionPolicy.RUNTIME
+        ));
+    }
+
+    private void visitAnnotation(AnnotationDef annotation, @Nullable AnnotationVisitor annotationVisitor) {
+        if (annotationVisitor == null) {
+            return;
+        }
         for (Map.Entry<String, Object> entry : annotation.getValues().entrySet()) {
             String key = entry.getKey();
             Object value = entry.getValue();
@@ -811,13 +886,21 @@ public final class ByteCodeWriter {
         annotationVisitor.visitEnd();
     }
 
-    private void visitAnnotation(AnnotationVisitor annotationVisitor, String name, Object value) {
+    private void visitAnnotation(AnnotationVisitor annotationVisitor, @Nullable String name, Object value) {
         if (value instanceof VariableDef.StaticField staticField) {
-            annotationVisitor.visitEnum(
-                name,
-                TypeUtils.getType(staticField.ownerType(), null).getDescriptor(),
-                staticField.name()
-            );
+            if (staticField.name().equals("class") && staticField.type().equals(TypeDef.CLASS)) {
+                annotationVisitor.visit(name, TypeUtils.getType(staticField.ownerType(), null));
+            } else {
+                annotationVisitor.visitEnum(
+                    name,
+                    TypeUtils.getType(staticField.ownerType(), null).getDescriptor(),
+                    staticField.name()
+                );
+            }
+        } else if (value instanceof ClassTypeDef classTypeDef) {
+            annotationVisitor.visit(name, TypeUtils.getType(classTypeDef, null));
+        } else if (value instanceof Class<?> type) {
+            annotationVisitor.visit(name, Type.getType(type));
         } else if (value instanceof AnnotationDef nestedAnnotation) {
             visitAnnotation(
                 nestedAnnotation,
@@ -828,20 +911,20 @@ public final class ByteCodeWriter {
             for (AnnotationDef annotationDef : annotations) {
                 visitAnnotation(
                     annotationDef,
-                    annotationVisitor.visitAnnotation(name, TypeUtils.getType(annotationDef.getType(), null).getDescriptor())
+                    arrayVisitor.visitAnnotation(null, TypeUtils.getType(annotationDef.getType(), null).getDescriptor())
                 );
             }
             arrayVisitor.visitEnd();
         } else if (value instanceof Collection<?> coll) {
             AnnotationVisitor arrayVisitor = annotationVisitor.visitArray(name);
             for (Object object : coll) {
-                visitAnnotation(arrayVisitor, name, object);
+                visitAnnotation(arrayVisitor, null, object);
             }
             arrayVisitor.visitEnd();
         } else if (value instanceof Object[] array) {
             AnnotationVisitor arrayVisitor = annotationVisitor.visitArray(name);
             for (Object object : array) {
-                visitAnnotation(arrayVisitor, name, object);
+                visitAnnotation(arrayVisitor, null, object);
             }
             arrayVisitor.visitEnd();
         } else {
@@ -915,9 +998,18 @@ public final class ByteCodeWriter {
             (modifiersFlag & ACC_BRIDGE) == 0 ? SignatureWriterUtils.getMethodSignature(objectDef, methodDef) : null,
             exceptions
         );
+        if (objectDef instanceof RecordDef recordDef && isCanonicalRecordConstructor(recordDef, methodDef)) {
+            for (ParameterDef parameter : methodDef.getParameters()) {
+                int parameterModifiers = parameter.getModifiers().contains(Modifier.FINAL) ? ACC_FINAL : 0;
+                if (parameter.isSynthetic()) {
+                    parameterModifiers |= ACC_SYNTHETIC;
+                }
+                methodVisitor.visitParameter(parameter.getName(), parameterModifiers);
+            }
+        }
         GeneratorAdapter generatorAdapter = new GeneratorAdapter(methodVisitor, modifiersFlag, name, methodDescriptor);
         for (AnnotationDef annotation : methodDef.getAnnotations()) {
-            visitAnnotation(annotation, generatorAdapter.visitAnnotation(TypeUtils.getType(annotation.getType(), null).getDescriptor(), true));
+            writeAnnotation(annotation, generatorAdapter::visitAnnotation);
         }
 
         if (!methodDef.isConstructor()) {
@@ -957,6 +1049,21 @@ public final class ByteCodeWriter {
         }
     }
 
+    private static boolean isCanonicalRecordConstructor(RecordDef recordDef, MethodDef methodDef) {
+        if (!methodDef.isConstructor() || methodDef.getParameters().size() != recordDef.getProperties().size()) {
+            return false;
+        }
+        for (int i = 0; i < methodDef.getParameters().size(); i++) {
+            ParameterDef parameter = methodDef.getParameters().get(i);
+            PropertyDef property = recordDef.getProperties().get(i);
+            if (!parameter.getName().equals(property.getName())
+                || !TypeUtils.getType(parameter.getType(), recordDef).equals(TypeUtils.getType(property.getType(), recordDef))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /**
      * Register the parameters as locals and write their annotations.
      *
@@ -980,8 +1087,8 @@ public final class ByteCodeWriter {
                 startMethod = new Label();
             }
             for (AnnotationDef annotation : parameter.getAnnotations()) {
-                AnnotationVisitor annotationVisitor = generatorAdapter.visitParameterAnnotation(parameterIndex, TypeUtils.getType(annotation.getType(), null).getDescriptor(), true);
-                visitAnnotation(annotation, annotationVisitor);
+                int index = parameterIndex;
+                writeAnnotation(annotation, (descriptor, visible) -> generatorAdapter.visitParameterAnnotation(index, descriptor, visible));
             }
             writeTypeAnnotations(
                 parameter.getType(),
@@ -1258,6 +1365,12 @@ public final class ByteCodeWriter {
     private interface TypeAnnotatable {
 
         AnnotationVisitor visitTypeAnnotation(int typeRef, @Nullable TypePath typePath, String descriptor, boolean visible);
+    }
+
+    @FunctionalInterface
+    private interface Annotatable {
+
+        AnnotationVisitor visitAnnotation(String descriptor, boolean visible);
     }
 
 }

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/SignatureWriterUtils.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/SignatureWriterUtils.java
@@ -32,7 +32,9 @@ import org.objectweb.asm.signature.SignatureVisitor;
 import org.objectweb.asm.signature.SignatureWriter;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The bytecode signature utils.
@@ -42,6 +44,12 @@ import java.util.Objects;
  */
 @Internal
 final class SignatureWriterUtils {
+
+    /**
+     * Whether the class a bound names is an interface, kept per name so writing many bounds asks the
+     * class loader about each one once.
+     */
+    private static final Map<String, Boolean> NAMED_BOUND_IS_INTERFACE = new ConcurrentHashMap<>();
 
     @Nullable
     static String getFieldSignature(@Nullable ObjectDef objectDef, FieldDef fieldDef) {
@@ -262,7 +270,7 @@ final class SignatureWriterUtils {
             );
             return;
         }
-        if (wildcard.upperBounds().isEmpty() || wildcard.upperBounds().equals(List.of(TypeDef.OBJECT))) {
+        if (isUnbounded(wildcard)) {
             signatureWriter.visitTypeArgument();
             return;
         }
@@ -273,6 +281,27 @@ final class SignatureWriterUtils {
             wildcard.upperBounds().get(0),
             false
         );
+    }
+
+    /**
+     * Whether a wildcard is the unbounded {@code ?}: no lower bound, and either no upper bound or the
+     * single implicit {@code Object} one. The bound is unwrapped and compared by name rather than by
+     * instance, so an annotated {@code Object}, or one named as a string instead of built from
+     * {@link Object}, is still recognised as the implicit bound it is rather than written out as
+     * {@code ? extends Object}.
+     *
+     * @param wildcard The wildcard
+     * @return True when the wildcard carries no bound of its own
+     */
+    private static boolean isUnbounded(TypeDef.Wildcard wildcard) {
+        List<TypeDef> upperBounds = wildcard.upperBounds();
+        if (upperBounds.isEmpty()) {
+            return true;
+        }
+        return upperBounds.size() == 1
+            && unwrapAnnotated(upperBounds.get(0)) instanceof ClassTypeDef classTypeDef
+            && !(classTypeDef instanceof ClassTypeDef.Parameterized)
+            && Object.class.getName().equals(classTypeDef.getName());
     }
 
     /**
@@ -295,14 +324,17 @@ final class SignatureWriterUtils {
             return true;
         }
         if (classTypeDef instanceof ClassTypeDef.ClassName) {
-            try {
-                return Class.forName(classTypeDef.getName(), false, SignatureWriterUtils.class.getClassLoader())
-                    .isInterface();
-            } catch (ClassNotFoundException | LinkageError e) {
-                return false;
-            }
+            return NAMED_BOUND_IS_INTERFACE.computeIfAbsent(classTypeDef.getName(), SignatureWriterUtils::loadIsInterface);
         }
         return false;
+    }
+
+    private static boolean loadIsInterface(String name) {
+        try {
+            return Class.forName(name, false, SignatureWriterUtils.class.getClassLoader()).isInterface();
+        } catch (ClassNotFoundException | LinkageError e) {
+            return false;
+        }
     }
 
     private static boolean isVariablePartOfTheDefinition(String variableName, @Nullable ObjectDef objectDef, @Nullable MethodDef methodDef) {

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/SignatureWriterUtils.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/SignatureWriterUtils.java
@@ -275,12 +275,34 @@ final class SignatureWriterUtils {
         );
     }
 
+    /**
+     * Whether a bound is an interface, which decides the position it is written in: the first bound goes
+     * into the class bound only when it is a class. A {@link ClassTypeDef.ClassName} is only a name and
+     * carries no answer, so the class it names is the last place left to ask.
+     *
+     * @param typeDef The bound
+     * @return True when the bound is known to be an interface
+     */
     private static boolean isInterface(TypeDef typeDef) {
         typeDef = unwrapAnnotated(typeDef);
         if (typeDef instanceof ClassTypeDef.Parameterized parameterized) {
             typeDef = parameterized.rawType();
         }
-        return typeDef instanceof ClassTypeDef classTypeDef && classTypeDef.isInterface();
+        if (!(typeDef instanceof ClassTypeDef classTypeDef)) {
+            return false;
+        }
+        if (classTypeDef.isInterface()) {
+            return true;
+        }
+        if (classTypeDef instanceof ClassTypeDef.ClassName) {
+            try {
+                return Class.forName(classTypeDef.getName(), false, SignatureWriterUtils.class.getClassLoader())
+                    .isInterface();
+            } catch (ClassNotFoundException | LinkageError e) {
+                return false;
+            }
+        }
+        return false;
     }
 
     private static boolean isVariablePartOfTheDefinition(String variableName, @Nullable ObjectDef objectDef, @Nullable MethodDef methodDef) {

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/SignatureWriterUtils.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/SignatureWriterUtils.java
@@ -31,6 +31,7 @@ import org.objectweb.asm.Type;
 import org.objectweb.asm.signature.SignatureVisitor;
 import org.objectweb.asm.signature.SignatureWriter;
 
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -139,7 +140,12 @@ final class SignatureWriterUtils {
 
     private static boolean needsSignature(TypeDef typeDef) {
         typeDef = unwrapAnnotated(typeDef);
-        return typeDef instanceof ClassTypeDef.Parameterized || typeDef instanceof TypeDef.TypeVariable;
+        if (typeDef instanceof TypeDef.Array array) {
+            return needsSignature(array.componentType());
+        }
+        return typeDef instanceof ClassTypeDef.Parameterized
+            || typeDef instanceof TypeDef.TypeVariable
+            || typeDef instanceof TypeDef.Wildcard;
     }
 
     /**
@@ -178,12 +184,16 @@ final class SignatureWriterUtils {
             if (isDefinition) {
                 signatureWriter.visitFormalTypeParameter(name);
                 if (typeVariable.bounds().isEmpty()) {
-                    signatureWriter.visitClassType(TypeUtils.OBJECT_TYPE.getInternalName());
-                    signatureWriter.visitEnd();
+                    writeSignature(signatureWriter.visitClassBound(), objectDef, TypeDef.OBJECT, false);
                 } else {
-                    TypeDef bound = typeVariable.bounds().get(0);
-                    signatureWriter.visitClassBound();
-                    writeSignature(signatureWriter, objectDef, methodDef, bound, false);
+                    boolean first = true;
+                    for (TypeDef bound : typeVariable.bounds()) {
+                        SignatureVisitor boundVisitor = first && !isInterface(bound)
+                            ? signatureWriter.visitClassBound()
+                            : signatureWriter.visitInterfaceBound();
+                        writeSignature(boundVisitor, objectDef, methodDef, bound, false);
+                        first = false;
+                    }
                 }
             } else {
                 if (isVariablePartOfTheDefinition(name, objectDef, methodDef)) {
@@ -202,8 +212,7 @@ final class SignatureWriterUtils {
             signatureWriter.visitClassType(TypeUtils.getType(parameterized.rawType()).getInternalName());
             if (!parameterized.typeArguments().isEmpty()) {
                 for (TypeDef typeArgument : parameterized.typeArguments()) {
-                    SignatureVisitor signatureVisitor = signatureWriter.visitTypeArgument(SignatureVisitor.INSTANCEOF);
-                    writeSignature(signatureVisitor, objectDef, methodDef, typeArgument, false);
+                    writeTypeArgument(signatureWriter, objectDef, methodDef, typeArgument);
                 }
                 signatureWriter.visitEnd();
             }
@@ -232,6 +241,46 @@ final class SignatureWriterUtils {
             return;
         }
         throw new IllegalStateException("Not recognized typedef: " + typeDef);
+    }
+
+    private static void writeTypeArgument(SignatureVisitor signatureWriter,
+                                          @Nullable ObjectDef objectDef,
+                                          @Nullable MethodDef methodDef,
+                                          TypeDef typeArgument) {
+        TypeDef unwrapped = unwrapAnnotated(typeArgument);
+        if (!(unwrapped instanceof TypeDef.Wildcard wildcard)) {
+            writeSignature(signatureWriter.visitTypeArgument(SignatureVisitor.INSTANCEOF), objectDef, methodDef, typeArgument, false);
+            return;
+        }
+        if (!wildcard.lowerBounds().isEmpty()) {
+            writeSignature(
+                signatureWriter.visitTypeArgument(SignatureVisitor.SUPER),
+                objectDef,
+                methodDef,
+                wildcard.lowerBounds().get(0),
+                false
+            );
+            return;
+        }
+        if (wildcard.upperBounds().isEmpty() || wildcard.upperBounds().equals(List.of(TypeDef.OBJECT))) {
+            signatureWriter.visitTypeArgument();
+            return;
+        }
+        writeSignature(
+            signatureWriter.visitTypeArgument(SignatureVisitor.EXTENDS),
+            objectDef,
+            methodDef,
+            wildcard.upperBounds().get(0),
+            false
+        );
+    }
+
+    private static boolean isInterface(TypeDef typeDef) {
+        typeDef = unwrapAnnotated(typeDef);
+        if (typeDef instanceof ClassTypeDef.Parameterized parameterized) {
+            typeDef = parameterized.rawType();
+        }
+        return typeDef instanceof ClassTypeDef classTypeDef && classTypeDef.isInterface();
     }
 
     private static boolean isVariablePartOfTheDefinition(String variableName, @Nullable ObjectDef objectDef, @Nullable MethodDef methodDef) {

--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterRecordRegressionTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterRecordRegressionTest.java
@@ -1,0 +1,304 @@
+package io.micronaut.sourcegen.bytecode;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.sourcegen.model.AnnotationDef;
+import io.micronaut.sourcegen.model.AnnotationObjectDef;
+import io.micronaut.sourcegen.model.ClassDef;
+import io.micronaut.sourcegen.model.ClassTypeDef;
+import io.micronaut.sourcegen.model.ExpressionDef;
+import io.micronaut.sourcegen.model.MethodDef;
+import io.micronaut.sourcegen.model.ObjectDef;
+import io.micronaut.sourcegen.model.PropertyDef;
+import io.micronaut.sourcegen.model.RecordDef;
+import io.micronaut.sourcegen.model.TypeDef;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.TypePath;
+import org.objectweb.asm.util.TraceClassVisitor;
+
+import javax.lang.model.element.Modifier;
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.io.StringWriter;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ByteCodeWriterRecordRegressionTest {
+
+    @Test
+    void preservesGenericArrayComponentSignatures() throws Exception {
+        RecordDef recordDef = RecordDef.builder("example.ArrayRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addTypeVariable(TypeDef.variable("T"))
+            .addProperty(PropertyDef.builder("values").ofType(TypeDef.variable("T").array()).build())
+            .build();
+
+        Class<?> generated = define(recordDef);
+
+        assertInstanceOf(GenericArrayType.class, generated.getRecordComponents()[0].getGenericType());
+        assertInstanceOf(GenericArrayType.class, generated.getDeclaredField("values").getGenericType());
+        assertInstanceOf(GenericArrayType.class, generated.getMethod("values").getGenericReturnType());
+        assertInstanceOf(GenericArrayType.class, generated.getDeclaredConstructors()[0].getGenericParameterTypes()[0]);
+    }
+
+    @Test
+    void preservesWildcardComponentSignatures() {
+        RecordDef recordDef = RecordDef.builder("example.WildcardRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(PropertyDef.builder("upper").ofType(TypeDef.parameterized(
+                List.class, TypeDef.wildcardSubtypeOf(TypeDef.of(Number.class))
+            )).build())
+            .addProperty(PropertyDef.builder("lower").ofType(TypeDef.parameterized(
+                List.class, TypeDef.wildcardSupertypeOf(TypeDef.of(Integer.class))
+            )).build())
+            .addProperty(PropertyDef.builder("any").ofType(TypeDef.parameterized(
+                List.class, TypeDef.wildcard()
+            )).build())
+            .build();
+
+        Class<?> generated = define(recordDef);
+        WildcardType upper = wildcard(generated, 0);
+        WildcardType lower = wildcard(generated, 1);
+        WildcardType any = wildcard(generated, 2);
+
+        assertEquals(List.of(Number.class), List.of(upper.getUpperBounds()));
+        assertEquals(List.of(), List.of(upper.getLowerBounds()));
+        assertEquals(List.of(Object.class), List.of(lower.getUpperBounds()));
+        assertEquals(List.of(Integer.class), List.of(lower.getLowerBounds()));
+        assertEquals(List.of(Object.class), List.of(any.getUpperBounds()));
+        assertEquals(List.of(), List.of(any.getLowerBounds()));
+    }
+
+    @Test
+    void preservesEveryTypeVariableBound() {
+        RecordDef recordDef = RecordDef.builder("example.BoundedRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addTypeVariable(TypeDef.variable("T", TypeDef.of(Number.class), TypeDef.of(Serializable.class)))
+            .addProperty(PropertyDef.builder("value").ofType(TypeDef.variable("T")).build())
+            .build();
+
+        TypeVariable<?> variable = define(recordDef).getTypeParameters()[0];
+
+        assertEquals(List.of(Number.class, Serializable.class), List.of(variable.getBounds()));
+    }
+
+    @Test
+    void writesCanonicalConstructorParameterNames() {
+        RecordDef recordDef = RecordDef.builder("example.NamedRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(PropertyDef.builder("name").ofType(TypeDef.STRING).build())
+            .build();
+
+        var parameter = define(recordDef).getDeclaredConstructors()[0].getParameters()[0];
+
+        assertTrue(parameter.isNamePresent());
+        assertEquals("name", parameter.getName());
+    }
+
+    @Test
+    void writesNestedAnnotationArraysOnMethods() throws Exception {
+        AnnotationDef nested = AnnotationDef.builder(ClassTypeDef.of(Nested.class))
+            .addMember("value", "kept")
+            .build();
+        RecordDef recordDef = methodAnnotatedRecord(
+            "example.NestedAnnotatedRecord",
+            AnnotationDef.builder(ClassTypeDef.of(Container.class))
+                .addMember("value", new AnnotationDef[]{nested})
+                .build()
+        );
+
+        Container annotation = define(recordDef).getMethod("annotated").getAnnotation(Container.class);
+
+        assertEquals("kept", annotation.value()[0].value());
+    }
+
+    @Test
+    void writesClassValuedAnnotationMembersOnMethods() throws Exception {
+        RecordDef recordDef = methodAnnotatedRecord(
+            "example.ClassAnnotatedRecord",
+            AnnotationDef.builder(ClassTypeDef.of(ClassMember.class))
+                .addMember("value", ClassTypeDef.of(String.class).getStaticField("class", TypeDef.CLASS))
+                .build()
+        );
+
+        ClassMember annotation = define(recordDef).getMethod("annotated").getAnnotation(ClassMember.class);
+
+        assertEquals(String.class, annotation.value());
+    }
+
+    @Test
+    void honorsTypeAnnotationRetention() {
+        AnnotationDef annotation = AnnotationDef.builder(ClassTypeDef.of(ClassRetentionTypeUse.class)).build();
+        RecordDef recordDef = RecordDef.builder("example.RetentionRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(PropertyDef.builder("value").ofType(TypeDef.STRING.annotated(annotation)).build())
+            .build();
+        boolean[] seen = {false};
+        boolean[] visible = {true};
+
+        new ClassReader(new ByteCodeWriter().write(recordDef)).accept(new ClassVisitor(Opcodes.ASM9) {
+            @Override
+            public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+                return new FieldVisitor(Opcodes.ASM9) {
+                    @Override
+                    public org.objectweb.asm.AnnotationVisitor visitTypeAnnotation(
+                            int typeRef, TypePath typePath, String annotationDescriptor, boolean runtimeVisible) {
+                        seen[0] = true;
+                        visible[0] = runtimeVisible;
+                        return null;
+                    }
+                };
+            }
+        }, 0);
+
+        assertTrue(seen[0]);
+        assertFalse(visible[0]);
+    }
+
+    @Test
+    void omitsSourceRetentionAnnotations() {
+        RecordDef recordDef = RecordDef.builder("example.SourceAnnotatedRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(PropertyDef.builder("value").ofType(TypeDef.STRING)
+                .addAnnotation(AnnotationDef.builder(ClassTypeDef.of(SourceComponent.class)).build())
+                .build())
+            .build();
+
+        assertFalse(trace(new ByteCodeWriter().write(recordDef)).contains(Type.getDescriptor(SourceComponent.class)));
+    }
+
+    @Test
+    void honorsAnExplicitlyEmptyGeneratedTarget() {
+        AnnotationObjectDef nowhere = AnnotationObjectDef.builder("example.Nowhere")
+            .addAnnotation(AnnotationDef.builder(ClassTypeDef.of(Target.class))
+                .addMember(AnnotationMetadata.VALUE_MEMBER, new Object[0])
+                .build())
+            .build();
+        RecordDef recordDef = RecordDef.builder("example.TargetRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(PropertyDef.builder("value").ofType(TypeDef.STRING)
+                .addAnnotation(AnnotationDef.builder(ClassTypeDef.of(nowhere)).build())
+                .build())
+            .build();
+
+        assertFalse(trace(new ByteCodeWriter().write(recordDef)).contains("Lexample/Nowhere;"));
+    }
+
+    @Test
+    void usesOneNestHostForEveryNestingLevel() throws Exception {
+        RecordDef deep = RecordDef.builder("Deep").build();
+        RecordDef inner = RecordDef.builder("Inner").addInnerType(deep).build();
+        ClassDef outer = ClassDef.builder("example.Outer")
+            .addModifiers(Modifier.PUBLIC)
+            .addInnerType(inner)
+            .build();
+        ObjectDef emittedInner = outer.getInnerTypes().get(0);
+        ObjectDef emittedDeep = emittedInner.getInnerTypes().get(0);
+        Map<String, byte[]> definitions = new LinkedHashMap<>();
+        ByteCodeWriter writer = new ByteCodeWriter();
+        definitions.put(outer.getName(), writer.write(outer));
+        definitions.put(emittedInner.getName(), writer.write(emittedInner, outer.asTypeDef()));
+        definitions.put(emittedDeep.getName(), writer.write(emittedDeep, emittedInner.asTypeDef()));
+
+        ClassLoader loader = new ClassLoader() {
+            @Override
+            protected Class<?> findClass(String name) throws ClassNotFoundException {
+                byte[] bytes = definitions.get(name);
+                if (bytes == null) {
+                    return super.findClass(name);
+                }
+                return defineClass(name, bytes, 0, bytes.length);
+            }
+        };
+        Class<?> outerClass = loader.loadClass("example.Outer");
+        Class<?> innerClass = loader.loadClass("example.Outer$Inner");
+        Class<?> deepClass = loader.loadClass("example.Outer$Inner$Deep");
+
+        assertEquals(outerClass, innerClass.getNestHost());
+        assertEquals(outerClass, deepClass.getNestHost());
+        assertEquals(
+            List.of("example.Outer", "example.Outer$Inner", "example.Outer$Inner$Deep"),
+            Arrays.stream(outerClass.getNestMembers()).map(Class::getName).sorted().toList()
+        );
+    }
+
+    private static WildcardType wildcard(Class<?> generated, int componentIndex) {
+        ParameterizedType type = assertInstanceOf(
+            ParameterizedType.class,
+            generated.getRecordComponents()[componentIndex].getGenericType()
+        );
+        return assertInstanceOf(WildcardType.class, type.getActualTypeArguments()[0]);
+    }
+
+    private static RecordDef methodAnnotatedRecord(String name, AnnotationDef annotation) {
+        return RecordDef.builder(name)
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("annotated")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(TypeDef.STRING)
+                .addAnnotation(annotation)
+                .build((aThis, parameters) -> ExpressionDef.constant("ok").returning()))
+            .build();
+    }
+
+    private static Class<?> define(RecordDef recordDef) {
+        byte[] bytes = new ByteCodeWriter().write(recordDef);
+        return new ClassLoader() {
+            Class<?> define() {
+                return defineClass(recordDef.getName(), bytes, 0, bytes.length);
+            }
+        }.define();
+    }
+
+    private static String trace(byte[] bytes) {
+        StringWriter out = new StringWriter();
+        new ClassReader(bytes).accept(new TraceClassVisitor(null, new PrintWriter(out)), 0);
+        return out.toString();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    @interface Container {
+        Nested[] value();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Nested {
+        String value();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    @interface ClassMember {
+        Class<?> value();
+    }
+
+    @Retention(RetentionPolicy.CLASS)
+    @Target(ElementType.TYPE_USE)
+    @interface ClassRetentionTypeUse {
+    }
+
+    @Retention(RetentionPolicy.SOURCE)
+    @Target(ElementType.RECORD_COMPONENT)
+    @interface SourceComponent {
+    }
+}

--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterRecordRegressionTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterRecordRegressionTest.java
@@ -204,6 +204,53 @@ class ByteCodeWriterRecordRegressionTest {
     }
 
     @Test
+    void keepsAnAnnotationWhoseGeneratedTargetIsNotRecognisable() {
+        AnnotationObjectDef unrecognisable = AnnotationObjectDef.builder("example.Unrecognisable")
+            .addAnnotation(AnnotationDef.builder(ClassTypeDef.of(Target.class))
+                // Nothing here names an ElementType, which leaves the annotation untargeted
+                .addMember(AnnotationMetadata.VALUE_MEMBER, "java.lang.annotation.ElementType.FIELD")
+                .build())
+            .build();
+        RecordDef recordDef = RecordDef.builder("example.UntargetedRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(PropertyDef.builder("value").ofType(TypeDef.STRING)
+                .addAnnotation(AnnotationDef.builder(ClassTypeDef.of(unrecognisable)).build())
+                .build())
+            .build();
+
+        assertTrue(trace(new ByteCodeWriter().write(recordDef)).contains("Lexample/Unrecognisable;"));
+    }
+
+    @Test
+    void writesAnInterfaceBoundNamedByStringInTheInterfacePosition() {
+        RecordDef recordDef = RecordDef.builder("example.NamedBoundRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addTypeVariable(TypeDef.variable("T", ClassTypeDef.of(Serializable.class.getName())))
+            .addProperty(PropertyDef.builder("value").ofType(TypeDef.variable("T")).build())
+            .build();
+
+        assertTrue(
+            trace(new ByteCodeWriter().write(recordDef)).contains("<T::Ljava/io/Serializable;>"),
+            trace(new ByteCodeWriter().write(recordDef))
+        );
+    }
+
+    @Test
+    void writesAnInnerClassEntryForEveryNestMember() {
+        RecordDef deep = RecordDef.builder("Deep").build();
+        RecordDef inner = RecordDef.builder("Inner").addInnerType(deep).build();
+        ClassDef outer = ClassDef.builder("example.Outer")
+            .addModifiers(Modifier.PUBLIC)
+            .addInnerType(inner)
+            .build();
+
+        String trace = trace(new ByteCodeWriter().write(outer));
+
+        assertTrue(trace.contains("NESTMEMBER example/Outer$Inner$Deep"), trace);
+        assertTrue(trace.contains("INNERCLASS example/Outer$Inner$Deep example/Outer$Inner Deep"), trace);
+    }
+
+    @Test
     void usesOneNestHostForEveryNestingLevel() throws Exception {
         RecordDef deep = RecordDef.builder("Deep").build();
         RecordDef inner = RecordDef.builder("Inner").addInnerType(deep).build();

--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/ByteCodeWriterTest.java
@@ -5029,6 +5029,8 @@ public final class example/MyRecord extends java/lang/Record {
 
   // access flags 0x1
   public <init>(Ljava/lang/String;I)V
+    // parameter  name
+    // parameter  age
    L0
     ALOAD 0
     INVOKESPECIAL java/lang/Record.<init> ()V
@@ -5110,10 +5112,6 @@ public final class example/MyRecord extends java/lang/Record {
 package example;
 
 public record MyRecord(String name, int age) {
-   public MyRecord(String name, int age) {
-      this.name = name;
-      this.age = age;
-   }
 }
 """, decompileToJava(bytes));
 
@@ -5167,6 +5165,7 @@ public final class example/MyRecord extends java/lang/Record implements java/uti
   // signature (TT;)V
   // declaration: void <init>(T)
   public <init>(Ljava/lang/Object;)V
+    // parameter  value
    L0
     ALOAD 0
     INVOKESPECIAL java/lang/Record.<init> ()V
@@ -5283,6 +5282,7 @@ public final class example/MyRecord extends java/lang/Record {
   // signature (TT;)V
   // declaration: void <init>(T)
   public <init>(Ljava/lang/Object;)V
+    // parameter  value
    L0
     ALOAD 0
     INVOKESPECIAL java/lang/Record.<init> ()V
@@ -5394,6 +5394,7 @@ public final class example/MyRecord extends java/lang/Record {
   // signature (TT;)V
   // declaration: void <init>(T)
   public <init>(Ljava/lang/Number;)V
+    // parameter  value
    L0
     ALOAD 0
     INVOKESPECIAL java/lang/Record.<init> ()V
@@ -5504,6 +5505,8 @@ public final class example/MyRecord extends java/lang/Record {
 
   // access flags 0x1
   public <init>(Ljava/lang/String;I)V
+    // parameter  name
+    // parameter  age
    L0
     ALOAD 0
     INVOKESPECIAL java/lang/Record.<init> ()V
@@ -5730,6 +5733,9 @@ public final class example/MyRecord extends java/lang/Record {
 
   // access flags 0x1
   public <init>(JD[Ljava/lang/String;)V
+    // parameter  id
+    // parameter  weight
+    // parameter  tags
    L0
     ALOAD 0
     INVOKESPECIAL java/lang/Record.<init> ()V
@@ -5863,6 +5869,7 @@ public final class example/MyRecord extends java/lang/Record {
 
   // access flags 0x1
   public <init>(Ljava/lang/String;)V
+    // parameter  name
    L0
     ALOAD 0
     INVOKESPECIAL java/lang/Record.<init> ()V
@@ -5967,6 +5974,7 @@ public final class example/MyRecord extends java/lang/Record implements java/uti
 
   // access flags 0x1
   public <init>(Ljava/lang/String;)V
+    // parameter  get
    L0
     ALOAD 0
     INVOKESPECIAL java/lang/Record.<init> ()V
@@ -6094,6 +6102,7 @@ public final class example/Outer$Inner extends java/lang/Record {
 
   // access flags 0x1
   public <init>(I)V
+    // parameter  id
    L0
     ALOAD 0
     INVOKESPECIAL java/lang/Record.<init> ()V
@@ -6510,6 +6519,7 @@ public final class example/MyRecord extends java/lang/Record {
 
   // access flags 0x1
   public <init>(Ljava/lang/String;)V
+    // parameter  name
    L0
     ALOAD 0
     INVOKESPECIAL java/lang/Record.<init> ()V

--- a/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
+++ b/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
@@ -357,7 +357,7 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
     private void buildFields(ObjectDef objectDef, List<FieldDef> fields, TypeSpec.Builder builder) {
         for (FieldDef field : fields) {
             FieldSpec.Builder fieldBuilder = FieldSpec.builder(
-                asType(field.getType(), objectDef),
+                asType(field.getType(), objectDef, field.getModifiers().contains(Modifier.STATIC)),
                 field.getName()
             ).addModifiers(field.getModifiersArray());
             field.getInitializer().ifPresent(init ->
@@ -490,23 +490,35 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
     }
 
     private TypeName asType(TypeDef typeDef, @Nullable ObjectDef objectDef) {
-        return asType(typeDef, objectDef, null);
+        return asType(typeDef, objectDef, null, false);
     }
 
     private TypeName asType(TypeDef typeDef, @Nullable ObjectDef objectDef, @Nullable MethodDef methodDef) {
+        return asType(typeDef, objectDef, methodDef,
+            methodDef != null && methodDef.getModifiers().contains(Modifier.STATIC));
+    }
+
+    private TypeName asType(TypeDef typeDef, @Nullable ObjectDef objectDef, boolean staticContext) {
+        return asType(typeDef, objectDef, null, staticContext);
+    }
+
+    private TypeName asType(TypeDef typeDef,
+                            @Nullable ObjectDef objectDef,
+                            @Nullable MethodDef methodDef,
+                            boolean staticContext) {
         if (typeDef.equals(TypeDef.THIS)) {
             if (objectDef == null) {
                 throw new IllegalStateException("This type is used outside of the instance scope!");
             }
             // The scope is kept: the self type of a generic definition carries the variables it declares
-            return asType(objectDef.asTypeDef(), objectDef, methodDef);
+            return asType(objectDef.asTypeDef(), staticContext ? null : objectDef, methodDef, staticContext);
         }
         if (typeDef.equals(TypeDef.SUPER)) {
             if (objectDef == null) {
                 throw new IllegalStateException("Super type is used outside of the instance scope!");
             }
             if (objectDef instanceof ClassDef classDef) {
-                return asType(Objects.requireNonNullElse(classDef.getSuperclass(), ClassTypeDef.OBJECT), objectDef);
+                return asType(Objects.requireNonNullElse(classDef.getSuperclass(), ClassTypeDef.OBJECT), objectDef, methodDef, staticContext);
             }
             if (objectDef instanceof EnumDef) {
                 return asClassType(ClassTypeDef.of(Enum.class));
@@ -515,7 +527,7 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
         }
         switch (typeDef) {
             case TypeDef.Array array -> {
-                TypeName arrayTypeName = ArrayTypeName.of(asType(array.componentType(), objectDef));
+                TypeName arrayTypeName = ArrayTypeName.of(asType(array.componentType(), objectDef, methodDef, staticContext));
                 for (int i = 1; i < array.dimensions(); ++i) {
                     arrayTypeName = ArrayTypeName.of(arrayTypeName);
                 }
@@ -524,7 +536,7 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
             case ClassTypeDef.Parameterized parameterized -> {
                 return ParameterizedTypeName.get(
                     asClassType(parameterized.rawType()),
-                    parameterized.typeArguments().stream().map(t -> asType(t, objectDef, methodDef)).toArray(TypeName[]::new)
+                    parameterized.typeArguments().stream().map(t -> asType(t, objectDef, methodDef, staticContext)).toArray(TypeName[]::new)
                 );
             }
             case TypeDef.Primitive primitive -> {
@@ -544,7 +556,7 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
             }
             case ClassTypeDef.AnnotatedClassTypeDef annotatedType -> {
                 var annotationsSpecs = annotatedType.annotations().stream().map(this::asAnnotationSpec).toList();
-                return asType(annotatedType.typeDef(), objectDef).annotated(annotationsSpecs);
+                return asType(annotatedType.typeDef(), objectDef, methodDef, staticContext).annotated(annotationsSpecs);
             }
             case ClassTypeDef classType -> {
                 return asClassType(classType);
@@ -554,38 +566,48 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
                     return WildcardTypeName.supertypeOf(
                         asType(
                             wildcard.lowerBounds().get(0),
-                            objectDef
+                            objectDef,
+                            methodDef,
+                            staticContext
                         )
                     );
                 }
                 return WildcardTypeName.subtypeOf(
                     asType(
                         wildcard.upperBounds().get(0),
-                        objectDef
+                        objectDef,
+                        methodDef,
+                        staticContext
                     )
                 );
             }
             case TypeDef.TypeVariable typeVariable -> {
-                if (isVariablePartOfTheDefinition(typeVariable.name(), objectDef, methodDef)) {
+                if (isVariablePartOfTheDefinition(typeVariable.name(), objectDef, methodDef, staticContext)) {
                     return asTypeVariable(typeVariable, objectDef);
                 }
                 if (typeVariable.bounds().isEmpty()) {
-                    return asType(ClassTypeDef.OBJECT, objectDef);
+                    return asType(ClassTypeDef.OBJECT, objectDef, methodDef, staticContext);
                 }
-                return asType(typeVariable.bounds().get(0), objectDef);
+                return asType(typeVariable.bounds().get(0), objectDef, methodDef, staticContext);
             }
             case TypeDef.AnnotatedTypeDef annotatedType -> {
                 var annotationsSpecs = annotatedType.annotations().stream().map(this::asAnnotationSpec).toList();
-                return asType(annotatedType.typeDef(), objectDef).annotated(annotationsSpecs);
+                return asType(annotatedType.typeDef(), objectDef, methodDef, staticContext).annotated(annotationsSpecs);
             }
             default -> throw new IllegalStateException("Unrecognized type definition " + typeDef);
         }
     }
 
-    private static boolean isVariablePartOfTheDefinition(String variableName, @Nullable ObjectDef objectDef, @Nullable MethodDef methodDef) {
+    private static boolean isVariablePartOfTheDefinition(String variableName,
+                                                         @Nullable ObjectDef objectDef,
+                                                         @Nullable MethodDef methodDef,
+                                                         boolean staticContext) {
         if (methodDef != null
             && methodDef.getTypeVariables().stream().anyMatch(v -> v.name().equals(variableName))) {
             return true;
+        }
+        if (staticContext) {
+            return false;
         }
         return switch (objectDef) {
             case ClassDef classDef -> classDef.getTypeVariables().stream()

--- a/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
+++ b/sourcegen-generator-java/src/main/java/io/micronaut/sourcegen/JavaPoetSourceGenerator.java
@@ -507,31 +507,14 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
                             @Nullable MethodDef methodDef,
                             boolean staticContext) {
         if (typeDef.equals(TypeDef.THIS)) {
-            if (objectDef == null) {
-                throw new IllegalStateException("This type is used outside of the instance scope!");
-            }
-            // The scope is kept: the self type of a generic definition carries the variables it declares
-            return asType(objectDef.asTypeDef(), staticContext ? null : objectDef, methodDef, staticContext);
+            return asSelfType(objectDef, methodDef, staticContext);
         }
         if (typeDef.equals(TypeDef.SUPER)) {
-            if (objectDef == null) {
-                throw new IllegalStateException("Super type is used outside of the instance scope!");
-            }
-            if (objectDef instanceof ClassDef classDef) {
-                return asType(Objects.requireNonNullElse(classDef.getSuperclass(), ClassTypeDef.OBJECT), objectDef, methodDef, staticContext);
-            }
-            if (objectDef instanceof EnumDef) {
-                return asClassType(ClassTypeDef.of(Enum.class));
-            }
-            throw new IllegalStateException("Super type is not supported for " + objectDef);
+            return asSuperType(objectDef, methodDef, staticContext);
         }
         switch (typeDef) {
             case TypeDef.Array array -> {
-                TypeName arrayTypeName = ArrayTypeName.of(asType(array.componentType(), objectDef, methodDef, staticContext));
-                for (int i = 1; i < array.dimensions(); ++i) {
-                    arrayTypeName = ArrayTypeName.of(arrayTypeName);
-                }
-                return arrayTypeName;
+                return asArrayType(array, objectDef, methodDef, staticContext);
             }
             case ClassTypeDef.Parameterized parameterized -> {
                 return ParameterizedTypeName.get(
@@ -540,19 +523,7 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
                 );
             }
             case TypeDef.Primitive primitive -> {
-                return switch (primitive.name()) {
-                    case "void" -> TypeName.VOID;
-                    case "byte" -> TypeName.BYTE;
-                    case "short" -> TypeName.SHORT;
-                    case "char" -> TypeName.CHAR;
-                    case "int" -> TypeName.INT;
-                    case "long" -> TypeName.LONG;
-                    case "float" -> TypeName.FLOAT;
-                    case "double" -> TypeName.DOUBLE;
-                    case "boolean" -> TypeName.BOOLEAN;
-                    default ->
-                        throw new IllegalStateException("Unrecognized primitive name: " + primitive.name());
-                };
+                return asPrimitiveType(primitive);
             }
             case ClassTypeDef.AnnotatedClassTypeDef annotatedType -> {
                 var annotationsSpecs = annotatedType.annotations().stream().map(this::asAnnotationSpec).toList();
@@ -562,33 +533,10 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
                 return asClassType(classType);
             }
             case TypeDef.Wildcard wildcard -> {
-                if (!wildcard.lowerBounds().isEmpty()) {
-                    return WildcardTypeName.supertypeOf(
-                        asType(
-                            wildcard.lowerBounds().get(0),
-                            objectDef,
-                            methodDef,
-                            staticContext
-                        )
-                    );
-                }
-                return WildcardTypeName.subtypeOf(
-                    asType(
-                        wildcard.upperBounds().get(0),
-                        objectDef,
-                        methodDef,
-                        staticContext
-                    )
-                );
+                return asWildcardType(wildcard, objectDef, methodDef, staticContext);
             }
             case TypeDef.TypeVariable typeVariable -> {
-                if (isVariablePartOfTheDefinition(typeVariable.name(), objectDef, methodDef, staticContext)) {
-                    return asTypeVariable(typeVariable, objectDef);
-                }
-                if (typeVariable.bounds().isEmpty()) {
-                    return asType(ClassTypeDef.OBJECT, objectDef, methodDef, staticContext);
-                }
-                return asType(typeVariable.bounds().get(0), objectDef, methodDef, staticContext);
+                return asTypeVariableType(typeVariable, objectDef, methodDef, staticContext);
             }
             case TypeDef.AnnotatedTypeDef annotatedType -> {
                 var annotationsSpecs = annotatedType.annotations().stream().map(this::asAnnotationSpec).toList();
@@ -596,6 +544,80 @@ public sealed class JavaPoetSourceGenerator implements SourceGenerator permits G
             }
             default -> throw new IllegalStateException("Unrecognized type definition " + typeDef);
         }
+    }
+
+    /**
+     * The self type in the scope it is written in. In a static context the enclosing definition is dropped,
+     * so its type variables are not treated as being in scope.
+     */
+    private TypeName asSelfType(@Nullable ObjectDef objectDef, @Nullable MethodDef methodDef, boolean staticContext) {
+        if (objectDef == null) {
+            throw new IllegalStateException("This type is used outside of the instance scope!");
+        }
+        // The scope is kept: the self type of a generic definition carries the variables it declares
+        return asType(objectDef.asTypeDef(), staticContext ? null : objectDef, methodDef, staticContext);
+    }
+
+    private TypeName asSuperType(@Nullable ObjectDef objectDef, @Nullable MethodDef methodDef, boolean staticContext) {
+        if (objectDef == null) {
+            throw new IllegalStateException("Super type is used outside of the instance scope!");
+        }
+        if (objectDef instanceof ClassDef classDef) {
+            return asType(Objects.requireNonNullElse(classDef.getSuperclass(), ClassTypeDef.OBJECT), objectDef, methodDef, staticContext);
+        }
+        if (objectDef instanceof EnumDef) {
+            return asClassType(ClassTypeDef.of(Enum.class));
+        }
+        throw new IllegalStateException("Super type is not supported for " + objectDef);
+    }
+
+    private TypeName asArrayType(TypeDef.Array array,
+                                 @Nullable ObjectDef objectDef,
+                                 @Nullable MethodDef methodDef,
+                                 boolean staticContext) {
+        TypeName arrayTypeName = ArrayTypeName.of(asType(array.componentType(), objectDef, methodDef, staticContext));
+        for (int i = 1; i < array.dimensions(); ++i) {
+            arrayTypeName = ArrayTypeName.of(arrayTypeName);
+        }
+        return arrayTypeName;
+    }
+
+    private TypeName asWildcardType(TypeDef.Wildcard wildcard,
+                                    @Nullable ObjectDef objectDef,
+                                    @Nullable MethodDef methodDef,
+                                    boolean staticContext) {
+        if (!wildcard.lowerBounds().isEmpty()) {
+            return WildcardTypeName.supertypeOf(asType(wildcard.lowerBounds().get(0), objectDef, methodDef, staticContext));
+        }
+        return WildcardTypeName.subtypeOf(asType(wildcard.upperBounds().get(0), objectDef, methodDef, staticContext));
+    }
+
+    private TypeName asTypeVariableType(TypeDef.TypeVariable typeVariable,
+                                        @Nullable ObjectDef objectDef,
+                                        @Nullable MethodDef methodDef,
+                                        boolean staticContext) {
+        if (isVariablePartOfTheDefinition(typeVariable.name(), objectDef, methodDef, staticContext)) {
+            return asTypeVariable(typeVariable, objectDef);
+        }
+        if (typeVariable.bounds().isEmpty()) {
+            return asType(ClassTypeDef.OBJECT, objectDef, methodDef, staticContext);
+        }
+        return asType(typeVariable.bounds().get(0), objectDef, methodDef, staticContext);
+    }
+
+    private static TypeName asPrimitiveType(TypeDef.Primitive primitive) {
+        return switch (primitive.name()) {
+            case "void" -> TypeName.VOID;
+            case "byte" -> TypeName.BYTE;
+            case "short" -> TypeName.SHORT;
+            case "char" -> TypeName.CHAR;
+            case "int" -> TypeName.INT;
+            case "long" -> TypeName.LONG;
+            case "float" -> TypeName.FLOAT;
+            case "double" -> TypeName.DOUBLE;
+            case "boolean" -> TypeName.BOOLEAN;
+            default -> throw new IllegalStateException("Unrecognized primitive name: " + primitive.name());
+        };
     }
 
     private static boolean isVariablePartOfTheDefinition(String variableName,

--- a/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/RecordWriteTest.java
+++ b/sourcegen-generator-java/src/test/java/io/micronaut/sourcegen/javapoet/write/RecordWriteTest.java
@@ -17,6 +17,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class RecordWriteTest {
@@ -211,6 +212,32 @@ public class RecordWriteTest {
         }
         """;
         assertEquals(expected.strip(), result.strip());
+    }
+
+    @Test
+    public void staticSelfTypeDoesNotUseRecordTypeVariables() throws IOException {
+        RecordDef recordDef = RecordDef.builder("test.StaticSelfRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addTypeVariable(TypeDef.variable("T"))
+            .addMethod(MethodDef.builder("create")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .returns(TypeDef.THIS)
+                .build((aThis, parameters) -> ClassTypeDef.of(UnsupportedOperationException.class)
+                    .instantiate()
+                    .doThrow()))
+            .build();
+
+        String source = writeRecordFile(recordDef);
+
+        assertTrue(source.contains("static StaticSelfRecord<Object> create()"), source);
+        JavaCompileAssertions.assertCompiles(source);
+    }
+
+    private String writeRecordFile(RecordDef recordDef) throws IOException {
+        try (StringWriter writer = new StringWriter()) {
+            new JavaPoetSourceGenerator().write(recordDef, writer);
+            return writer.toString();
+        }
     }
 
 }

--- a/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
+++ b/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
@@ -864,78 +864,96 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             methodDef: MethodDef?,
             staticContext: Boolean,
         ): TypeName {
-            val result: TypeName = if (typeDef == TypeDef.THIS) {
-                if (objectDef == null) {
-                    throw java.lang.IllegalStateException("This type is used outside of the instance scope!")
-                }
-                // The scope is kept: the self type of a generic definition carries the variables it declares
-                asType(objectDef.asTypeDef(), if (staticContext) null else objectDef, methodDef, staticContext)
-            } else if (typeDef is TypeDef.Array) {
-                asArray(typeDef, objectDef, methodDef, staticContext)
-            } else if (typeDef is ClassTypeDef.Parameterized) {
-                asClassName(typeDef.rawType).parameterizedBy(
+            val result: TypeName = when {
+                typeDef == TypeDef.THIS -> asSelfType(objectDef, methodDef, staticContext)
+                typeDef is TypeDef.Array -> asArray(typeDef, objectDef, methodDef, staticContext)
+                typeDef is ClassTypeDef.Parameterized -> asClassName(typeDef.rawType).parameterizedBy(
                     typeDef.typeArguments.map { v: TypeDef -> this.asType(v, objectDef, methodDef, staticContext) }
                 )
-            } else if (typeDef is TypeDef.Primitive) {
-                when (typeDef.name()) {
-                    "void" -> UNIT
-                    "byte" -> com.squareup.javapoet.TypeName.BYTE.toKTypeName()
-                    "short" -> com.squareup.javapoet.TypeName.SHORT.toKTypeName()
-                    "char" -> com.squareup.javapoet.TypeName.CHAR.toKTypeName()
-                    "int" -> com.squareup.javapoet.TypeName.INT.toKTypeName()
-                    "long" -> com.squareup.javapoet.TypeName.LONG.toKTypeName()
-                    "float" -> com.squareup.javapoet.TypeName.FLOAT.toKTypeName()
-                    "double" -> com.squareup.javapoet.TypeName.DOUBLE.toKTypeName()
-                    "boolean" -> com.squareup.javapoet.TypeName.BOOLEAN.toKTypeName()
-                    else -> unrecognizedPrimitive(typeDef.name())
-                }
-            } else if (typeDef is ClassTypeDef) {
-                asClassName(typeDef)
-            } else if (typeDef is ClassTypeDef.AnnotatedClassTypeDef) {
-                asType(typeDef.typeDef, objectDef, methodDef, staticContext).copy(
-                    typeDef.typeDef.isNullable,
-                    typeDef.annotations.stream().map{ asAnnotationSpec(it) }.toList()
+                typeDef is TypeDef.Primitive -> asPrimitive(typeDef)
+                typeDef is ClassTypeDef -> asClassName(typeDef)
+                typeDef is ClassTypeDef.AnnotatedClassTypeDef -> asAnnotated(
+                    typeDef.typeDef, typeDef.annotations, objectDef, methodDef, staticContext
                 )
-            } else if (typeDef is TypeDef.Wildcard) {
-                if (typeDef.lowerBounds.isNotEmpty()) {
-                    WildcardTypeName.consumerOf(
-                        asType(
-                            typeDef.lowerBounds[0],
-                            objectDef,
-                            methodDef,
-                            staticContext,
-                        )
-                    )
-                } else {
-                    WildcardTypeName.producerOf(
-                        asType(
-                            typeDef.upperBounds[0],
-                            objectDef,
-                            methodDef,
-                            staticContext,
-                        )
-                    )
-                }
-            } else if (typeDef is TypeDef.TypeVariable) {
-                if (isVariablePartOfTheDefinition(typeDef.name, objectDef, methodDef, staticContext)) {
-                    return asTypeVariable(typeDef, objectDef)
-                }
-                if (typeDef.bounds.isEmpty()) {
-                    return asType(TypeDef.OBJECT, objectDef, methodDef, staticContext)
-                }
-                return asType(typeDef.bounds.get(0), objectDef, methodDef, staticContext)
-            } else if (typeDef is TypeDef.Annotated && typeDef is TypeDef.AnnotatedTypeDef) {
-                return asType(typeDef.typeDef, objectDef, methodDef, staticContext).copy(
-                    typeDef.typeDef.isNullable,
-                    typeDef.annotations.stream().map{ asAnnotationSpec(it) }.toList()
+                typeDef is TypeDef.Wildcard -> asWildcard(typeDef, objectDef, methodDef, staticContext)
+                typeDef is TypeDef.TypeVariable ->
+                    return asTypeVariableType(typeDef, objectDef, methodDef, staticContext)
+                typeDef is TypeDef.Annotated && typeDef is TypeDef.AnnotatedTypeDef -> return asAnnotated(
+                    typeDef.typeDef, typeDef.annotations, objectDef, methodDef, staticContext
                 )
-            } else {
-                throw IllegalStateException("Unrecognized type definition $typeDef")
+                else -> throw IllegalStateException("Unrecognized type definition $typeDef")
             }
             if (typeDef.isNullable) {
                 return asNullable(result)
             }
             return result
+        }
+
+        /**
+         * The self type in the scope it is written in. In a static context the enclosing definition is
+         * dropped, so its type variables are not treated as being in scope.
+         */
+        @OptIn(KotlinPoetJavaPoetPreview::class)
+        private fun asSelfType(objectDef: ObjectDef?, methodDef: MethodDef?, staticContext: Boolean): TypeName {
+            if (objectDef == null) {
+                throw java.lang.IllegalStateException("This type is used outside of the instance scope!")
+            }
+            // The scope is kept: the self type of a generic definition carries the variables it declares
+            return asType(objectDef.asTypeDef(), if (staticContext) null else objectDef, methodDef, staticContext)
+        }
+
+        @OptIn(KotlinPoetJavaPoetPreview::class)
+        private fun asAnnotated(
+            typeDef: TypeDef,
+            annotations: List<AnnotationDef>,
+            objectDef: ObjectDef?,
+            methodDef: MethodDef?,
+            staticContext: Boolean,
+        ): TypeName = asType(typeDef, objectDef, methodDef, staticContext).copy(
+            typeDef.isNullable,
+            annotations.map { asAnnotationSpec(it) }
+        )
+
+        @OptIn(KotlinPoetJavaPoetPreview::class)
+        private fun asWildcard(
+            typeDef: TypeDef.Wildcard,
+            objectDef: ObjectDef?,
+            methodDef: MethodDef?,
+            staticContext: Boolean,
+        ): TypeName = if (typeDef.lowerBounds.isNotEmpty()) {
+            WildcardTypeName.consumerOf(asType(typeDef.lowerBounds[0], objectDef, methodDef, staticContext))
+        } else {
+            WildcardTypeName.producerOf(asType(typeDef.upperBounds[0], objectDef, methodDef, staticContext))
+        }
+
+        @OptIn(KotlinPoetJavaPoetPreview::class)
+        private fun asTypeVariableType(
+            typeDef: TypeDef.TypeVariable,
+            objectDef: ObjectDef?,
+            methodDef: MethodDef?,
+            staticContext: Boolean,
+        ): TypeName {
+            if (isVariablePartOfTheDefinition(typeDef.name, objectDef, methodDef, staticContext)) {
+                return asTypeVariable(typeDef, objectDef)
+            }
+            if (typeDef.bounds.isEmpty()) {
+                return asType(TypeDef.OBJECT, objectDef, methodDef, staticContext)
+            }
+            return asType(typeDef.bounds[0], objectDef, methodDef, staticContext)
+        }
+
+        @OptIn(KotlinPoetJavaPoetPreview::class)
+        private fun asPrimitive(typeDef: TypeDef.Primitive): TypeName = when (typeDef.name()) {
+            "void" -> UNIT
+            "byte" -> com.squareup.javapoet.TypeName.BYTE.toKTypeName()
+            "short" -> com.squareup.javapoet.TypeName.SHORT.toKTypeName()
+            "char" -> com.squareup.javapoet.TypeName.CHAR.toKTypeName()
+            "int" -> com.squareup.javapoet.TypeName.INT.toKTypeName()
+            "long" -> com.squareup.javapoet.TypeName.LONG.toKTypeName()
+            "float" -> com.squareup.javapoet.TypeName.FLOAT.toKTypeName()
+            "double" -> com.squareup.javapoet.TypeName.DOUBLE.toKTypeName()
+            "boolean" -> com.squareup.javapoet.TypeName.BOOLEAN.toKTypeName()
+            else -> unrecognizedPrimitive(typeDef.name())
         }
 
         private fun isVariablePartOfTheDefinition(

--- a/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
+++ b/sourcegen-generator-kotlin/src/main/kotlin/io/micronaut/sourcegen/KotlinPoetSourceGenerator.kt
@@ -206,7 +206,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 }
                 modifiers = stripStatic(modifiers)
                 companionBuilder.addFunction(
-                    buildFunction(null, method, modifiers)
+                    buildFunction(interfaceDef, method, modifiers)
                 )
             } else {
                 interfaceBuilder.addFunction(
@@ -270,7 +270,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 }
                 modifiers = stripStatic(modifiers)
                 currentCompanion.addFunction(
-                    buildFunction(null, method, modifiers)
+                    buildFunction(classDef, method, modifiers)
                 )
             } else if (method.name == "<init>") {
                 val superCallStatement = method.statements.firstOrNull {
@@ -401,7 +401,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 }
                 modifiers = stripStatic(modifiers)
                 companionBuilder.addFunction(
-                    buildFunction(null, method, modifiers)
+                    buildFunction(recordDef, method, modifiers)
                 )
             } else {
                 classBuilder.addFunction(
@@ -475,7 +475,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 }
                 modifiers = stripStatic(modifiers)
                 companionBuilder.addFunction(
-                    buildFunction(null, method, modifiers)
+                    buildFunction(enumDef, method, modifiers)
                 )
             } else {
                 enumBuilder.addFunction(
@@ -615,11 +615,12 @@ class KotlinPoetSourceGenerator : SourceGenerator {
         modifiers: Set<Modifier>,
         annotations: List<AnnotationDef>,
         docs: List<String>, initializer: ExpressionDef?,
-        objectDef: ObjectDef?
+        objectDef: ObjectDef?,
+        staticContext: Boolean = false,
     ): PropertySpec {
         val propertyBuilder = PropertySpec.builder(
             name,
-            asType(typeDef, objectDef),
+            asType(typeDef, objectDef, staticContext),
             asKModifiers(modifiers)
         )
         docs.forEach(Consumer { format: String -> propertyBuilder.addKdoc(format) })
@@ -683,7 +684,8 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             field.annotations,
             docs,
             field.initializer.orElse(null),
-            objectDef
+            objectDef,
+            field.modifiers.contains(Modifier.STATIC),
         )
     }
 
@@ -691,7 +693,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
         var funBuilder = if (method.name == "<init>") {
             FunSpec.constructorBuilder()
         } else {
-            FunSpec.builder(method.name).returns(asType(method.returnType, objectDef))
+            FunSpec.builder(method.name).returns(asType(method.returnType, objectDef, method))
         }
         funBuilder = funBuilder
             .addModifiers(asKModifiers(method, modifiers))
@@ -700,7 +702,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                     .map { param: ParameterDef ->
                         ParameterSpec.builder(
                             param.name,
-                            asType(param.type, objectDef)
+                            asType(param.type, objectDef, method)
                         ).build()
                     }
                     .toList()
@@ -718,14 +720,15 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                 AnnotationSpec.builder(Throws::class)
                     .addMember(
                         method.throwTypes.joinToString { "%T::class" },
-                        *method.throwTypes.map { asType(it, objectDef) }.toTypedArray()
+                        *method.throwTypes.map { asType(it, objectDef, method) }.toTypedArray()
                     )
                     .build(),
             )
         }
         val scope = RenderScope.root(method)
+        val renderingObjectDef = if (method.modifiers.contains(Modifier.STATIC)) null else objectDef
         method.statements.stream()
-            .map { st: StatementDef -> renderStatementCodeBlock(objectDef, method, scope, st) }
+            .map { st: StatementDef -> renderStatementCodeBlock(renderingObjectDef, method, scope, st) }
             .forEach(funBuilder::addCode)
         method.javadoc.forEach(Consumer { format: String -> funBuilder.addKdoc(format) })
         return funBuilder.build()
@@ -836,22 +839,42 @@ class KotlinPoetSourceGenerator : SourceGenerator {
 
         @OptIn(KotlinPoetJavaPoetPreview::class)
         private fun asType(typeDef: TypeDef?, objectDef: ObjectDef?): TypeName {
-            return asType(typeDef, objectDef, null)
+            return asType(typeDef, objectDef, null, false)
         }
 
         @OptIn(KotlinPoetJavaPoetPreview::class)
         private fun asType(typeDef: TypeDef?, objectDef: ObjectDef?, methodDef: MethodDef?): TypeName {
+            return asType(
+                typeDef,
+                objectDef,
+                methodDef,
+                methodDef != null && methodDef.modifiers.contains(Modifier.STATIC),
+            )
+        }
+
+        @OptIn(KotlinPoetJavaPoetPreview::class)
+        private fun asType(typeDef: TypeDef?, objectDef: ObjectDef?, staticContext: Boolean): TypeName {
+            return asType(typeDef, objectDef, null, staticContext)
+        }
+
+        @OptIn(KotlinPoetJavaPoetPreview::class)
+        private fun asType(
+            typeDef: TypeDef?,
+            objectDef: ObjectDef?,
+            methodDef: MethodDef?,
+            staticContext: Boolean,
+        ): TypeName {
             val result: TypeName = if (typeDef == TypeDef.THIS) {
                 if (objectDef == null) {
                     throw java.lang.IllegalStateException("This type is used outside of the instance scope!")
                 }
                 // The scope is kept: the self type of a generic definition carries the variables it declares
-                asType(objectDef.asTypeDef(), objectDef, methodDef)
+                asType(objectDef.asTypeDef(), if (staticContext) null else objectDef, methodDef, staticContext)
             } else if (typeDef is TypeDef.Array) {
-                asArray(typeDef, objectDef)
+                asArray(typeDef, objectDef, methodDef, staticContext)
             } else if (typeDef is ClassTypeDef.Parameterized) {
                 asClassName(typeDef.rawType).parameterizedBy(
-                    typeDef.typeArguments.map { v: TypeDef -> this.asType(v, objectDef) }
+                    typeDef.typeArguments.map { v: TypeDef -> this.asType(v, objectDef, methodDef, staticContext) }
                 )
             } else if (typeDef is TypeDef.Primitive) {
                 when (typeDef.name()) {
@@ -869,7 +892,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             } else if (typeDef is ClassTypeDef) {
                 asClassName(typeDef)
             } else if (typeDef is ClassTypeDef.AnnotatedClassTypeDef) {
-                asType(typeDef.typeDef, objectDef).copy(
+                asType(typeDef.typeDef, objectDef, methodDef, staticContext).copy(
                     typeDef.typeDef.isNullable,
                     typeDef.annotations.stream().map{ asAnnotationSpec(it) }.toList()
                 )
@@ -878,27 +901,31 @@ class KotlinPoetSourceGenerator : SourceGenerator {
                     WildcardTypeName.consumerOf(
                         asType(
                             typeDef.lowerBounds[0],
-                            objectDef
+                            objectDef,
+                            methodDef,
+                            staticContext,
                         )
                     )
                 } else {
                     WildcardTypeName.producerOf(
                         asType(
                             typeDef.upperBounds[0],
-                            objectDef
+                            objectDef,
+                            methodDef,
+                            staticContext,
                         )
                     )
                 }
             } else if (typeDef is TypeDef.TypeVariable) {
-                if (isVariablePartOfTheDefinition(typeDef.name, objectDef, methodDef)) {
+                if (isVariablePartOfTheDefinition(typeDef.name, objectDef, methodDef, staticContext)) {
                     return asTypeVariable(typeDef, objectDef)
                 }
                 if (typeDef.bounds.isEmpty()) {
-                    return asType(TypeDef.OBJECT, objectDef)
+                    return asType(TypeDef.OBJECT, objectDef, methodDef, staticContext)
                 }
-                return asType(typeDef.bounds.get(0), objectDef)
+                return asType(typeDef.bounds.get(0), objectDef, methodDef, staticContext)
             } else if (typeDef is TypeDef.Annotated && typeDef is TypeDef.AnnotatedTypeDef) {
-                return asType(typeDef.typeDef, objectDef).copy(
+                return asType(typeDef.typeDef, objectDef, methodDef, staticContext).copy(
                     typeDef.typeDef.isNullable,
                     typeDef.annotations.stream().map{ asAnnotationSpec(it) }.toList()
                 )
@@ -914,12 +941,16 @@ class KotlinPoetSourceGenerator : SourceGenerator {
         private fun isVariablePartOfTheDefinition(
             variableName: String,
             objectDef: ObjectDef?,
-            methodDef: MethodDef?
+            methodDef: MethodDef?,
+            staticContext: Boolean,
         ): Boolean {
             if (methodDef != null
                 && methodDef.typeVariables.stream().anyMatch { v: TypeDef.TypeVariable -> v.name == variableName }
             ) {
                 return true
+            }
+            if (staticContext) {
+                return false
             }
             if (objectDef != null) {
                 if (objectDef is ClassDef) {
@@ -945,7 +976,12 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             )
         }
 
-        private fun asArray(classType: TypeDef.Array, objectDef: ObjectDef?): TypeName {
+        private fun asArray(
+            classType: TypeDef.Array,
+            objectDef: ObjectDef?,
+            methodDef: MethodDef?,
+            staticContext: Boolean,
+        ): TypeName {
             val componentType = classType.componentType
             // Kotlin has a dedicated type per primitive array, Array<Int> is an Integer[]
             val primitiveArray = primitiveArrayType(componentType)
@@ -954,7 +990,7 @@ class KotlinPoetSourceGenerator : SourceGenerator {
             for (i in 2..classType.dimensions) {
                 newDef = ClassTypeDef.Parameterized(ClassTypeDef.of("kotlin.Array"), listOf(newDef))
             }
-            return asType(newDef, objectDef)
+            return asType(newDef, objectDef, methodDef, staticContext)
         }
 
         /**

--- a/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/RecordWriteTest.kt
+++ b/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/RecordWriteTest.kt
@@ -77,6 +77,28 @@ class RecordWriteTest {
         Assertions.assertEquals(expected.trim(), write(recordDef).trim())
     }
 
+    @Test
+    fun staticSelfTypeDoesNotUseRecordTypeVariables() {
+        val recordDef = RecordDef.builder("test.StaticSelfRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addTypeVariable(TypeDef.variable("T"))
+            .addMethod(
+                MethodDef.builder("create")
+                    .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                    .returns(TypeDef.THIS)
+                    .build { _, _ ->
+                        ClassTypeDef.of(UnsupportedOperationException::class.java)
+                            .instantiate()
+                            .doThrow()
+                    }
+            )
+            .build()
+
+        val source = write(recordDef)
+
+        Assertions.assertTrue(source.contains("fun create(): StaticSelfRecord<Any>"), source)
+    }
+
     private fun write(recordDef: RecordDef): String {
         val generator = KotlinPoetSourceGenerator()
         StringWriter().use { writer ->

--- a/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/RecordWriteTest.kt
+++ b/sourcegen-generator-kotlin/src/test/kotlin/io/micronaut/sourcegen/RecordWriteTest.kt
@@ -99,6 +99,41 @@ class RecordWriteTest {
         Assertions.assertTrue(source.contains("fun create(): StaticSelfRecord<Any>"), source)
     }
 
+    @Test
+    fun writeWildcardsAndOutOfScopeVariables() {
+        val recordDef = RecordDef.builder("test.WildcardRecord")
+            .addModifiers(Modifier.PUBLIC)
+            .addProperty(
+                PropertyDef.builder("producers").ofType(
+                    TypeDef.parameterized(
+                        ClassTypeDef.of(java.util.List::class.java),
+                        TypeDef.wildcardSubtypeOf(TypeDef.of(Number::class.java))
+                    )
+                ).build()
+            )
+            .addProperty(
+                PropertyDef.builder("consumers").ofType(
+                    TypeDef.parameterized(
+                        ClassTypeDef.of(java.util.List::class.java),
+                        TypeDef.wildcardSupertypeOf(TypeDef.of(Number::class.java))
+                    )
+                ).build()
+            )
+            // A variable neither the record nor the method declares falls back to its bound
+            .addProperty(
+                PropertyDef.builder("bound").ofType(TypeDef.variable("U", TypeDef.of(CharSequence::class.java))).build()
+            )
+            .addProperty(PropertyDef.builder("unbound").ofType(TypeDef.variable("W")).build())
+            .build()
+
+        val source = write(recordDef)
+
+        Assertions.assertTrue(source.contains("val producers: List<out Number>"), source)
+        Assertions.assertTrue(source.contains("val consumers: List<in Number>"), source)
+        Assertions.assertTrue(source.contains("val bound: CharSequence"), source)
+        Assertions.assertTrue(source.contains("val unbound: Any"), source)
+    }
+
     private fun write(recordDef: RecordDef): String {
         val generator = KotlinPoetSourceGenerator()
         StringWriter().use { writer ->

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
@@ -692,7 +692,11 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                         // List.of()
                         ExpressionDef.constant(0), javaListType.invokeStatic("of", javaListType),
                         // List.of(single)
-                        ExpressionDef.constant(1), javaListType.invokeStatic("of", javaListType, field.invoke("get", elementType, ExpressionDef.constant(0)))
+                        ExpressionDef.constant(1), javaListType.invokeStatic(
+                            "of",
+                            javaListType,
+                            field.invoke("get", ClassTypeDef.OBJECT, ExpressionDef.constant(0))
+                        )
                     ),
                     javaListType.invokeStatic("copyOf", javaListType, field)
                 );
@@ -705,7 +709,11 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                         // Set.of()
                         ExpressionDef.constant(0), setListType.invokeStatic("of", setListType),
                         // Set.of(single)
-                        ExpressionDef.constant(1), setListType.invokeStatic("of", setListType, field.invoke("get", elementType, ExpressionDef.constant(0)))
+                        ExpressionDef.constant(1), setListType.invokeStatic(
+                            "of",
+                            setListType,
+                            field.invoke("get", ClassTypeDef.OBJECT, ExpressionDef.constant(0))
+                        )
                     ),
                     // Collections.unmodifiableSet(new LinkedHashSet(all))
                     ClassTypeDef.of(Collections.class)

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/AnnotationObjectDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/AnnotationObjectDef.java
@@ -54,7 +54,7 @@ public final class AnnotationObjectDef extends ObjectDef {
 
     @Override
     public ObjectDef withClassName(ClassName className) {
-        return new AnnotationObjectDef(members, fields, className, modifiers, annotations, javadoc, innerTypes);
+        return new AnnotationObjectDef(members, fields, className, modifiers, annotations, javadoc, rebaseInnerTypes(className, innerTypes));
     }
 
     /**

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ClassDef.java
@@ -68,7 +68,7 @@ public final class ClassDef extends ObjectDef {
 
     @Override
     public ClassDef withClassName(ClassTypeDef.ClassName className) {
-        return new ClassDef(className, modifiers, fields, methods, properties, annotations, javadoc, typeVariables, superinterfaces, superclass, innerTypes, staticInitializer, synthetic);
+        return new ClassDef(className, modifiers, fields, methods, properties, annotations, javadoc, typeVariables, superinterfaces, superclass, rebaseInnerTypes(className, innerTypes), staticInitializer, synthetic);
     }
 
     @Override

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/EnumDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/EnumDef.java
@@ -60,7 +60,7 @@ public final class EnumDef extends ObjectDef {
 
     @Override
     public EnumDef withClassName(ClassTypeDef.ClassName className) {
-        return new EnumDef(className, modifiers, fields, methods, properties, annotations, javadoc, enumConstants, superinterfaces, innerTypes, synthetic);
+        return new EnumDef(className, modifiers, fields, methods, properties, annotations, javadoc, enumConstants, superinterfaces, rebaseInnerTypes(className, innerTypes), synthetic);
     }
 
     public static EnumDefBuilder builder(String name) {

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/InterfaceDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/InterfaceDef.java
@@ -49,7 +49,7 @@ public final class InterfaceDef extends ObjectDef {
 
     @Override
     public InterfaceDef withClassName(ClassTypeDef.ClassName className) {
-        return new InterfaceDef(className, modifiers, methods, properties, annotations, javadoc, typeVariables, superinterfaces, innerTypes, synthetic);
+        return new InterfaceDef(className, modifiers, methods, properties, annotations, javadoc, typeVariables, superinterfaces, rebaseInnerTypes(className, innerTypes), synthetic);
     }
 
     @Override

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ObjectDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/ObjectDef.java
@@ -90,6 +90,22 @@ public abstract sealed class ObjectDef extends AbstractElement permits ClassDef,
     public abstract ObjectDef withClassName(ClassTypeDef.ClassName className);
 
     /**
+     * Rebase member type names when their enclosing definition is itself moved below another type.
+     *
+     * @param className The new name of the enclosing definition
+     * @param innerTypes Its member types
+     * @return The member types with names rooted at the new enclosing name
+     */
+    static List<ObjectDef> rebaseInnerTypes(ClassTypeDef.ClassName className, List<ObjectDef> innerTypes) {
+        return innerTypes.stream()
+            .map(innerType -> innerType.withClassName(new ClassTypeDef.ClassName(
+                className.getName() + "$" + innerType.getSimpleName(),
+                true
+            )))
+            .toList();
+    }
+
+    /**
      * Get the type definition for this type.
      *
      * @return The type definition

--- a/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/RecordDef.java
+++ b/sourcegen-model/src/main/java/io/micronaut/sourcegen/model/RecordDef.java
@@ -67,7 +67,7 @@ public final class RecordDef extends ObjectDef {
 
     @Override
     public RecordDef withClassName(ClassTypeDef.ClassName className) {
-        return new RecordDef(className, modifiers, methods, properties, annotations, javadoc, typeVariables, superinterfaces, innerTypes, synthetic);
+        return new RecordDef(className, modifiers, methods, properties, annotations, javadoc, typeVariables, superinterfaces, rebaseInnerTypes(className, innerTypes), synthetic);
     }
 
     public static RecordDefBuilder builder(String name) {

--- a/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/MutableSingular.java
+++ b/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/MutableSingular.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import io.micronaut.sourcegen.annotations.Builder;
+import io.micronaut.sourcegen.annotations.Singular;
+
+import java.util.List;
+
+@Builder(annotatedWith = {})
+public final class MutableSingular {
+
+    @Singular
+    private List<String> names;
+
+    public List<String> getNames() {
+        return names;
+    }
+
+    public void setNames(List<String> names) {
+        this.names = names;
+    }
+}

--- a/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/MutableSingularTest.java
+++ b/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/MutableSingularTest.java
@@ -1,0 +1,20 @@
+package io.micronaut.sourcegen.example;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MutableSingularTest {
+
+    @Test
+    void buildsWritableSingularProperty() {
+        MutableSingular value = MutableSingularBuilder.builder()
+            .name("one")
+            .name("two")
+            .build();
+
+        assertEquals(List.of("one", "two"), value.getNames());
+    }
+}


### PR DESCRIPTION
## Summary
- correct deep nested-type names and JVM nest host/member metadata
- preserve generic arrays, wildcard variance, multiple bounds, and canonical record parameter metadata
- honor annotation retention and explicit targets, including nested arrays and class-valued members
- render static self types safely in Java and Kotlin generators
- fix writable singular builder fields and erased collection calls

## Verification
- ./gradlew check docs japiCmp spotlessCheck
- focused bytecode, Java generator, Kotlin generator, and builder regression tests