### PR TITLE
Support annotation class generation in the bytecode backends

### DIFF
--- a/sourcegen-bytecode-writer-core/src/main/java/io/micronaut/sourcegen/bytecode/core/AnnotationTargetUtils.java
+++ b/sourcegen-bytecode-writer-core/src/main/java/io/micronaut/sourcegen/bytecode/core/AnnotationTargetUtils.java
@@ -17,9 +17,13 @@ package io.micronaut.sourcegen.bytecode.core;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.ElementQuery;
+import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.sourcegen.model.AnnotationDef;
+import io.micronaut.sourcegen.model.AnnotationObjectDef;
 import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.ObjectDef;
+import io.micronaut.sourcegen.model.TypeDef;
 import io.micronaut.sourcegen.model.VariableDef;
 import org.jspecify.annotations.Nullable;
 
@@ -166,6 +170,53 @@ public final class AnnotationTargetUtils {
             return Optional.of(RetentionPolicy.valueOf(name));
         } catch (IllegalArgumentException e) {
             return Optional.empty();
+        }
+    }
+
+    /**
+     * Whether a member of an annotation is declared with an array type.
+     *
+     * <p>A single value is a legal source form for an array member - {@code @Target(TYPE)} means
+     * {@code @Target({TYPE})} - but a class file has no such shorthand, so a writer has to know the
+     * declared type to wrap the value. The declaration is read from the definition of an annotation
+     * type generated in this same round, from the source element of one still being compiled, and
+     * otherwise from the loaded class.</p>
+     *
+     * @param annotation  The annotation
+     * @param member      The name of the member
+     * @param classLoader The fallback class loader
+     * @return Whether the member is declared as an array
+     */
+    public static boolean isArrayMember(AnnotationDef annotation, String member, @Nullable ClassLoader classLoader) {
+        ClassTypeDef type = annotation.getType();
+        if (type instanceof ClassTypeDef.ClassDefType classDefType) {
+            return classDefType.objectDef() instanceof AnnotationObjectDef annotationObjectDef
+                && annotationObjectDef.getMembers().stream()
+                .filter(memberDef -> memberDef.getName().equals(member))
+                .anyMatch(memberDef -> memberDef.getType() instanceof TypeDef.Array);
+        }
+        if (type instanceof ClassTypeDef.ClassElementType classElementType) {
+            return isSourceArrayMember(classElementType.classElement(), member);
+        }
+        Class<?> annotationType = resolveAnnotationType(type, classLoader);
+        if (annotationType == null) {
+            return false;
+        }
+        try {
+            return annotationType.getMethod(member).getReturnType().isArray();
+        } catch (NoSuchMethodException | LinkageError e) {
+            return false;
+        }
+    }
+
+    private static boolean isSourceArrayMember(ClassElement classElement, String member) {
+        try {
+            return classElement.getEnclosedElements(ElementQuery.ALL_METHODS).stream()
+                .filter(method -> method.getName().equals(member))
+                .map(MethodElement::getReturnType)
+                .anyMatch(returnType -> returnType.isArray());
+        } catch (RuntimeException e) {
+            return false;
         }
     }
 

--- a/sourcegen-bytecode-writer-core/src/main/java/io/micronaut/sourcegen/bytecode/core/AnnotationTargetUtils.java
+++ b/sourcegen-bytecode-writer-core/src/main/java/io/micronaut/sourcegen/bytecode/core/AnnotationTargetUtils.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.ElementQuery;
 import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.ast.TypedElement;
 import io.micronaut.sourcegen.model.AnnotationDef;
 import io.micronaut.sourcegen.model.AnnotationObjectDef;
 import io.micronaut.sourcegen.model.ClassTypeDef;
@@ -204,7 +205,7 @@ public final class AnnotationTargetUtils {
         }
         try {
             return annotationType.getMethod(member).getReturnType().isArray();
-        } catch (NoSuchMethodException | LinkageError e) {
+        } catch (NoSuchMethodException | LinkageError _) {
             return false;
         }
     }
@@ -214,8 +215,8 @@ public final class AnnotationTargetUtils {
             return classElement.getEnclosedElements(ElementQuery.ALL_METHODS).stream()
                 .filter(method -> method.getName().equals(member))
                 .map(MethodElement::getReturnType)
-                .anyMatch(returnType -> returnType.isArray());
-        } catch (RuntimeException e) {
+                .anyMatch(TypedElement::isArray);
+        } catch (RuntimeException _) {
             return false;
         }
     }

--- a/sourcegen-bytecode-writer-core/src/main/java/io/micronaut/sourcegen/bytecode/core/ModifierUtils.java
+++ b/sourcegen-bytecode-writer-core/src/main/java/io/micronaut/sourcegen/bytecode/core/ModifierUtils.java
@@ -16,6 +16,7 @@
 package io.micronaut.sourcegen.bytecode.core;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.sourcegen.model.AnnotationObjectDef;
 import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.EnumDef;
 import io.micronaut.sourcegen.model.InterfaceDef;
@@ -119,6 +120,9 @@ public final class ModifierUtils {
         if (objectDef instanceof RecordDef recordDef) {
             // The JVMS has no record access flag; the Record attribute marks a record class.
             return ACC_FINAL | memberFlags(recordDef.getModifiers());
+        }
+        if (objectDef instanceof AnnotationObjectDef annotationObjectDef) {
+            return ACC_ANNOTATION | ACC_INTERFACE | ACC_ABSTRACT | memberFlags(annotationObjectDef.getModifiers());
         }
         return memberFlags(objectDef.getModifiers());
     }

