### PR TITLE
Share the signature logic and lower switch yield cases

### DIFF
--- a/sourcegen-bytecode-writer-core/src/main/java/io/micronaut/sourcegen/bytecode/core/SignatureUtils.java
+++ b/sourcegen-bytecode-writer-core/src/main/java/io/micronaut/sourcegen/bytecode/core/SignatureUtils.java
@@ -41,6 +41,13 @@ import java.util.Objects;
 @Internal
 public final class SignatureUtils {
 
+    /**
+     * Whether the class a bound names is an interface, kept per name so writing many bounds asks
+     * the class loader about each one once.
+     */
+    private static final java.util.Map<String, Boolean> NAMED_BOUND_IS_INTERFACE =
+        new java.util.concurrent.ConcurrentHashMap<>();
+
     private SignatureUtils() {
     }
 
@@ -160,7 +167,12 @@ public final class SignatureUtils {
 
     private static boolean needsSignature(TypeDef typeDef) {
         typeDef = unwrapAnnotated(typeDef);
-        return typeDef instanceof ClassTypeDef.Parameterized || typeDef instanceof TypeDef.TypeVariable;
+        if (typeDef instanceof TypeDef.Array array) {
+            return needsSignature(array.componentType());
+        }
+        return typeDef instanceof ClassTypeDef.Parameterized
+            || typeDef instanceof TypeDef.TypeVariable
+            || typeDef instanceof TypeDef.Wildcard;
     }
 
     private static void writeSignature(StringBuilder signature,
@@ -179,9 +191,7 @@ public final class SignatureUtils {
             if (!parameterized.typeArguments().isEmpty()) {
                 signature.append('<');
                 for (TypeDef argument : parameterized.typeArguments()) {
-                    // The ASM backend historically emits unbounded type arguments here. Preserve
-                    // that representation so both backends have identical signatures.
-                    writeSignature(signature, objectDef, methodDef, argument, false);
+                    writeTypeArgument(signature, objectDef, methodDef, argument);
                 }
                 signature.append('>');
             }
@@ -205,12 +215,7 @@ public final class SignatureUtils {
                                            boolean definition) {
         String name = variable.name();
         if (definition) {
-            signature.append(name).append(':');
-            if (variable.bounds().isEmpty()) {
-                appendClass(signature, Object.class.getName());
-            } else {
-                writeSignature(signature, objectDef, methodDef, variable.bounds().get(0), false);
-            }
+            writeTypeVariableDeclaration(signature, objectDef, methodDef, variable);
             return;
         }
         if (isVariablePartOfDefinition(name, objectDef, methodDef)) {
@@ -218,9 +223,106 @@ public final class SignatureUtils {
         } else if (variable.bounds().isEmpty()) {
             appendClass(signature, Object.class.getName());
         } else {
-            appendClass(signature, TypeUtils.getInternalName(TypeUtils.getDescriptor(
-                variable.bounds().get(0), objectDef).substring(1,
-                TypeUtils.getDescriptor(variable.bounds().get(0), objectDef).length() - 1)));
+            // Outside its own declaration a variable stands for the erasure of its first bound
+            signature.append(TypeUtils.getDescriptor(variable.bounds().get(0), objectDef));
+        }
+    }
+
+    /**
+     * Writes the declaration of a formal type parameter, which the JVMS spells as its name, a class
+     * bound and then an interface bound per remaining bound. A variable bounded only by interfaces
+     * has an empty class bound, which is why the first bound decides whether {@code :} appears once
+     * or twice.
+     */
+    private static void writeTypeVariableDeclaration(StringBuilder signature,
+                                                     @Nullable ObjectDef objectDef,
+                                                     @Nullable MethodDef methodDef,
+                                                     TypeDef.TypeVariable variable) {
+        signature.append(variable.name());
+        if (variable.bounds().isEmpty()) {
+            signature.append(':');
+            appendClass(signature, Object.class.getName());
+            return;
+        }
+        boolean first = true;
+        for (TypeDef bound : variable.bounds()) {
+            if (first && isInterface(bound)) {
+                signature.append(':');
+            }
+            signature.append(':');
+            writeSignature(signature, objectDef, methodDef, bound, false);
+            first = false;
+        }
+    }
+
+    /**
+     * Writes one type argument. A wildcard is an argument in its own right rather than a type:
+     * {@code *} unbounded, {@code +} for an upper bound and {@code -} for a lower one.
+     */
+    private static void writeTypeArgument(StringBuilder signature,
+                                          @Nullable ObjectDef objectDef,
+                                          @Nullable MethodDef methodDef,
+                                          TypeDef argument) {
+        if (!(unwrapAnnotated(argument) instanceof TypeDef.Wildcard wildcard)) {
+            writeSignature(signature, objectDef, methodDef, argument, false);
+            return;
+        }
+        if (!wildcard.lowerBounds().isEmpty()) {
+            signature.append('-');
+            writeSignature(signature, objectDef, methodDef, wildcard.lowerBounds().get(0), false);
+            return;
+        }
+        if (isUnbounded(wildcard)) {
+            signature.append('*');
+            return;
+        }
+        signature.append('+');
+        writeSignature(signature, objectDef, methodDef, wildcard.upperBounds().get(0), false);
+    }
+
+    /**
+     * Whether a wildcard is the unbounded {@code ?}: no lower bound, and either no upper bound or
+     * the single implicit {@code Object} one. The bound is compared by name so an annotated
+     * {@code Object}, or one named as a string, is still recognised as the implicit bound it is
+     * rather than written out as {@code ? extends Object}.
+     */
+    private static boolean isUnbounded(TypeDef.Wildcard wildcard) {
+        List<TypeDef> upperBounds = wildcard.upperBounds();
+        if (upperBounds.isEmpty()) {
+            return true;
+        }
+        return upperBounds.size() == 1
+            && unwrapAnnotated(upperBounds.get(0)) instanceof ClassTypeDef classTypeDef
+            && !(classTypeDef instanceof ClassTypeDef.Parameterized)
+            && Object.class.getName().equals(classTypeDef.getName());
+    }
+
+    /**
+     * Whether the type a bound names is an interface, which decides where it belongs in a type
+     * parameter declaration. A named type has to be loaded to find out, so the answer is kept.
+     */
+    private static boolean isInterface(TypeDef typeDef) {
+        typeDef = unwrapAnnotated(typeDef);
+        if (typeDef instanceof ClassTypeDef.Parameterized parameterized) {
+            typeDef = parameterized.rawType();
+        }
+        if (!(typeDef instanceof ClassTypeDef classTypeDef)) {
+            return false;
+        }
+        if (classTypeDef.isInterface()) {
+            return true;
+        }
+        if (classTypeDef instanceof ClassTypeDef.ClassName) {
+            return NAMED_BOUND_IS_INTERFACE.computeIfAbsent(classTypeDef.getName(), SignatureUtils::loadIsInterface);
+        }
+        return false;
+    }
+
+    private static boolean loadIsInterface(String name) {
+        try {
+            return Class.forName(name, false, SignatureUtils.class.getClassLoader()).isInterface();
+        } catch (ClassNotFoundException | LinkageError e) {
+            return false;
         }
     }
 

--- a/sourcegen-bytecode-writer-core/src/test/java/io/micronaut/sourcegen/bytecode/core/SignatureUtilsTest.java
+++ b/sourcegen-bytecode-writer-core/src/test/java/io/micronaut/sourcegen/bytecode/core/SignatureUtilsTest.java
@@ -81,6 +81,53 @@ class SignatureUtilsTest {
     }
 
     @Test
+    void writesWildcardTypeArguments() {
+        // A wildcard is a type argument in its own right, not a type: * unbounded, + upper, - lower
+        assertEquals("Ljava/util/List<*>;", fieldSignature(
+            TypeDef.parameterized(ClassTypeDef.of(List.class), TypeDef.wildcard())));
+        assertEquals("Ljava/util/List<*>;", fieldSignature(
+            TypeDef.parameterized(ClassTypeDef.of(List.class),
+                TypeDef.wildcardSubtypeOf(TypeDef.OBJECT))));
+        assertEquals("Ljava/util/List<+Ljava/lang/Number;>;", fieldSignature(
+            TypeDef.parameterized(ClassTypeDef.of(List.class),
+                TypeDef.wildcardSubtypeOf(TypeDef.of(Number.class)))));
+        assertEquals("Ljava/util/List<-Ljava/lang/Number;>;", fieldSignature(
+            TypeDef.parameterized(ClassTypeDef.of(List.class),
+                TypeDef.wildcardSupertypeOf(TypeDef.of(Number.class)))));
+    }
+
+    @Test
+    void writesEveryBoundOfATypeVariable() {
+        // A class bound comes first, then an interface bound for each remaining bound
+        TypeDef.TypeVariable multiple = TypeDef.variable("T",
+            TypeDef.of(Number.class), TypeDef.of(Comparable.class));
+        assertEquals("<T:Ljava/lang/Number;:Ljava/lang/Comparable;>Ljava/lang/Object;",
+            SignatureUtils.getClassSignature(
+                ClassDef.builder("example.Bounded").addTypeVariable(multiple).build()));
+
+        // Bounded only by interfaces, the class bound is present but empty
+        TypeDef.TypeVariable interfaces = TypeDef.variable("T",
+            TypeDef.of(Comparable.class), TypeDef.of(Runnable.class));
+        assertEquals("<T::Ljava/lang/Comparable;:Ljava/lang/Runnable;>Ljava/lang/Object;",
+            SignatureUtils.getClassSignature(
+                ClassDef.builder("example.Interfaces").addTypeVariable(interfaces).build()));
+    }
+
+    @Test
+    void looksThroughArraysWhenDecidingWhetherASignatureIsNeeded() {
+        // The array itself is not generic; its component decides
+        assertNull(fieldSignature(TypeDef.STRING.array()));
+        assertEquals("[Ljava/util/List<Ljava/lang/String;>;", fieldSignature(
+            TypeDef.parameterized(List.class, String.class).array()));
+        assertEquals("[[Ljava/util/List<Ljava/lang/String;>;", fieldSignature(
+            new TypeDef.Array(TypeDef.parameterized(List.class, String.class), 2, false)));
+    }
+
+    private static String fieldSignature(TypeDef type) {
+        return SignatureUtils.getFieldSignature(null, FieldDef.builder("value", type).build());
+    }
+
+    @Test
     void writesFieldAndMethodSignaturesIncludingTypeVariables() {
         assertEquals("Ljava/util/List<Ljava/lang/String;>;",
             SignatureUtils.getFieldSignature(null,

--- a/sourcegen-bytecode-writer-jdk/src/main/java/io/micronaut/sourcegen/bytecode/jdk/JdkMethodSupport.java
+++ b/sourcegen-bytecode-writer-jdk/src/main/java/io/micronaut/sourcegen/bytecode/jdk/JdkMethodSupport.java
@@ -83,10 +83,13 @@ final class JdkMethodSupport {
         }
         // Distinctness is of the case values themselves; two strings that share a hash code are
         // still two cases, and the writer separates them with an equality test
+        // A case value has to match the kind of the selector: the writer switches on an int
+        // directly and on a string by its hash, and cannot mix the two
+        boolean strings = aSwitch.expression().type().equals(TypeDef.STRING);
         java.util.Set<Object> keys = new java.util.HashSet<>();
         for (var entry : aSwitch.cases().entrySet()) {
             Object value = entry.getKey().value();
-            if (!(value instanceof Integer) && !(value instanceof String)) {
+            if (strings ? !(value instanceof String) : !(value instanceof Integer)) {
                 return false;
             }
             if (!keys.add(value) || !supported(entry.getValue())) {
@@ -139,7 +142,7 @@ final class JdkMethodSupport {
             case MethodReferenceExpression methodReference -> methodReference.instance() == null
                 || supported(methodReference.instance());
             case ExpressionDef.Switch aSwitch -> supportedSwitch(aSwitch);
-            case ExpressionDef.SwitchYieldCase _ -> false;
+            case ExpressionDef.SwitchYieldCase yieldCase -> supported(yieldCase.statement());
             default -> false;
         };
     }
@@ -152,10 +155,13 @@ final class JdkMethodSupport {
         }
         // Distinctness is of the case values themselves; two strings that share a hash code are
         // still two cases, and the writer separates them with an equality test
+        // A case value has to match the kind of the selector: the writer switches on an int
+        // directly and on a string by its hash, and cannot mix the two
+        boolean strings = aSwitch.expression().type().equals(TypeDef.STRING);
         java.util.Set<Object> keys = new java.util.HashSet<>();
         for (var entry : aSwitch.cases().entrySet()) {
             Object value = entry.getKey().value();
-            if (!(value instanceof Integer) && !(value instanceof String)) {
+            if (strings ? !(value instanceof String) : !(value instanceof Integer)) {
                 return false;
             }
             if (!keys.add(value) || !supported(entry.getValue())) {

--- a/sourcegen-bytecode-writer-jdk/src/main/java/io/micronaut/sourcegen/bytecode/jdk/JdkMethodWriter.java
+++ b/sourcegen-bytecode-writer-jdk/src/main/java/io/micronaut/sourcegen/bytecode/jdk/JdkMethodWriter.java
@@ -583,6 +583,7 @@ final class JdkMethodWriter {
             case MethodReferenceExpression methodReference -> writeMethodReference(methodReference);
             case ExpressionDef.IfElse ifElse -> writeIfElseExpression(ifElse);
             case ExpressionDef.Switch aSwitch -> writeExpressionSwitch(aSwitch);
+            case ExpressionDef.SwitchYieldCase yieldCase -> writeStatement(yieldCase.statement());
             case ExpressionDef.NewArrayOfSize array -> {
                 code.loadConstant(array.size());
                 writeNewArray(array.type());
@@ -821,14 +822,32 @@ final class JdkMethodWriter {
         writeSwitchInstruction(defaultLabel, labels);
         for (Map.Entry<Label, ExpressionDef> body : bodies) {
             code.labelBinding(body.getKey());
-            writeExpression(new ExpressionDef.Cast(aSwitch.type(), body.getValue()));
-            code.goto_(end);
+            writeCaseValue(aSwitch.type(), body.getValue(), end);
         }
         code.labelBinding(defaultLabel);
         if (aSwitch.defaultCase() != null) {
-            writeExpression(new ExpressionDef.Cast(aSwitch.type(), aSwitch.defaultCase()));
+            writeCaseValue(aSwitch.type(), aSwitch.defaultCase(), null);
         }
         code.labelBinding(end);
+    }
+
+    /**
+     * Writes the value a case contributes to a switch expression. A yield case is a statement
+     * block, so it is written as one and only jumps to the end of the switch when control can
+     * reach there; the ASM backend lowers a yielding return the same way.
+     */
+    private void writeCaseValue(TypeDef type, ExpressionDef value, @Nullable Label end) {
+        if (value instanceof ExpressionDef.SwitchYieldCase yieldCase) {
+            writeStatement(yieldCase.statement());
+            if (end != null && canCompleteNormally(yieldCase.statement())) {
+                code.goto_(end);
+            }
+            return;
+        }
+        writeExpression(new ExpressionDef.Cast(type, value));
+        if (end != null) {
+            code.goto_(end);
+        }
     }
 
     private void writeStringExpressionSwitch(ExpressionDef.Switch aSwitch) {
@@ -842,12 +861,11 @@ final class JdkMethodWriter {
         writeStringDispatch(aSwitch.cases().keySet(), caseLabels, valueSlot, defaultLabel);
         for (Map.Entry<Label, ExpressionDef> body : bodies) {
             code.labelBinding(body.getKey());
-            writeExpression(new ExpressionDef.Cast(aSwitch.type(), body.getValue()));
-            code.goto_(end);
+            writeCaseValue(aSwitch.type(), body.getValue(), end);
         }
         code.labelBinding(defaultLabel);
         if (aSwitch.defaultCase() != null) {
-            writeExpression(new ExpressionDef.Cast(aSwitch.type(), aSwitch.defaultCase()));
+            writeCaseValue(aSwitch.type(), aSwitch.defaultCase(), null);
         }
         code.labelBinding(end);
     }

--- a/sourcegen-bytecode-writer-jdk/src/test/java/io/micronaut/sourcegen/bytecode/jdk/JdkByteCodeWriterParityTest.java
+++ b/sourcegen-bytecode-writer-jdk/src/test/java/io/micronaut/sourcegen/bytecode/jdk/JdkByteCodeWriterParityTest.java
@@ -817,18 +817,16 @@ class JdkByteCodeWriterParityTest {
 
     @Test
     void publicWriterFallsBackToJavacForConstructsTheDirectWriterDeclines() throws Exception {
-        // A switch yield case is not lowered directly yet
+        // A char selector is not lowered directly
         ClassDef definition = ClassDef.builder("example.JdkJavacFallback")
             .addModifiers(Modifier.PUBLIC)
             .addMethod(MethodDef.builder("describe")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .addParameter("value", TypeDef.Primitive.INT)
+                .addParameter("value", TypeDef.Primitive.CHAR)
                 .returns(TypeDef.STRING)
-                .build((ignored, parameters) -> parameters.get(0).asExpressionSwitch(TypeDef.STRING,
-                    Map.of(ExpressionDef.constant(1), new ExpressionDef.SwitchYieldCase(TypeDef.STRING,
-                        ExpressionDef.constant("one").returning())),
-                    ExpressionDef.constant("other")
-                ).returning()))
+                .build((ignored, parameters) -> parameters.get(0).asStatementSwitch(TypeDef.STRING,
+                    Map.of(ExpressionDef.constant(1), ExpressionDef.constant("one").returning()),
+                    ExpressionDef.constant("other").returning())))
             .build();
         assertTrue(new JdkClassFileWriter(true).write(definition, null).isEmpty());
 
@@ -839,8 +837,8 @@ class JdkByteCodeWriterParityTest {
         assertArrayEquals(first, second);
         assertVerified(first);
         Class<?> generated = new MapClassLoader(Map.of(definition.getName(), first)).loadClass(definition.getName());
-        assertEquals("one", generated.getMethod("describe", int.class).invoke(null, 1));
-        assertEquals("other", generated.getMethod("describe", int.class).invoke(null, 2));
+        assertEquals("one", generated.getMethod("describe", char.class).invoke(null, (char) 1));
+        assertEquals("other", generated.getMethod("describe", char.class).invoke(null, (char) 9));
     }
 
     @Test

--- a/sourcegen-bytecode-writer-jdk/src/test/java/io/micronaut/sourcegen/bytecode/jdk/JdkExpressionLoweringTest.java
+++ b/sourcegen-bytecode-writer-jdk/src/test/java/io/micronaut/sourcegen/bytecode/jdk/JdkExpressionLoweringTest.java
@@ -25,7 +25,9 @@ import io.micronaut.sourcegen.model.TypeDef;
 import org.junit.jupiter.api.Test;
 
 import javax.lang.model.element.Modifier;
+import java.lang.classfile.ClassFile;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -323,6 +325,46 @@ class JdkExpressionLoweringTest {
         assertEquals(5, generated.getMethod("countTo", int.class).invoke(null, 5));
         assertEquals(0, generated.getMethod("countTo", int.class).invoke(null, 0));
         assertEquals("inside", generated.getMethod("guarded", Object.class).invoke(null, new Object()));
+    }
+
+    @Test
+    void lowersSwitchYieldCasesWithoutTheSourceFallback() throws Exception {
+        Map<ExpressionDef.Constant, ExpressionDef> cases = new LinkedHashMap<>();
+        // A yield case is a statement block; a plain expression case sits alongside it
+        cases.put(ExpressionDef.constant(1), new ExpressionDef.SwitchYieldCase(TypeDef.STRING,
+            ExpressionDef.constant("one").returning()));
+        cases.put(ExpressionDef.constant(2), ExpressionDef.constant("two"));
+        Map<ExpressionDef.Constant, ExpressionDef> strings = new LinkedHashMap<>();
+        strings.put(ExpressionDef.constant("a"), new ExpressionDef.SwitchYieldCase(TypeDef.STRING,
+            ExpressionDef.constant("first").returning()));
+        strings.put(ExpressionDef.constant("b"), ExpressionDef.constant("second"));
+
+        ClassDef definition = ClassDef.builder("example.JdkYieldCase")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("byIndex")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .addParameter("index", TypeDef.Primitive.INT)
+                .returns(TypeDef.STRING)
+                .build((ignored, parameters) -> parameters.get(0)
+                    .asExpressionSwitch(TypeDef.STRING, cases, ExpressionDef.constant("none"))
+                    .returning()))
+            .addMethod(MethodDef.builder("byName")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .addParameter("name", TypeDef.STRING)
+                .returns(TypeDef.STRING)
+                .build((ignored, parameters) -> parameters.get(0)
+                    .asExpressionSwitch(TypeDef.STRING, strings, ExpressionDef.constant("none"))
+                    .returning()))
+            .build();
+
+        Class<?> generated = define(definition);
+
+        assertEquals("one", generated.getMethod("byIndex", int.class).invoke(null, 1));
+        assertEquals("two", generated.getMethod("byIndex", int.class).invoke(null, 2));
+        assertEquals("none", generated.getMethod("byIndex", int.class).invoke(null, 3));
+        assertEquals("first", generated.getMethod("byName", String.class).invoke(null, "a"));
+        assertEquals("second", generated.getMethod("byName", String.class).invoke(null, "b"));
+        assertEquals("none", generated.getMethod("byName", String.class).invoke(null, "c"));
     }
 
     private static final class MapClassLoader extends ClassLoader {

--- a/sourcegen-bytecode-writer-jdk/src/test/java/io/micronaut/sourcegen/bytecode/jdk/JdkMethodSupportTest.java
+++ b/sourcegen-bytecode-writer-jdk/src/test/java/io/micronaut/sourcegen/bytecode/jdk/JdkMethodSupportTest.java
@@ -116,20 +116,28 @@ class JdkMethodSupportTest {
 
     @Test
     void declinesConstructsTheWriterCannotLowerYet() {
-        // A switch yield case has no direct lowering
-        assertFalse(JdkMethodSupport.supported(NUMBER.asExpressionSwitch(TypeDef.STRING,
-            Map.of(ExpressionDef.constant(1), new ExpressionDef.SwitchYieldCase(
-                TypeDef.STRING, TEXT.returning())),
-            TEXT)));
-        // A switch is only lowered over int and String, with distinct keys
+        // A switch is only lowered over int and String
         assertFalse(JdkMethodSupport.supported(TEXT.cast(TypeDef.Primitive.LONG)
             .asStatementSwitch(TypeDef.STRING,
                 Map.of(ExpressionDef.constant(1), TEXT.returning()), TEXT.returning())));
-        // A case body that cannot be lowered makes the whole switch unsupported
+        // A case key that is neither an int nor a String has no switch key
         assertFalse(JdkMethodSupport.supported(NUMBER.asStatementSwitch(TypeDef.STRING,
+            Map.of(ExpressionDef.constant('a'), TEXT.returning()), TEXT.returning())));
+    }
+
+    @Test
+    void supportsSwitchYieldCases() {
+        // A yield case is a statement block, and is supported when its body is
+        assertTrue(JdkMethodSupport.supported(NUMBER.asExpressionSwitch(TypeDef.STRING,
             Map.of(ExpressionDef.constant(1), new ExpressionDef.SwitchYieldCase(
-                TypeDef.STRING, TEXT.returning()).returning()),
-            TEXT.returning())));
+                TypeDef.STRING, TEXT.returning())),
+            TEXT)));
+        // ... and declined when its body is not
+        assertFalse(JdkMethodSupport.supported(NUMBER.asExpressionSwitch(TypeDef.STRING,
+            Map.of(ExpressionDef.constant(1), new ExpressionDef.SwitchYieldCase(TypeDef.STRING,
+                TEXT.cast(TypeDef.Primitive.LONG).asStatementSwitch(TypeDef.STRING,
+                    Map.of(ExpressionDef.constant(1), TEXT.returning()), TEXT.returning()))),
+            TEXT)));
     }
 
     @Test

--- a/sourcegen-bytecode-writer-jdk/src/test/java/io/micronaut/sourcegen/bytecode/jdk/JdkSourceFallbackTest.java
+++ b/sourcegen-bytecode-writer-jdk/src/test/java/io/micronaut/sourcegen/bytecode/jdk/JdkSourceFallbackTest.java
@@ -37,20 +37,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * The Java source fallback, used for definitions the direct writer declines. Every definition here
- * carries a switch yield case, which is the construct that sends it down that path.
+ * switches on a char, a selector the writer does not lower, and so goes down that path.
  */
 class JdkSourceFallbackTest {
 
     private static MethodDef declinedMethod(String name) {
         return MethodDef.builder(name)
             .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-            .addParameter("index", TypeDef.Primitive.INT)
+            .addParameter("index", TypeDef.Primitive.CHAR)
             .returns(TypeDef.STRING)
-            .build((ignored, parameters) -> parameters.get(0).asExpressionSwitch(TypeDef.STRING,
-                Map.of(ExpressionDef.constant(1), new ExpressionDef.SwitchYieldCase(TypeDef.STRING,
-                    ExpressionDef.constant("one").returning())),
-                ExpressionDef.constant("other")
-            ).returning());
+            .build((ignored, parameters) -> parameters.get(0).asStatementSwitch(TypeDef.STRING,
+                Map.of(ExpressionDef.constant(1), ExpressionDef.constant("one").returning()),
+                ExpressionDef.constant("other").returning()));
     }
 
     @Test
@@ -115,8 +113,8 @@ class JdkSourceFallbackTest {
         Map<String, byte[]> produced = new ByteCodeWriter().writeAll(definition);
         Class<?> generated = new MapClassLoader(produced).loadClass(definition.getName());
 
-        assertEquals("one", generated.getMethod("describe", int.class).invoke(null, 1));
-        assertEquals("other", generated.getMethod("describe", int.class).invoke(null, 2));
+        assertEquals("one", generated.getMethod("describe", char.class).invoke(null, (char) 1));
+        assertEquals("other", generated.getMethod("describe", char.class).invoke(null, (char) 9));
         assertEquals(3, generated.getField("counter").get(null));
     }
 

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/SignatureWriterUtils.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/SignatureWriterUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,28 +16,17 @@
 package io.micronaut.sourcegen.bytecode;
 
 import io.micronaut.core.annotation.Internal;
-import org.jspecify.annotations.Nullable;
-import io.micronaut.inject.processing.JavaModelUtils;
+import io.micronaut.sourcegen.bytecode.core.SignatureUtils;
 import io.micronaut.sourcegen.model.ClassDef;
-import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.FieldDef;
 import io.micronaut.sourcegen.model.InterfaceDef;
 import io.micronaut.sourcegen.model.MethodDef;
 import io.micronaut.sourcegen.model.ObjectDef;
-import io.micronaut.sourcegen.model.ParameterDef;
 import io.micronaut.sourcegen.model.RecordDef;
-import io.micronaut.sourcegen.model.TypeDef;
-import org.objectweb.asm.Type;
-import org.objectweb.asm.signature.SignatureVisitor;
-import org.objectweb.asm.signature.SignatureWriter;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jspecify.annotations.Nullable;
 
 /**
- * The bytecode signature utils.
+ * Compatibility facade for the backend-neutral signature utilities.
  *
  * @author Denis Stepanov
  * @since 1.5
@@ -45,316 +34,29 @@ import java.util.concurrent.ConcurrentHashMap;
 @Internal
 final class SignatureWriterUtils {
 
-    /**
-     * Whether the class a bound names is an interface, kept per name so writing many bounds asks the
-     * class loader about each one once.
-     */
-    private static final Map<String, Boolean> NAMED_BOUND_IS_INTERFACE = new ConcurrentHashMap<>();
+    private SignatureWriterUtils() {
+    }
 
     @Nullable
     static String getFieldSignature(@Nullable ObjectDef objectDef, FieldDef fieldDef) {
-        if (!needsSignature(fieldDef.getType())) {
-            return null;
-        }
-        SignatureWriter writer = new SignatureWriter();
-        // A field signature references its type, it never defines a type parameter
-        writeSignature(writer, objectDef, fieldDef.getType(), false);
-        return writer.toString();
+        return SignatureUtils.getFieldSignature(objectDef, fieldDef);
     }
 
-    @Nullable
     static String getClassSignature(ClassDef classDef) {
-        SignatureWriter writer = new SignatureWriter();
-
-        for (TypeDef.TypeVariable typeVariable : classDef.getTypeVariables()) {
-            writeSignature(writer, classDef, typeVariable, true);
-        }
-
-        TypeDef superclass = Objects.requireNonNullElse(classDef.getSuperclass(), TypeDef.OBJECT);
-        writeSignature(writer.visitSuperclass(), classDef, superclass, false);
-
-        for (TypeDef superinterface : classDef.getSuperinterfaces()) {
-            writeSignature(writer.visitInterface(), classDef, superinterface, false);
-        }
-
-        return writer.toString();
+        return SignatureUtils.getClassSignature(classDef);
     }
 
-    @Nullable
     static String getRecordSignature(RecordDef recordDef) {
-        SignatureWriter writer = new SignatureWriter();
-
-        for (TypeDef.TypeVariable typeVariable : recordDef.getTypeVariables()) {
-            writeSignature(writer, recordDef, typeVariable, true);
-        }
-
-        writeSignature(writer.visitSuperclass(), recordDef, TypeDef.of(Record.class), false);
-
-        for (TypeDef superinterface : recordDef.getSuperinterfaces()) {
-            writeSignature(writer.visitInterface(), recordDef, superinterface, false);
-        }
-
-        return writer.toString();
+        return SignatureUtils.getRecordSignature(recordDef);
     }
 
     @Nullable
     static String getInterfaceSignature(InterfaceDef interfaceDef) {
-        if (interfaceDef.getTypeVariables().isEmpty() && interfaceDef.getSuperinterfaces().isEmpty()) {
-            return null;
-        }
-        SignatureWriter writer = new SignatureWriter();
-
-        for (TypeDef.TypeVariable typeVariable : interfaceDef.getTypeVariables()) {
-            writeSignature(writer, interfaceDef, typeVariable, true);
-        }
-
-        SignatureVisitor superclassVisitor = writer.visitSuperclass();
-        superclassVisitor.visitClassType(TypeUtils.OBJECT_TYPE.getInternalName());
-        superclassVisitor.visitEnd();
-
-        for (TypeDef superinterface : interfaceDef.getSuperinterfaces()) {
-            writeSignature(writer.visitInterface(), interfaceDef, superinterface, false);
-        }
-
-        return writer.toString();
+        return SignatureUtils.getInterfaceSignature(interfaceDef);
     }
 
     @Nullable
     static String getMethodSignature(@Nullable ObjectDef objectDef, MethodDef methodDef) {
-        if (!needsSignature(methodDef)) {
-            return null;
-        }
-        SignatureWriter signatureWriter = new SignatureWriter();
-        for (TypeDef.TypeVariable typeVariable : methodDef.getTypeVariables()) {
-            writeSignature(signatureWriter, objectDef, methodDef, typeVariable, true);
-        }
-        for (ParameterDef parameter : methodDef.getParameters()) {
-            writeSignature(signatureWriter.visitParameterType(), objectDef, methodDef, parameter.getType(), false);
-        }
-
-        writeSignature(signatureWriter.visitReturnType(), objectDef, methodDef, methodDef.getReturnType(), false);
-
-        return signatureWriter.toString();
+        return SignatureUtils.getMethodSignature(objectDef, methodDef);
     }
-
-    private static boolean needsSignature(MethodDef methodDef) {
-        for (ParameterDef parameter : methodDef.getParameters()) {
-            if (needsSignature(parameter.getType())) {
-                return true;
-            }
-        }
-        return needsSignature(methodDef.getReturnType());
-    }
-
-    private static boolean needsSignature(TypeDef typeDef) {
-        typeDef = unwrapAnnotated(typeDef);
-        if (typeDef instanceof TypeDef.Array array) {
-            return needsSignature(array.componentType());
-        }
-        return typeDef instanceof ClassTypeDef.Parameterized
-            || typeDef instanceof TypeDef.TypeVariable
-            || typeDef instanceof TypeDef.Wildcard;
-    }
-
-    /**
-     * @param typeDef The type
-     * @return The type without the annotations it carries, which have no place in a signature
-     */
-    private static TypeDef unwrapAnnotated(TypeDef typeDef) {
-        if (typeDef instanceof TypeDef.AnnotatedTypeDef annotated) {
-            return unwrapAnnotated(annotated.typeDef());
-        }
-        if (typeDef instanceof ClassTypeDef.AnnotatedClassTypeDef annotated) {
-            return unwrapAnnotated(annotated.typeDef());
-        }
-        return typeDef;
-    }
-
-    private static void writeSignature(SignatureVisitor signatureWriter,
-                                       @Nullable ObjectDef objectDef,
-                                       TypeDef typeDef, boolean isDefinition) {
-        writeSignature(signatureWriter, objectDef, null, typeDef, isDefinition);
-    }
-
-    private static void writeSignature(SignatureVisitor signatureWriter,
-                                       @Nullable ObjectDef objectDef,
-                                       @Nullable MethodDef methodDef,
-                                       TypeDef typeDef, boolean isDefinition) {
-        typeDef = ObjectDef.getContextualType(objectDef, typeDef);
-        typeDef = unwrapAnnotated(typeDef);
-        if (typeDef instanceof TypeDef.Primitive primitive) {
-            Type type = Type.getType(JavaModelUtils.NAME_TO_TYPE_MAP.get(primitive.name()));
-            signatureWriter.visitBaseType(type.getDescriptor().charAt(0));
-            return;
-        }
-        if (typeDef instanceof TypeDef.TypeVariable typeVariable) {
-            String name = typeVariable.name();
-            if (isDefinition) {
-                signatureWriter.visitFormalTypeParameter(name);
-                if (typeVariable.bounds().isEmpty()) {
-                    writeSignature(signatureWriter.visitClassBound(), objectDef, TypeDef.OBJECT, false);
-                } else {
-                    boolean first = true;
-                    for (TypeDef bound : typeVariable.bounds()) {
-                        SignatureVisitor boundVisitor = first && !isInterface(bound)
-                            ? signatureWriter.visitClassBound()
-                            : signatureWriter.visitInterfaceBound();
-                        writeSignature(boundVisitor, objectDef, methodDef, bound, false);
-                        first = false;
-                    }
-                }
-            } else {
-                if (isVariablePartOfTheDefinition(name, objectDef, methodDef)) {
-                    signatureWriter.visitTypeVariable(typeVariable.name());
-                } else if (typeVariable.bounds().isEmpty()) {
-                    signatureWriter.visitClassType(TypeUtils.OBJECT_TYPE.getInternalName());
-                    signatureWriter.visitEnd();
-                } else {
-                    signatureWriter.visitClassType(TypeUtils.getType(typeVariable.bounds().get(0), objectDef).getInternalName());
-                    signatureWriter.visitEnd();
-                }
-            }
-            return;
-        }
-        if (typeDef instanceof ClassTypeDef.Parameterized parameterized) {
-            signatureWriter.visitClassType(TypeUtils.getType(parameterized.rawType()).getInternalName());
-            if (!parameterized.typeArguments().isEmpty()) {
-                for (TypeDef typeArgument : parameterized.typeArguments()) {
-                    writeTypeArgument(signatureWriter, objectDef, methodDef, typeArgument);
-                }
-                signatureWriter.visitEnd();
-            }
-            return;
-        }
-        if (typeDef instanceof ClassTypeDef classDef) {
-            signatureWriter.visitClassType(TypeUtils.getType(classDef.getName()).getInternalName());
-            signatureWriter.visitEnd();
-            return;
-        }
-        if (typeDef instanceof TypeDef.Wildcard) {
-            signatureWriter.visitClassType(TypeUtils.OBJECT_TYPE.getInternalName());
-            signatureWriter.visitEnd();
-            return;
-        }
-        if (typeDef instanceof TypeDef.Array array) {
-            if (array.dimensions() == 1) {
-                writeSignature(signatureWriter.visitArrayType(), objectDef, methodDef, array.componentType(), false);
-            } else {
-                writeSignature(signatureWriter.visitArrayType(), objectDef, methodDef, new TypeDef.Array(
-                    array.componentType(),
-                    array.dimensions() - 1,
-                    false
-                ), false);
-            }
-            return;
-        }
-        throw new IllegalStateException("Not recognized typedef: " + typeDef);
-    }
-
-    private static void writeTypeArgument(SignatureVisitor signatureWriter,
-                                          @Nullable ObjectDef objectDef,
-                                          @Nullable MethodDef methodDef,
-                                          TypeDef typeArgument) {
-        TypeDef unwrapped = unwrapAnnotated(typeArgument);
-        if (!(unwrapped instanceof TypeDef.Wildcard wildcard)) {
-            writeSignature(signatureWriter.visitTypeArgument(SignatureVisitor.INSTANCEOF), objectDef, methodDef, typeArgument, false);
-            return;
-        }
-        if (!wildcard.lowerBounds().isEmpty()) {
-            writeSignature(
-                signatureWriter.visitTypeArgument(SignatureVisitor.SUPER),
-                objectDef,
-                methodDef,
-                wildcard.lowerBounds().get(0),
-                false
-            );
-            return;
-        }
-        if (isUnbounded(wildcard)) {
-            signatureWriter.visitTypeArgument();
-            return;
-        }
-        writeSignature(
-            signatureWriter.visitTypeArgument(SignatureVisitor.EXTENDS),
-            objectDef,
-            methodDef,
-            wildcard.upperBounds().get(0),
-            false
-        );
-    }
-
-    /**
-     * Whether a wildcard is the unbounded {@code ?}: no lower bound, and either no upper bound or the
-     * single implicit {@code Object} one. The bound is unwrapped and compared by name rather than by
-     * instance, so an annotated {@code Object}, or one named as a string instead of built from
-     * {@link Object}, is still recognised as the implicit bound it is rather than written out as
-     * {@code ? extends Object}.
-     *
-     * @param wildcard The wildcard
-     * @return True when the wildcard carries no bound of its own
-     */
-    private static boolean isUnbounded(TypeDef.Wildcard wildcard) {
-        List<TypeDef> upperBounds = wildcard.upperBounds();
-        if (upperBounds.isEmpty()) {
-            return true;
-        }
-        return upperBounds.size() == 1
-            && unwrapAnnotated(upperBounds.get(0)) instanceof ClassTypeDef classTypeDef
-            && !(classTypeDef instanceof ClassTypeDef.Parameterized)
-            && Object.class.getName().equals(classTypeDef.getName());
-    }
-
-    /**
-     * Whether a bound is an interface, which decides the position it is written in: the first bound goes
-     * into the class bound only when it is a class. A {@link ClassTypeDef.ClassName} is only a name and
-     * carries no answer, so the class it names is the last place left to ask.
-     *
-     * @param typeDef The bound
-     * @return True when the bound is known to be an interface
-     */
-    private static boolean isInterface(TypeDef typeDef) {
-        typeDef = unwrapAnnotated(typeDef);
-        if (typeDef instanceof ClassTypeDef.Parameterized parameterized) {
-            typeDef = parameterized.rawType();
-        }
-        if (!(typeDef instanceof ClassTypeDef classTypeDef)) {
-            return false;
-        }
-        if (classTypeDef.isInterface()) {
-            return true;
-        }
-        if (classTypeDef instanceof ClassTypeDef.ClassName) {
-            return NAMED_BOUND_IS_INTERFACE.computeIfAbsent(classTypeDef.getName(), SignatureWriterUtils::loadIsInterface);
-        }
-        return false;
-    }
-
-    private static boolean loadIsInterface(String name) {
-        try {
-            return Class.forName(name, false, SignatureWriterUtils.class.getClassLoader()).isInterface();
-        } catch (ClassNotFoundException | LinkageError e) {
-            return false;
-        }
-    }
-
-    private static boolean isVariablePartOfTheDefinition(String variableName, @Nullable ObjectDef objectDef, @Nullable MethodDef methodDef) {
-        if (methodDef != null
-            && methodDef.getTypeVariables().stream().anyMatch(v -> v.name().equals(variableName))) {
-            return true;
-        }
-        if (objectDef instanceof ClassDef classDef) {
-            return classDef.getTypeVariables().stream()
-                .anyMatch(tv -> tv.name().equals(variableName));
-        }
-        if (objectDef instanceof InterfaceDef interfaceDef) {
-            return interfaceDef.getTypeVariables().stream()
-                .anyMatch(tv -> tv.name().equals(variableName));
-        }
-        if (objectDef instanceof RecordDef recordDef) {
-            return recordDef.getTypeVariables().stream()
-                .anyMatch(tv -> tv.name().equals(variableName));
-        }
-        return false;
-    }
-
 }

--- a/sourcegen-generator-bytecode-jdk/src/test/groovy/io/micronaut/sourcegen/generator/bytecode/jdk/ByteCodeGeneratorSpec.groovy
+++ b/sourcegen-generator-bytecode-jdk/src/test/groovy/io/micronaut/sourcegen/generator/bytecode/jdk/ByteCodeGeneratorSpec.groovy
@@ -65,16 +65,15 @@ class ByteCodeGeneratorSpec extends Specification {
     private static ClassDef broken(String name) {
         ClassDef.builder(name)
                 .addModifiers(Modifier.PUBLIC)
-                // A switch yield case is not lowered directly, so this goes to the source fallback
+                // A char selector is not lowered directly, so this goes to the source fallback
                 .addMethod(MethodDef.builder("describe")
                         .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                        .addParameter("index", TypeDef.Primitive.INT)
+                        .addParameter("index", TypeDef.Primitive.CHAR)
                         .returns(TypeDef.STRING)
                         .build({ aThis, parameters ->
-                            parameters.get(0).asExpressionSwitch(TypeDef.STRING,
-                                    [(ExpressionDef.constant(1)): new ExpressionDef.SwitchYieldCase(
-                                            TypeDef.STRING, ExpressionDef.constant("one").returning())],
-                                    ExpressionDef.constant("other")).returning()
+                            parameters.get(0).asStatementSwitch(TypeDef.STRING,
+                                    [(ExpressionDef.constant(1)): ExpressionDef.constant("one").returning()],
+                                    ExpressionDef.constant("other").returning())
                         }))
                 // ... where it names a type that exists nowhere, so the compilation fails
                 .addMethod(MethodDef.builder("broken")


### PR DESCRIPTION
Follow-ups from the review of #497, which is now merged.

## Generic signatures are shared again

#498 taught the ASM writer to emit real wildcard type arguments (`*`, `+`, `-`), to honour every bound of a type variable, and to look through arrays when deciding whether a signature is needed. That work landed in `SignatureWriterUtils` alone, so the backend-neutral core the JDK writer reads did none of it and the JDK backend's generic metadata was poorer than the ASM backend's for the same model.

The core now does all three, and `SignatureWriterUtils` delegates to it again instead of keeping its own copy. That is deliberate: the ASM module's own tests, including the golden bytecode dumps, then stand as the proof that the two backends emit identical signatures. They pass unchanged.

## Switch yield cases lower directly

A yield case was the main reason a definition still reached the Java source fallback. It is a statement block, so it is now written as one, jumping to the end of the switch only when control can reach there — the same lowering the ASM backend uses for a yielding return. Covered for both int and string switches, and for a switch that mixes a yield case with a plain expression case.

## A smaller fix found on the way

A case value now has to match the kind of the switch selector. A string switch carrying an int case passed the support check and then failed inside the writer, casting that case to a string.

## Verification

All on JDK 25.

| What | Result |
|---|---|
| `./gradlew check` | 1451 tests, 0 failures |
| micronaut-core 5.2.x compiled with the JDK backend | every module, no fallbacks |
| micronaut-core inject / context / test-suite | 8319 tests, 0 failures |

## Left open, with a finding

The third follow-up, making the JDK writer honour `RetentionPolicy`, is **not** in this PR. I implemented it — skipping `SOURCE` annotations and writing `CLASS` ones invisible, at the same sites the ASM writer does, resolving retention with the same rules — and it broke micronaut-core: `MessageEndpointSpec` fails with a connection reset and `RefreshEventSpec` with four `Not Found`s. Reverting only that change makes both pass again, so the cause is the retention handling and not the rest of this branch.

Worth knowing before anyone attempts it again: a faithful port of the ASM rule is not sufficient for the JDK writer, and the next step is to find which annotation loses the visibility Micronaut needs. Until then the JDK backend writes every annotation runtime-visible, which is what it did before #497.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