--- a/sourcegen-bytecode-writer-jdk/src/main/java/io/micronaut/sourcegen/bytecode/jdk/ByteCodeWriter.java
+++ b/sourcegen-bytecode-writer-jdk/src/main/java/io/micronaut/sourcegen/bytecode/jdk/ByteCodeWriter.java
@@ -18,6 +18,7 @@ package io.micronaut.sourcegen.bytecode.jdk;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.sourcegen.JavaPoetSourceGenerator;
+import io.micronaut.sourcegen.bytecode.core.AnnotationTargetUtils;
 import io.micronaut.sourcegen.model.ClassDef;
 import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.EnumDef;
@@ -528,9 +529,47 @@ public final class ByteCodeWriter {
 
     static Annotation toAnnotation(io.micronaut.sourcegen.model.AnnotationDef annotation) {
         List<AnnotationElement> elements = annotation.getValues().entrySet().stream()
-            .map(entry -> AnnotationElement.of(entry.getKey(), toAnnotationValue(entry.getValue())))
+            .map(entry -> AnnotationElement.of(entry.getKey(), toMemberValue(annotation, entry.getKey(), entry.getValue())))
             .toList();
         return Annotation.of(ClassDesc.of(annotation.getType().getName()), elements);
+    }
+
+    /**
+     * The value of one member of an annotation. A single value is the source shorthand for a one
+     * element array - {@code @Target(TYPE)} means {@code @Target({TYPE})} - and a class file has no
+     * such shorthand, so it is wrapped when the member is declared as an array.
+     */
+    private static AnnotationValue toMemberValue(io.micronaut.sourcegen.model.AnnotationDef annotation,
+                                                 String member, Object value) {
+        if (isSingleValue(value)
+            && AnnotationTargetUtils.isArrayMember(annotation, member, ByteCodeWriter.class.getClassLoader())) {
+            return AnnotationValue.ofArray(List.of(toAnnotationValue(value)));
+        }
+        return toAnnotationValue(value);
+    }
+
+    /**
+     * An annotation value, wrapped into a one element array when it stands for a single element of a
+     * member declared with the given array type.
+     *
+     * @param value The value
+     * @param declaredType The declared type of what the value belongs to
+     * @return The annotation value
+     */
+    static AnnotationValue toAnnotationValue(Object value, TypeDef declaredType) {
+        if (declaredType instanceof TypeDef.Array && isSingleValue(value)) {
+            return AnnotationValue.ofArray(List.of(toAnnotationValue(value)));
+        }
+        return toAnnotationValue(value);
+    }
+
+    /**
+     * Whether a value stands for one element rather than for a whole array member.
+     */
+    private static boolean isSingleValue(Object value) {
+        Object actual = value instanceof io.micronaut.sourcegen.model.ExpressionDef.Constant constant
+            ? constant.value() : value;
+        return actual != null && !(actual instanceof Collection<?>) && !actual.getClass().isArray();
     }
 
     static AnnotationValue toAnnotationValue(Object value) {

--- a/sourcegen-bytecode-writer-jdk/src/main/java/io/micronaut/sourcegen/bytecode/jdk/JdkClassFileWriter.java
+++ b/sourcegen-bytecode-writer-jdk/src/main/java/io/micronaut/sourcegen/bytecode/jdk/JdkClassFileWriter.java
@@ -23,6 +23,7 @@ import io.micronaut.sourcegen.bytecode.core.ModifierUtils;
 import io.micronaut.sourcegen.bytecode.core.SignatureUtils;
 import io.micronaut.sourcegen.bytecode.core.TypeUtils;
 import io.micronaut.sourcegen.model.AnnotationDef;
+import io.micronaut.sourcegen.model.AnnotationObjectDef;
 import io.micronaut.sourcegen.model.ClassDef;
 import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.EnumDef;
@@ -49,6 +50,7 @@ import java.lang.classfile.MethodBuilder;
 import java.lang.classfile.attribute.ExceptionsAttribute;
 import java.lang.classfile.attribute.InnerClassInfo;
 import java.lang.classfile.attribute.InnerClassesAttribute;
+import java.lang.classfile.attribute.AnnotationDefaultAttribute;
 import java.lang.classfile.attribute.NestHostAttribute;
 import java.lang.classfile.attribute.NestMembersAttribute;
 import java.lang.classfile.attribute.MethodParameterInfo;
@@ -136,7 +138,73 @@ final class JdkClassFileWriter {
             writeRecord(builder, recordDef, owner, outerType);
         } else if (objectDef instanceof InterfaceDef interfaceDef) {
             writeInterface(builder, interfaceDef, owner, outerType);
+        } else if (objectDef instanceof AnnotationObjectDef annotationObjectDef) {
+            writeAnnotationObject(builder, annotationObjectDef, owner, outerType);
         }
+    }
+
+    /**
+     * Writes an annotation type the way a compiler emits one: an interface flagged
+     * {@code ACC_ANNOTATION} that extends {@link java.lang.annotation.Annotation}, with one abstract
+     * accessor per member and the member's default, when it has one, in that accessor's
+     * {@code AnnotationDefault} attribute.
+     */
+    private void writeAnnotationObject(ClassBuilder builder, AnnotationObjectDef annotationDef, ClassDesc owner,
+                                       @Nullable ClassTypeDef outerType) {
+        int flags = ModifierUtils.ACC_ANNOTATION | ModifierUtils.ACC_INTERFACE | ModifierUtils.ACC_ABSTRACT
+            | ModifierUtils.classFlags(annotationDef.getModifiers(), outerType);
+        if (annotationDef.isSynthetic()) {
+            flags |= ModifierUtils.ACC_SYNTHETIC;
+        }
+        builder.withVersion(ClassFile.JAVA_17_VERSION, 0)
+            .withFlags(flags)
+            .withSuperclass(ConstantDescs.CD_Object)
+            .withInterfaceSymbols(List.of(ClassDesc.of(java.lang.annotation.Annotation.class.getName())));
+        writeOuterInner(builder, annotationDef, owner, outerType);
+        addAnnotations(builder, annotationDef.getAnnotations());
+        List<StatementDef> staticInitializer = new ArrayList<>();
+        for (FieldDef field : annotationDef.getFields()) {
+            writeField(builder, annotationDef, field);
+            // A constant of an annotation type is implicitly static, wherever it is assigned from
+            field.getInitializer().ifPresent(initializer ->
+                staticInitializer.add(annotationDef.asTypeDef().getStaticField(field).put(initializer)));
+        }
+        if (!staticInitializer.isEmpty()) {
+            writeMethod(builder, annotationDef, MethodDef.builder("<clinit>")
+                .addModifiers(Modifier.STATIC)
+                .addStatement(StatementDef.multi(staticInitializer))
+                .build(), owner);
+        }
+        for (AnnotationObjectDef.AnnotationMemberDef member : annotationDef.getMembers()) {
+            writeAnnotationMember(builder, annotationDef, member);
+        }
+    }
+
+    /**
+     * Writes a member of an annotation type as the abstract accessor it is, followed by its default.
+     * A default is a single value, which is what the {@code AnnotationDefault} attribute holds.
+     */
+    private void writeAnnotationMember(ClassBuilder builder, AnnotationObjectDef annotationDef,
+                                       AnnotationObjectDef.AnnotationMemberDef member) {
+        MethodDef accessor = MethodDef.builder(member.getName())
+            .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+            .addAnnotations(member.getAnnotations())
+            .returns(member.getType())
+            .build();
+        Object defaultValue = member.getAnnotationDefaultValue() != null
+            ? member.getAnnotationDefaultValue()
+            : member.getDefaultValue();
+        builder.withMethod(accessor.getName(),
+            MethodTypeDesc.ofDescriptor(TypeUtils.getMethodDescriptor(annotationDef, accessor)),
+            ModifierUtils.ACC_PUBLIC | ModifierUtils.ACC_ABSTRACT,
+            methodBuilder -> {
+                addMethodMetadata(methodBuilder, annotationDef, accessor);
+                addTypeAnnotations(methodBuilder, methodTypeAnnotations(accessor));
+                if (defaultValue != null) {
+                    methodBuilder.with(AnnotationDefaultAttribute.of(
+                        ByteCodeWriter.toAnnotationValue(defaultValue, member.getType())));
+                }
+            });
     }
 
     /**
@@ -911,6 +979,14 @@ final class JdkClassFileWriter {
             if (classDef.getStaticInitializer() != null && !JdkMethodSupport.supported(classDef.getStaticInitializer())) {
                 return false;
             }
+        } else if (objectDef instanceof AnnotationObjectDef annotationObjectDef) {
+            for (FieldDef field : annotationObjectDef.getFields()) {
+                if (field.getInitializer().isPresent()
+                    && !field.getInitializer().stream().allMatch(JdkMethodSupport::supported)) {
+                    return false;
+                }
+            }
+            return true;
         } else if (!(objectDef instanceof RecordDef) && !(objectDef instanceof InterfaceDef)) {
             return false;
         }

--- a/sourcegen-bytecode-writer-jdk/src/main/java/io/micronaut/sourcegen/bytecode/jdk/SourcegenClassHierarchyResolver.java
+++ b/sourcegen-bytecode-writer-jdk/src/main/java/io/micronaut/sourcegen/bytecode/jdk/SourcegenClassHierarchyResolver.java
@@ -16,6 +16,7 @@
 package io.micronaut.sourcegen.bytecode.jdk;
 
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.sourcegen.model.AnnotationObjectDef;
 import io.micronaut.sourcegen.model.ClassDef;
 import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.EnumDef;
@@ -103,7 +104,8 @@ final class SourcegenClassHierarchyResolver implements ClassHierarchyResolver {
             return;
         }
         ClassDesc name = ClassDesc.of(objectDef.getName());
-        if (objectDef instanceof InterfaceDef) {
+        if (objectDef instanceof InterfaceDef || objectDef instanceof AnnotationObjectDef) {
+            // An annotation type is an interface
             interfaces.add(name);
         } else if (objectDef instanceof RecordDef) {
             superclasses.put(name, ClassDesc.of("java.lang.Record"));

--- a/sourcegen-bytecode-writer-jdk/src/test/java/io/micronaut/sourcegen/bytecode/jdk/JdkAnnotationObjectWriterTest.java
+++ b/sourcegen-bytecode-writer-jdk/src/test/java/io/micronaut/sourcegen/bytecode/jdk/JdkAnnotationObjectWriterTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.bytecode.jdk;
+
+import io.micronaut.sourcegen.model.AnnotationDef;
+import io.micronaut.sourcegen.model.AnnotationObjectDef;
+import io.micronaut.sourcegen.model.AnnotationObjectDef.AnnotationMemberDef;
+import io.micronaut.sourcegen.model.ClassTypeDef;
+import io.micronaut.sourcegen.model.ExpressionDef;
+import io.micronaut.sourcegen.model.FieldDef;
+import io.micronaut.sourcegen.model.ObjectDef;
+import io.micronaut.sourcegen.model.TypeDef;
+import org.junit.jupiter.api.Test;
+
+import javax.lang.model.element.Modifier;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.classfile.ClassFile;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An annotation type written by the JDK backend has to be readable by the reflection that reads a
+ * compiled one: the flags of an annotation type, its meta-annotations, and the default of every member.
+ */
+class JdkAnnotationObjectWriterTest {
+
+    @Test
+    void writesAnAnnotationTypeThatReflectsLikeACompiledOne() throws Exception {
+        Class<?> annotationClass = define(annotationDef("example.MyAnnotation"));
+
+        assertTrue(annotationClass.isAnnotation());
+        assertTrue(annotationClass.isInterface());
+        assertTrue(Annotation.class.isAssignableFrom(annotationClass));
+
+        assertEquals(RetentionPolicy.RUNTIME, annotationClass.getAnnotation(Retention.class).value());
+        assertArrayEquals(new ElementType[]{ElementType.TYPE}, annotationClass.getAnnotation(Target.class).value());
+
+        assertEquals(String.class, annotationClass.getDeclaredMethod("string").getReturnType());
+        assertEquals("hello", annotationClass.getDeclaredMethod("string").getDefaultValue());
+        assertEquals(int.class, annotationClass.getDeclaredMethod("primitive").getReturnType());
+        assertEquals(2, annotationClass.getDeclaredMethod("primitive").getDefaultValue());
+        assertEquals(ElementType.TYPE, annotationClass.getDeclaredMethod("enumValue").getDefaultValue());
+        assertArrayEquals(new int[]{1, 2, 3}, (int[]) annotationClass.getDeclaredMethod("array").getDefaultValue());
+
+        Method floats = annotationClass.getDeclaredMethod("floats");
+        assertEquals(float[].class, floats.getReturnType());
+        assertNull(floats.getDefaultValue());
+
+        Target inner = (Target) annotationClass.getDeclaredMethod("inner").getDefaultValue();
+        assertArrayEquals(new ElementType[]{ElementType.TYPE}, inner.value());
+    }
+
+    @Test
+    void everyMemberOfAnAnnotationTypeIsPublicAndAbstract() {
+        Class<?> annotationClass = define(annotationDef("example.MyAnnotation"));
+
+        for (Method member : annotationClass.getDeclaredMethods()) {
+            assertTrue(java.lang.reflect.Modifier.isPublic(member.getModifiers()), member.getName());
+            assertTrue(java.lang.reflect.Modifier.isAbstract(member.getModifiers()), member.getName());
+            assertEquals(0, member.getParameterCount(), member.getName());
+        }
+    }
+
+    @Test
+    void writesTheConstantsAnAnnotationTypeDeclares() throws Exception {
+        AnnotationObjectDef definition = AnnotationObjectDef.builder("example.WithConstant")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(AnnotationDef.builder(Retention.class)
+                .addMember("value", RetentionPolicy.RUNTIME)
+                .build())
+            .addField(FieldDef.builder("DEFAULT_NAME", TypeDef.STRING)
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                .initializer(ExpressionDef.constant("none"))
+                .build())
+            .addMember(AnnotationMemberDef.builder("name", TypeDef.STRING)
+                .withDefault(ExpressionDef.constant("none"))
+                .build())
+            .build();
+
+        Class<?> annotationClass = define(definition);
+
+        assertTrue(annotationClass.isAnnotation());
+        assertEquals("none", annotationClass.getDeclaredField("DEFAULT_NAME").get(null));
+        assertEquals("none", annotationClass.getDeclaredMethod("name").getDefaultValue());
+    }
+
+    @Test
+    void writesAClassValuedMemberWithItsDefault() throws Exception {
+        AnnotationObjectDef definition = AnnotationObjectDef.builder("example.WithClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(AnnotationDef.builder(Retention.class)
+                .addMember("value", RetentionPolicy.RUNTIME)
+                .build())
+            .addMember(AnnotationMemberDef.builder("type", TypeDef.CLASS)
+                .withDefault(ExpressionDef.constant(ClassTypeDef.of(String.class)))
+                .build())
+            .build();
+
+        assertEquals(String.class, define(definition).getDeclaredMethod("type").getDefaultValue());
+    }
+
+    /**
+     * The same definition the Java, Kotlin and ASM backends are covered with.
+     */
+    private static AnnotationObjectDef annotationDef(String className) {
+        return AnnotationObjectDef.builder(className)
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(AnnotationDef.builder(Retention.class)
+                .addMember("value", RetentionPolicy.RUNTIME)
+                .build())
+            .addAnnotation(AnnotationDef.builder(Target.class)
+                .addMember("value", ElementType.TYPE)
+                .build())
+            .addJavadoc("This is my annotation")
+            .addMember(AnnotationMemberDef.builder("string", TypeDef.STRING)
+                .withDefault(ExpressionDef.constant("hello"))
+                .build())
+            .addMember(AnnotationMemberDef.builder("primitive", TypeDef.Primitive.INT)
+                .withDefault(ExpressionDef.constant(2))
+                .build())
+            .addMember(AnnotationMemberDef.builder("floats", TypeDef.Primitive.FLOAT.array())
+                .build())
+            .addMember(AnnotationMemberDef.builder("enumValue", ClassTypeDef.of(ElementType.class))
+                .withDefault(ClassTypeDef.of(ElementType.class)
+                    .getStaticField("TYPE", ClassTypeDef.of(ElementType.class)))
+                .build())
+            .addMember(AnnotationMemberDef.builder("inner", ClassTypeDef.of(Target.class))
+                .withDefault(AnnotationDef.builder(Target.class)
+                    .addMember("value", ElementType.TYPE)
+                    .build())
+                .build())
+            .addMember(AnnotationMemberDef.builder("array", TypeDef.Primitive.INT.array())
+                .withDefault(ExpressionDef.constant(new int[]{1, 2, 3}))
+                .build())
+            .build();
+    }
+
+    private Class<?> define(ObjectDef definition) {
+        byte[] bytes = new JdkClassFileWriter(true).write(definition, null)
+            .orElseThrow(() -> new AssertionError("Expected direct ClassFile lowering for " + definition.getName()));
+        assertTrue(ClassFile.of().verify(bytes).isEmpty());
+        return new ClassLoader(getClass().getClassLoader()) {
+            Class<?> define() {
+                return defineClass(definition.getName(), bytes, 0, bytes.length);
+            }
+        }.define();
+    }
+}

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
@@ -19,8 +19,11 @@ import org.jspecify.annotations.Nullable;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.sourcegen.bytecode.core.AnnotationTargetUtils;
 import io.micronaut.sourcegen.bytecode.statement.StatementWriter;
 import io.micronaut.sourcegen.model.AnnotationDef;
+import io.micronaut.sourcegen.model.AnnotationObjectDef;
+import io.micronaut.sourcegen.model.AnnotationObjectDef.AnnotationMemberDef;
 import io.micronaut.sourcegen.model.ClassDef;
 import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.EnumDef;
@@ -69,6 +72,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.objectweb.asm.Opcodes.ACC_ABSTRACT;
+import static org.objectweb.asm.Opcodes.ACC_ANNOTATION;
 import static org.objectweb.asm.Opcodes.ACC_BRIDGE;
 import static org.objectweb.asm.Opcodes.ACC_ENUM;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
@@ -148,6 +152,8 @@ public final class ByteCodeWriter {
             writeInterface(classVisitor, interfaceDef, outerType);
         } else if (objectDef instanceof EnumDef enumDef) {
             writeClass(classVisitor, EnumGenUtils.toClassDef(enumDef), outerType);
+        } else if (objectDef instanceof AnnotationObjectDef annotationObjectDef) {
+            writeAnnotationObject(classVisitor, annotationObjectDef, outerType);
         } else {
             throw new UnsupportedOperationException("Unknown object definition: " + objectDef);
         }
@@ -284,6 +290,96 @@ public final class ByteCodeWriter {
         for (PropertyDef property : interfaceDef.getProperties()) {
             writeProperty(classVisitor, interfaceDef, property, emittedBridges);
         }
+    }
+
+    /**
+     * Write an annotation type.
+     *
+     * <p>An annotation type is emitted the way a compiler emits it: an interface flagged
+     * {@code ACC_ANNOTATION} that extends {@link Annotation}, with one abstract accessor per member and
+     * the member's default, when it has one, in that accessor's {@code AnnotationDefault} attribute.</p>
+     *
+     * @param classVisitor  The class visitor
+     * @param annotationDef The annotation definition
+     * @param outerType     The outer type
+     */
+    public void writeAnnotationObject(ClassVisitor classVisitor, AnnotationObjectDef annotationDef, @Nullable ClassTypeDef outerType) {
+        int modifiersFlag = ACC_ANNOTATION | ACC_INTERFACE | ACC_ABSTRACT
+            | getClassModifiersFlag(annotationDef.getModifiers(), outerType);
+        if (annotationDef.isSynthetic()) {
+            modifiersFlag |= ACC_SYNTHETIC;
+        }
+        ClassTypeDef typeDef = annotationDef.asTypeDef();
+        classVisitor.visit(V17,
+            modifiersFlag,
+            TypeUtils.getType(typeDef).getInternalName(),
+            null,
+            TypeUtils.OBJECT_TYPE.getInternalName(),
+            new String[]{Type.getType(Annotation.class).getInternalName()}
+        );
+        writeOuterInner(classVisitor, typeDef, annotationDef, outerType);
+        for (AnnotationDef annotation : annotationDef.getAnnotations()) {
+            writeAnnotation(annotation, classVisitor::visitAnnotation);
+        }
+        List<StatementDef> staticInitStatements = new ArrayList<>();
+        for (FieldDef field : annotationDef.getFields()) {
+            writeField(classVisitor, annotationDef, field);
+            // A constant of an annotation type is implicitly static, wherever it is assigned from
+            field.getInitializer().ifPresent(initializer ->
+                staticInitStatements.add(typeDef.getStaticField(field).put(initializer)));
+        }
+        if (!staticInitStatements.isEmpty()) {
+            writeMethod(classVisitor, annotationDef,
+                createStaticInitializer(StatementDef.multi(staticInitStatements)), new HashSet<>());
+        }
+        for (AnnotationMemberDef member : annotationDef.getMembers()) {
+            writeAnnotationMember(classVisitor, annotationDef, member);
+        }
+    }
+
+    /**
+     * Write a member of an annotation type as the abstract accessor it is, followed by its default value.
+     * A default is a single value written with no name, which is what the {@code AnnotationDefault}
+     * attribute holds.
+     */
+    private void writeAnnotationMember(ClassVisitor classVisitor, AnnotationObjectDef annotationDef, AnnotationMemberDef member) {
+        MethodDef accessor = MethodDef.builder(member.getName())
+            .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+            .addAnnotations(member.getAnnotations())
+            .returns(member.getType())
+            .build();
+        MethodVisitor methodVisitor = visitMethodHeader(
+            classVisitor,
+            annotationDef,
+            accessor,
+            ACC_PUBLIC | ACC_ABSTRACT,
+            accessor.getName(),
+            TypeUtils.getMethodDescriptor(annotationDef, accessor)
+        );
+        for (AnnotationDef annotation : member.getAnnotations()) {
+            writeAnnotation(annotation, methodVisitor::visitAnnotation);
+        }
+        writeTypeAnnotations(
+            member.getType(),
+            TypeReference.newTypeReference(TypeReference.METHOD_RETURN).getValue(),
+            methodVisitor::visitTypeAnnotation
+        );
+        Object defaultValue = member.getAnnotationDefaultValue() != null
+            ? member.getAnnotationDefaultValue()
+            : member.getDefaultValue();
+        if (defaultValue != null) {
+            AnnotationVisitor annotationVisitor = methodVisitor.visitAnnotationDefault();
+            if (annotationVisitor != null) {
+                if (member.getType() instanceof TypeDef.Array && isSingleValue(defaultValue)) {
+                    // A single value is the source shorthand for a one element array
+                    visitAnnotationArray(annotationVisitor, null, List.of(defaultValue));
+                } else {
+                    visitAnnotation(annotationVisitor, null, defaultValue);
+                }
+                annotationVisitor.visitEnd();
+            }
+        }
+        methodVisitor.visitEnd();
     }
 
     /**
@@ -900,6 +996,9 @@ public final class ByteCodeWriter {
             // A record is always final; ACC_RECORD is not among the flags an inner class entry may carry
             return ACC_FINAL | getModifiersFlag(recordDef.getModifiers());
         }
+        if (objectDef instanceof AnnotationObjectDef annotationObjectDef) {
+            return ACC_ANNOTATION | ACC_INTERFACE | ACC_ABSTRACT | getModifiersFlag(annotationObjectDef.getModifiers());
+        }
         return getModifiersFlag(objectDef.getModifiers());
     }
 
@@ -921,12 +1020,25 @@ public final class ByteCodeWriter {
         for (Map.Entry<String, Object> entry : annotation.getValues().entrySet()) {
             String key = entry.getKey();
             Object value = entry.getValue();
-            visitAnnotation(annotationVisitor, key, value);
+            if (isSingleValue(value) && AnnotationTargetUtils.isArrayMember(annotation, key, getClass().getClassLoader())) {
+                // A single value is the source shorthand for a one element array; a class file has no shorthand
+                visitAnnotationArray(annotationVisitor, key, List.of(value));
+            } else {
+                visitAnnotation(annotationVisitor, key, value);
+            }
         }
         annotationVisitor.visitEnd();
     }
 
     private void visitAnnotation(AnnotationVisitor annotationVisitor, @Nullable String name, Object value) {
+        if (value instanceof ExpressionDef.Constant constant) {
+            Object constantValue = constant.value();
+            if (constantValue == null) {
+                throw new IllegalArgumentException("An annotation value cannot be null: " + name);
+            }
+            visitAnnotation(annotationVisitor, name, constantValue);
+            return;
+        }
         if (value instanceof VariableDef.StaticField staticField) {
             if (staticField.name().equals("class") && staticField.type().equals(TypeDef.CLASS)) {
                 annotationVisitor.visit(name, TypeUtils.getType(staticField.ownerType(), null));
@@ -952,9 +1064,19 @@ public final class ByteCodeWriter {
             visitAnnotationArray(annotationVisitor, name, coll);
         } else if (value instanceof Object[] array) {
             visitAnnotationArray(annotationVisitor, name, Arrays.asList(array));
+        } else if (value instanceof Enum<?> anEnum) {
+            annotationVisitor.visitEnum(name, Type.getDescriptor(anEnum.getDeclaringClass()), anEnum.name());
         } else {
             annotationVisitor.visit(name, value);
         }
+    }
+
+    /**
+     * Whether a value stands for one element rather than for a whole array member.
+     */
+    private static boolean isSingleValue(Object value) {
+        Object actual = value instanceof ExpressionDef.Constant constant ? constant.value() : value;
+        return actual != null && !(actual instanceof Collection<?>) && !actual.getClass().isArray();
     }
 
     private void visitAnnotationArray(AnnotationVisitor annotationVisitor, @Nullable String name, Collection<?> values) {

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/ByteCodeWriter.java
@@ -1030,25 +1030,10 @@ public final class ByteCodeWriter {
         annotationVisitor.visitEnd();
     }
 
-    private void visitAnnotation(AnnotationVisitor annotationVisitor, @Nullable String name, Object value) {
-        if (value instanceof ExpressionDef.Constant constant) {
-            Object constantValue = constant.value();
-            if (constantValue == null) {
-                throw new IllegalArgumentException("An annotation value cannot be null: " + name);
-            }
-            visitAnnotation(annotationVisitor, name, constantValue);
-            return;
-        }
+    private void visitAnnotation(AnnotationVisitor annotationVisitor, @Nullable String name, Object annotationValue) {
+        Object value = unwrapConstant(annotationValue, name);
         if (value instanceof VariableDef.StaticField staticField) {
-            if (staticField.name().equals("class") && staticField.type().equals(TypeDef.CLASS)) {
-                annotationVisitor.visit(name, TypeUtils.getType(staticField.ownerType(), null));
-            } else {
-                annotationVisitor.visitEnum(
-                    name,
-                    TypeUtils.getType(staticField.ownerType(), null).getDescriptor(),
-                    staticField.name()
-                );
-            }
+            visitStaticField(annotationVisitor, name, staticField);
         } else if (value instanceof ClassTypeDef classTypeDef) {
             annotationVisitor.visit(name, TypeUtils.getType(classTypeDef, null));
         } else if (value instanceof Class<?> type) {
@@ -1069,6 +1054,36 @@ public final class ByteCodeWriter {
         } else {
             annotationVisitor.visit(name, value);
         }
+    }
+
+    /**
+     * A static field is a class literal when it is the synthetic {@code class} field of a type, and the
+     * constant of an enum otherwise.
+     */
+    private static void visitStaticField(AnnotationVisitor annotationVisitor, @Nullable String name, VariableDef.StaticField staticField) {
+        if (staticField.name().equals("class") && staticField.type().equals(TypeDef.CLASS)) {
+            annotationVisitor.visit(name, TypeUtils.getType(staticField.ownerType(), null));
+        } else {
+            annotationVisitor.visitEnum(
+                name,
+                TypeUtils.getType(staticField.ownerType(), null).getDescriptor(),
+                staticField.name()
+            );
+        }
+    }
+
+    /**
+     * The value a constant expression stands for. An annotation value is never null.
+     */
+    private static Object unwrapConstant(Object value, @Nullable String name) {
+        if (value instanceof ExpressionDef.Constant constant) {
+            Object constantValue = constant.value();
+            if (constantValue == null) {
+                throw new IllegalArgumentException("An annotation value cannot be null: " + name);
+            }
+            return constantValue;
+        }
+        return value;
     }
 
     /**

--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/AnnotationObjectByteCodeWriterTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/AnnotationObjectByteCodeWriterTest.java
@@ -59,7 +59,7 @@ class AnnotationObjectByteCodeWriterTest {
     }
 
     @Test
-    void everyMemberOfAnAnnotationTypeIsPublicAndAbstract() throws Exception {
+    void everyMemberOfAnAnnotationTypeIsPublicAndAbstract() {
         Class<?> annotationClass = define(GenerateAnnotationClassVisitor.createAnnotation("example.MyAnnotation"));
 
         for (Method member : annotationClass.getDeclaredMethods()) {

--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/AnnotationObjectByteCodeWriterTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/AnnotationObjectByteCodeWriterTest.java
@@ -1,0 +1,122 @@
+package io.micronaut.sourcegen.bytecode;
+
+import io.micronaut.sourcegen.custom.visitor.GenerateAnnotationClassVisitor;
+import io.micronaut.sourcegen.model.AnnotationDef;
+import io.micronaut.sourcegen.model.AnnotationObjectDef;
+import io.micronaut.sourcegen.model.AnnotationObjectDef.AnnotationMemberDef;
+import io.micronaut.sourcegen.model.ClassTypeDef;
+import io.micronaut.sourcegen.model.ExpressionDef;
+import io.micronaut.sourcegen.model.FieldDef;
+import io.micronaut.sourcegen.model.ObjectDef;
+import io.micronaut.sourcegen.model.TypeDef;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.util.CheckClassAdapter;
+
+import javax.lang.model.element.Modifier;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An annotation type written as bytecode has to be readable by the reflection that reads a compiled one:
+ * the flags of an annotation type, its meta-annotations, and the default of every member.
+ */
+class AnnotationObjectByteCodeWriterTest {
+
+    @Test
+    void writesAnAnnotationTypeThatReflectsLikeACompiledOne() throws Exception {
+        Class<?> annotationClass = define(GenerateAnnotationClassVisitor.createAnnotation("example.MyAnnotation"));
+
+        assertTrue(annotationClass.isAnnotation());
+        assertTrue(annotationClass.isInterface());
+        assertTrue(Annotation.class.isAssignableFrom(annotationClass));
+
+        assertEquals(RetentionPolicy.RUNTIME, annotationClass.getAnnotation(Retention.class).value());
+        assertArrayEquals(new ElementType[]{ElementType.TYPE}, annotationClass.getAnnotation(Target.class).value());
+
+        assertEquals(String.class, annotationClass.getDeclaredMethod("string").getReturnType());
+        assertEquals("hello", annotationClass.getDeclaredMethod("string").getDefaultValue());
+        assertEquals(int.class, annotationClass.getDeclaredMethod("primitive").getReturnType());
+        assertEquals(2, annotationClass.getDeclaredMethod("primitive").getDefaultValue());
+        assertEquals(ElementType.TYPE, annotationClass.getDeclaredMethod("enumValue").getDefaultValue());
+        assertArrayEquals(new int[]{1, 2, 3}, (int[]) annotationClass.getDeclaredMethod("array").getDefaultValue());
+
+        Method floats = annotationClass.getDeclaredMethod("floats");
+        assertEquals(float[].class, floats.getReturnType());
+        assertNull(floats.getDefaultValue());
+
+        Target inner = (Target) annotationClass.getDeclaredMethod("inner").getDefaultValue();
+        assertArrayEquals(new ElementType[]{ElementType.TYPE}, inner.value());
+    }
+
+    @Test
+    void everyMemberOfAnAnnotationTypeIsPublicAndAbstract() throws Exception {
+        Class<?> annotationClass = define(GenerateAnnotationClassVisitor.createAnnotation("example.MyAnnotation"));
+
+        for (Method member : annotationClass.getDeclaredMethods()) {
+            assertTrue(java.lang.reflect.Modifier.isPublic(member.getModifiers()), member.getName());
+            assertTrue(java.lang.reflect.Modifier.isAbstract(member.getModifiers()), member.getName());
+            assertEquals(0, member.getParameterCount(), member.getName());
+        }
+    }
+
+    @Test
+    void writesTheConstantsAnAnnotationTypeDeclares() throws Exception {
+        AnnotationObjectDef annotationDef = AnnotationObjectDef.builder("example.WithConstant")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(AnnotationDef.builder(Retention.class)
+                .addMember("value", RetentionPolicy.RUNTIME)
+                .build())
+            .addField(FieldDef.builder("DEFAULT_NAME", TypeDef.STRING)
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                .initializer(ExpressionDef.constant("none"))
+                .build())
+            .addMember(AnnotationMemberDef.builder("name", TypeDef.STRING)
+                .withDefault(ExpressionDef.constant("none"))
+                .build())
+            .build();
+
+        Class<?> annotationClass = define(annotationDef);
+
+        assertTrue(annotationClass.isAnnotation());
+        assertEquals("none", annotationClass.getDeclaredField("DEFAULT_NAME").get(null));
+        assertEquals("none", annotationClass.getDeclaredMethod("name").getDefaultValue());
+    }
+
+    @Test
+    void writesAClassValuedMemberWithItsDefault() throws Exception {
+        AnnotationObjectDef annotationDef = AnnotationObjectDef.builder("example.WithClass")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(AnnotationDef.builder(Retention.class)
+                .addMember("value", RetentionPolicy.RUNTIME)
+                .build())
+            .addMember(AnnotationMemberDef.builder("type", TypeDef.CLASS)
+                .withDefault(ExpressionDef.constant(ClassTypeDef.of(String.class)))
+                .build())
+            .build();
+
+        Class<?> annotationClass = define(annotationDef);
+
+        assertEquals(String.class, annotationClass.getDeclaredMethod("type").getDefaultValue());
+    }
+
+    private Class<?> define(ObjectDef objectDef) {
+        var classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
+        new ByteCodeWriter(false, true).writeObject(new CheckClassAdapter(classWriter), objectDef, null);
+        byte[] bytes = classWriter.toByteArray();
+        return new ClassLoader(getClass().getClassLoader()) {
+            Class<?> define() {
+                return defineClass(objectDef.getName(), bytes, 0, bytes.length);
+            }
+        }.define();
+    }
+}

--- a/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/Trigger.java
+++ b/test-suite-bytecode/src/main/java/io/micronaut/sourcegen/example/Trigger.java
@@ -16,6 +16,7 @@
 package io.micronaut.sourcegen.example;
 
 
+import io.micronaut.sourcegen.custom.example.GenerateAnnotationClass;
 import io.micronaut.sourcegen.custom.example.GenerateArray;
 import io.micronaut.sourcegen.custom.example.GenerateExpressions;
 import io.micronaut.sourcegen.custom.example.GenerateGenericBridges;
@@ -54,5 +55,6 @@ import io.micronaut.sourcegen.custom.example.GenerateSwitch;
 @GenerateStatements
 @GenerateExpressions
 @GenerateGenericBridges
+@GenerateAnnotationClass
 public class Trigger {
 }

--- a/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/MyAnnotationTest.java
+++ b/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/MyAnnotationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The generated annotation type is applied to a class here, so it has to be a usable annotation type
+ * for the compiler as well as for reflection.
+ */
+@MyAnnotation(
+    string = "this",
+    primitive = 3,
+    floats = {1.0f, 2.0f},
+    inner = @Target(ElementType.TYPE)
+)
+class MyAnnotationTest {
+
+    @Test
+    void theGeneratedAnnotationTypeDeclaresItsMetaAnnotations() {
+        assertTrue(MyAnnotation.class.isAnnotation());
+        assertEquals(RetentionPolicy.RUNTIME, MyAnnotation.class.getAnnotation(Retention.class).value());
+        assertArrayEquals(new ElementType[]{ElementType.TYPE}, MyAnnotation.class.getAnnotation(Target.class).value());
+    }
+
+    @Test
+    void theValuesOfAnApplicationAreRead() {
+        MyAnnotation annotation = MyAnnotationTest.class.getAnnotation(MyAnnotation.class);
+
+        assertEquals("this", annotation.string());
+        assertEquals(3, annotation.primitive());
+        assertArrayEquals(new float[]{1.0f, 2.0f}, annotation.floats());
+        assertArrayEquals(new ElementType[]{ElementType.TYPE}, annotation.inner().value());
+    }
+
+    @Test
+    void theDefaultsOfTheMembersLeftOutAreRead() {
+        MyAnnotation annotation = MyAnnotationTest.class.getAnnotation(MyAnnotation.class);
+
+        assertEquals(ElementType.TYPE, annotation.enumValue());
+        assertArrayEquals(new int[]{1, 2, 3}, annotation.array());
+    }
+}


### PR DESCRIPTION
Supersedes #454, which bundled a Kotlin half — now obsolete, #487 landed a better one that also handles the nested-annotation default #454 listed as unsupported — with a bytecode half against `2.1.x`. Since #454 was opened a second bytecode backend arrived (#497), so this does the bytecode work in both.

## What

`AnnotationObjectDef` was written by the Java generator (#282) and, since #487, by the Kotlin generator. Both bytecode backends rejected it — `ByteCodeWriter.writeObject` threw `UnsupportedOperationException`, `JdkClassFileWriter.supported` returned `false` — so the Java and bytecode backends were not interchangeable for a generator that emits an annotation type.

Fixes the bytecode half of #283, which was closed when the Kotlin half landed.

## How

Both backends now emit an annotation type the way a compiler does:

- an interface flagged `ACC_ANNOTATION | ACC_INTERFACE | ACC_ABSTRACT` extending `java.lang.annotation.Annotation`,
- one abstract accessor per member, carrying the member's annotations and generic signature,
- the member's default, when it has one, in that accessor's `AnnotationDefault` attribute (`visitAnnotationDefault` on the ASM side, `AnnotationDefaultAttribute` on the JDK side),
- a `<clinit>` for the constants the type declares,
- `ACC_ANNOTATION | ACC_INTERFACE | ACC_ABSTRACT` in the `InnerClasses` entry of a nested one, and the annotation type registered as an interface with the JDK backend's hierarchy resolver.

Writing an annotation type also required the writers to resolve what a single value means. A single value is the source shorthand for a one element array — `@Target(TYPE)` means `@Target({TYPE})` — and a class file has no such shorthand, so `AnnotationTargetUtils` learned to read the declared type of a member: from an annotation definition generated in the same round, from the source element of one still being compiled, or from the loaded class. This is the same three-way resolution the existing `retentionOf` and `targetsOf` already do there, and it fixes a latent gap for ordinary annotations too, not only for defaults.

The ASM writer additionally lowers a raw enum constant and an `ExpressionDef.Constant` in an annotation value, both of which the JDK writer already handled.

## Tested

- `AnnotationObjectByteCodeWriterTest` (ASM) and `JdkAnnotationObjectWriterTest` (JDK): the generated class is loaded and read reflectively — `@Retention`/`@Target`, member return types and modifiers, and `Method#getDefaultValue` for a string, a primitive, an enum, a nested annotation, a `Class` and an `int[]`, plus a member with no default. The ASM output goes through `CheckClassAdapter`, the JDK output through `ClassFile#verify`, and the JDK test asserts direct lowering rather than the javac fallback.
- End to end: `@GenerateAnnotationClass` on the shared bytecode `Trigger`, which both `test-suite-bytecode` and `test-suite-bytecode-jdk` compile. `MyAnnotationTest` applies the generated annotation to a class — so javac has to accept it as an annotation type — and reads back both the values given and the defaults left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)