### PR TITLE
Build a singular map on the bytecode backends

### DIFF
--- a/sourcegen-bytecode-writer-jdk/src/main/java/io/micronaut/sourcegen/bytecode/jdk/JdkMethodWriter.java
+++ b/sourcegen-bytecode-writer-jdk/src/main/java/io/micronaut/sourcegen/bytecode/jdk/JdkMethodWriter.java
@@ -40,7 +40,9 @@ import java.lang.constant.DirectMethodHandleDesc;
 import java.lang.constant.DynamicCallSiteDesc;
 import java.lang.constant.MethodHandleDesc;
 import java.lang.constant.MethodTypeDesc;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -74,6 +76,7 @@ final class JdkMethodWriter {
     private final ClassDesc owner;
     private final Map<String, Local> locals = new LinkedHashMap<>();
     private final List<Runnable> cleanups = new ArrayList<>();
+    private final Deque<YieldTarget> yieldTargets = new ArrayDeque<>();
     private final List<MethodDef> lambdaMethods = new ArrayList<>();
     private final MethodDef methodDef;
 
@@ -197,6 +200,11 @@ final class JdkMethodWriter {
     }
 
     private void writeReturn(@Nullable ExpressionDef expression) {
+        YieldTarget yieldTarget = yieldTargets.peek();
+        if (yieldTarget != null) {
+            writeYield(expression, yieldTarget);
+            return;
+        }
         TypeDef returnType = methodDef.getReturnType();
         if (expression == null || returnType.equals(TypeDef.VOID)) {
             // A void method may still return the result of an expression, which is evaluated for
@@ -223,8 +231,44 @@ final class JdkMethodWriter {
         code.loadLocal(returnKind, slot).return_(returnKind);
     }
 
+    /**
+     * Writes a return that is the value of the switch yield case being written: the value is held
+     * in the local of the case and control jumps to its end, where the case loads it.
+     */
+    private void writeYield(@Nullable ExpressionDef expression, YieldTarget yieldTarget) {
+        if (expression == null) {
+            throw new IllegalStateException("Switch yield return has no value");
+        }
+        writeExpression(new ExpressionDef.Cast(yieldTarget.type(), expression));
+        store(yieldTarget.type(), yieldTarget.slot());
+        writeCleanups(yieldTarget.cleanups());
+        code.goto_(yieldTarget.end());
+    }
+
+    /**
+     * Writes a switch yield case, leaving the value it yields on the stack. The case is a statement
+     * block, and the returns it contains are its yields; the ASM backend lowers them the same way.
+     */
+    private void writeYieldCase(ExpressionDef.SwitchYieldCase yieldCase) {
+        TypeKind kind = kind(yieldCase.type());
+        int slot = code.allocateLocal(kind);
+        Label end = code.newLabel();
+        yieldTargets.push(new YieldTarget(yieldCase.type(), slot, end, cleanups.size()));
+        try {
+            writeStatement(yieldCase.statement());
+        } finally {
+            yieldTargets.pop();
+        }
+        code.labelBinding(end);
+        code.loadLocal(kind, slot);
+    }
+
     private void writeCleanups() {
-        for (int i = cleanups.size() - 1; i >= 0; i--) {
+        writeCleanups(0);
+    }
+
+    private void writeCleanups(int from) {
+        for (int i = cleanups.size() - 1; i >= from; i--) {
             cleanups.get(i).run();
         }
     }
@@ -583,7 +627,7 @@ final class JdkMethodWriter {
             case MethodReferenceExpression methodReference -> writeMethodReference(methodReference);
             case ExpressionDef.IfElse ifElse -> writeIfElseExpression(ifElse);
             case ExpressionDef.Switch aSwitch -> writeExpressionSwitch(aSwitch);
-            case ExpressionDef.SwitchYieldCase yieldCase -> writeStatement(yieldCase.statement());
+            case ExpressionDef.SwitchYieldCase yieldCase -> writeYieldCase(yieldCase);
             case ExpressionDef.NewArrayOfSize array -> {
                 code.loadConstant(array.size());
                 writeNewArray(array.type());
@@ -838,8 +882,8 @@ final class JdkMethodWriter {
      */
     private void writeCaseValue(TypeDef type, ExpressionDef value, @Nullable Label end) {
         if (value instanceof ExpressionDef.SwitchYieldCase yieldCase) {
-            writeStatement(yieldCase.statement());
-            if (end != null && canCompleteNormally(yieldCase.statement())) {
+            writeYieldCase(yieldCase);
+            if (end != null) {
                 code.goto_(end);
             }
             return;
@@ -1625,6 +1669,18 @@ final class JdkMethodWriter {
 
     private static UnsupportedOperationException unsupported(Object value) {
         return new UnsupportedOperationException("Unsupported direct JDK lowering: " + value.getClass().getName());
+    }
+
+    /**
+     * A switch yield case being written.
+     *
+     * @param type     The type the case yields
+     * @param slot     The local the yielded value is held in
+     * @param end      The label the value is loaded at
+     * @param cleanups The number of finally blocks pending when the case was entered - only the
+     *                 ones opened inside the case run when it yields
+     */
+    private record YieldTarget(TypeDef type, int slot, Label end, int cleanups) {
     }
 
     private record Local(TypeDef type, int slot) {

--- a/sourcegen-bytecode-writer-jdk/src/main/java/io/micronaut/sourcegen/bytecode/jdk/JdkMethodWriter.java
+++ b/sourcegen-bytecode-writer-jdk/src/main/java/io/micronaut/sourcegen/bytecode/jdk/JdkMethodWriter.java
@@ -658,6 +658,15 @@ final class JdkMethodWriter {
             case ExpressionDef.InvokeHashCodeMethod hashCode ->
                 // Null-safe, array-aware and primitive-aware, exactly as the ASM writer lowers it
                 writeExpression(JavaIdioms.hashCode(hashCode));
+            default -> writeBooleanValued(expression);
+        }
+    }
+
+    /**
+     * Writes an expression whose value is a boolean, leaving 0 or 1 on the stack.
+     */
+    private void writeBooleanValued(ExpressionDef expression) {
+        switch (expression) {
             case ExpressionDef.InstanceOf instanceOf -> {
                 writeExpression(instanceOf.expression());
                 code.instanceOf(classDesc(instanceOf.instanceType()));
@@ -670,12 +679,8 @@ final class JdkMethodWriter {
                 code.loadConstant(1).ixor();
             }
             case ExpressionDef.ComparisonOperation comparison -> writeBooleanExpression(comparison);
-            case ExpressionDef.IsNull isNull -> {
-                writeBooleanExpression(isNull);
-            }
-            case ExpressionDef.IsNotNull isNotNull -> {
-                writeBooleanExpression(isNotNull);
-            }
+            case ExpressionDef.IsNull isNull -> writeBooleanExpression(isNull);
+            case ExpressionDef.IsNotNull isNotNull -> writeBooleanExpression(isNotNull);
             case ExpressionDef.IsTrue isTrue -> writeExpression(isTrue.expression());
             case ExpressionDef.IsFalse isFalse -> {
                 writeExpression(isFalse.expression());

--- a/sourcegen-bytecode-writer-jdk/src/test/java/io/micronaut/sourcegen/bytecode/jdk/JdkExpressionLoweringTest.java
+++ b/sourcegen-bytecode-writer-jdk/src/test/java/io/micronaut/sourcegen/bytecode/jdk/JdkExpressionLoweringTest.java
@@ -35,11 +35,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.classfile.Attributes;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
+import java.lang.reflect.Method;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.List;
 import java.util.Map;
 
+import static io.micronaut.sourcegen.model.ExpressionDef.ComparisonOperation.OpType.EQUAL_TO;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -89,6 +91,45 @@ class JdkExpressionLoweringTest {
         assertEquals(1, generated.getMethod("rank", String.class).invoke(null, "red"));
         assertEquals(2, generated.getMethod("rank", String.class).invoke(null, "blue"));
         assertEquals(0, generated.getMethod("rank", String.class).invoke(null, "green"));
+    }
+
+    @Test
+    void yieldsToTheSwitchWhenTheSwitchIsAnArgument() throws Exception {
+        // A switch yield case yields the value of its block to the switch, so a switch that is not
+        // itself what the method returns - here it is an argument - must not return from the method
+        Map<ExpressionDef.Constant, ExpressionDef> cases = new LinkedHashMap<>();
+        cases.put(ExpressionDef.constant(0), ExpressionDef.constant("10"));
+        ClassDef definition = ClassDef.builder("example.JdkSwitchYield")
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("size")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .addParameter("count", TypeDef.Primitive.INT)
+                .returns(TypeDef.Primitive.INT)
+                .build((ignored, parameters) -> ClassTypeDef.of(Integer.class).invokeStatic(
+                    "parseInt",
+                    TypeDef.Primitive.INT,
+                    parameters.get(0).asExpressionSwitch(
+                        TypeDef.STRING,
+                        cases,
+                        // An early yield and a final one; were either written as a method return,
+                        // the class would not verify - size returns an int, not a string
+                        new ExpressionDef.SwitchYieldCase(
+                            TypeDef.STRING,
+                            StatementDef.multi(
+                                parameters.get(0).compare(EQUAL_TO, TypeDef.Primitive.INT.constant(1))
+                                    .ifTrue(ExpressionDef.constant("20").returning()),
+                                ExpressionDef.constant("30").returning()
+                            )
+                        )
+                    )
+                ).returning()))
+            .build();
+
+        Method size = define(definition).getMethod("size", int.class);
+
+        assertEquals(10, size.invoke(null, 0));
+        assertEquals(20, size.invoke(null, 1));
+        assertEquals(30, size.invoke(null, 2));
     }
 
     @Test

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/MethodContext.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/MethodContext.java
@@ -19,10 +19,13 @@ import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.sourcegen.model.MethodDef;
 import io.micronaut.sourcegen.model.ObjectDef;
+import io.micronaut.sourcegen.model.TypeDef;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Type;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +38,7 @@ import java.util.Map;
  * @param locals    The locals
  * @param lambdaMethods  Lambda methods created by this method
  * @param isLambda  Whether this method is a lambda
+ * @param yieldTargets  The switch yield cases being written, innermost last
  * @since 1.5
  */
 @Internal
@@ -42,11 +46,41 @@ public record MethodContext(@Nullable ObjectDef objectDef,
                             MethodDef methodDef,
                             Map<String, LocalData> locals,
                             List<MethodDef> lambdaMethods,
-                            boolean isLambda) {
+                            boolean isLambda,
+                            Deque<YieldTarget> yieldTargets) {
+
+    public MethodContext(@Nullable ObjectDef objectDef,
+                         MethodDef methodDef,
+                         Map<String, LocalData> locals,
+                         List<MethodDef> lambdaMethods,
+                         boolean isLambda) {
+        this(objectDef, methodDef, locals, lambdaMethods, isLambda, new ArrayDeque<>());
+    }
 
     public MethodContext(@Nullable ObjectDef objectDef,
                          MethodDef methodDef, boolean isLambda) {
         this(objectDef, methodDef, new LinkedHashMap<>(), new ArrayList<>(), isLambda);
+    }
+
+    /**
+     * The switch yield case a return statement contributes its value to, instead of returning
+     * from the method.
+     *
+     * @return The innermost yield case being written, or null when a return is a method return
+     */
+    @Nullable
+    public YieldTarget currentYieldTarget() {
+        return yieldTargets.peek();
+    }
+
+    /**
+     * A switch yield case being written.
+     *
+     * @param type  The type the case yields
+     * @param slot  The local the yielded value is held in
+     * @param end   The label the value is loaded at
+     */
+    public record YieldTarget(TypeDef type, int slot, Label end) {
     }
 
     /**

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/expression/SwitchYieldCaseExpressionWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/expression/SwitchYieldCaseExpressionWriter.java
@@ -16,8 +16,11 @@
 package io.micronaut.sourcegen.bytecode.expression;
 
 import io.micronaut.sourcegen.bytecode.MethodContext;
+import io.micronaut.sourcegen.bytecode.TypeUtils;
 import io.micronaut.sourcegen.bytecode.statement.StatementWriter;
 import io.micronaut.sourcegen.model.ExpressionDef;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
 
 final class SwitchYieldCaseExpressionWriter implements ExpressionWriter {
@@ -29,6 +32,18 @@ final class SwitchYieldCaseExpressionWriter implements ExpressionWriter {
 
     @Override
     public void write(GeneratorAdapter generatorAdapter, MethodContext context) {
-        StatementWriter.of(switchYieldCase.statement()).write(generatorAdapter, context, null);
+        // The case is a statement block that yields its value with a return statement, so the returns
+        // it contains hold the value in a local and jump here instead of returning from the method
+        Type type = TypeUtils.getType(switchYieldCase.type(), context.objectDef());
+        Label end = new Label();
+        int slot = generatorAdapter.newLocal(type);
+        context.yieldTargets().push(new MethodContext.YieldTarget(switchYieldCase.type(), slot, end));
+        try {
+            StatementWriter.of(switchYieldCase.statement()).write(generatorAdapter, context, null);
+        } finally {
+            context.yieldTargets().pop();
+        }
+        generatorAdapter.visitLabel(end);
+        generatorAdapter.loadLocal(slot, type);
     }
 }

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/statement/ReturnStatementWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/statement/ReturnStatementWriter.java
@@ -18,6 +18,7 @@ package io.micronaut.sourcegen.bytecode.statement;
 import io.micronaut.sourcegen.bytecode.MethodContext;
 import io.micronaut.sourcegen.bytecode.TypeUtils;
 import io.micronaut.sourcegen.bytecode.expression.ExpressionWriter;
+import io.micronaut.sourcegen.model.ExpressionDef;
 import io.micronaut.sourcegen.model.StatementDef;
 import io.micronaut.sourcegen.model.TypeDef;
 import org.jspecify.annotations.Nullable;
@@ -33,6 +34,11 @@ final class ReturnStatementWriter implements StatementWriter {
 
     @Override
     public void write(GeneratorAdapter generatorAdapter, MethodContext context, @Nullable Runnable finallyBlock) {
+        MethodContext.YieldTarget yieldTarget = context.currentYieldTarget();
+        if (yieldTarget != null) {
+            writeYield(generatorAdapter, context, finallyBlock, yieldTarget);
+            return;
+        }
         aReturn.validate(context.methodDef());
         if (aReturn.expression() != null) {
             ExpressionWriter.writeExpressionCheckCast(generatorAdapter, context, aReturn.expression(), context.methodDef().getReturnType());
@@ -43,6 +49,26 @@ final class ReturnStatementWriter implements StatementWriter {
             }
         }
         generatorAdapter.returnValue();
+    }
+
+    /**
+     * Writes a return that is the value of the switch yield case being written: the value is held in
+     * the local of the case and control jumps to its end, where the case loads it.
+     */
+    private void writeYield(GeneratorAdapter generatorAdapter,
+                            MethodContext context,
+                            @Nullable Runnable finallyBlock,
+                            MethodContext.YieldTarget yieldTarget) {
+        ExpressionDef expression = aReturn.expression();
+        if (expression == null) {
+            throw new IllegalStateException("Switch yield return has no value");
+        }
+        ExpressionWriter.writeExpressionCheckCast(generatorAdapter, context, expression, yieldTarget.type());
+        generatorAdapter.storeLocal(yieldTarget.slot(), TypeUtils.getType(yieldTarget.type(), context.objectDef()));
+        if (finallyBlock != null) {
+            finallyBlock.run();
+        }
+        generatorAdapter.goTo(yieldTarget.end());
     }
 
     private void pushFinallyStatement(GeneratorAdapter generatorAdapter, MethodContext context, @Nullable Runnable finallyBlock, TypeDef expTypeDef) {

--- a/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/statement/StatementWriter.java
+++ b/sourcegen-bytecode-writer/src/main/java/io/micronaut/sourcegen/bytecode/statement/StatementWriter.java
@@ -112,7 +112,7 @@ public sealed interface StatementWriter permits AssignVariableStatementWriter, D
                              @Nullable Runnable finallyBlock) {
         Map<String, MethodContext.LocalData> oldLocals = context.locals();
         Map<String, MethodContext.LocalData> newLocals = new LinkedHashMap<>(oldLocals);
-        MethodContext newContext = new MethodContext(context.objectDef(), context.methodDef(), newLocals, new ArrayList<>(), false);
+        MethodContext newContext = new MethodContext(context.objectDef(), context.methodDef(), newLocals, new ArrayList<>(), false, context.yieldTargets());
         write(generatorAdapter, newContext, finallyBlock);
         oldLocals.keySet().forEach(newLocals::remove); // Remove locals not created in the scope
         Label endMethod = new Label();

--- a/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/SwitchYieldCaseTest.java
+++ b/sourcegen-bytecode-writer/src/test/java/io/micronaut/sourcegen/bytecode/SwitchYieldCaseTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.bytecode;
+
+import io.micronaut.sourcegen.model.ClassDef;
+import io.micronaut.sourcegen.model.ClassTypeDef;
+import io.micronaut.sourcegen.model.ExpressionDef;
+import io.micronaut.sourcegen.model.MethodDef;
+import io.micronaut.sourcegen.model.StatementDef;
+import io.micronaut.sourcegen.model.TypeDef;
+import org.junit.jupiter.api.Test;
+
+import javax.lang.model.element.Modifier;
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static io.micronaut.sourcegen.model.ExpressionDef.ComparisonOperation.OpType.EQUAL_TO;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A switch yield case yields the value of its block to the switch. The case is written as a
+ * statement block whose returns are its yields, so a switch that is not itself what the method
+ * returns - here it is an argument - must not return from the method.
+ */
+class SwitchYieldCaseTest {
+
+    @Test
+    void yieldsToTheSwitchWhenTheSwitchIsAnArgument() throws Exception {
+        Method size = define(switchAsArgument("example.AsmSwitchYield")).getMethod("size", int.class);
+
+        assertEquals(10, size.invoke(null, 0));
+        assertEquals(20, size.invoke(null, 1));
+        assertEquals(30, size.invoke(null, 2));
+    }
+
+    /**
+     * A class with a {@code size} method that passes a switch to {@code Integer.parseInt}. The
+     * default case is a yield block with an early yield and a final one; were either written as a
+     * method return, the class would not verify - {@code size} returns an int, not a string.
+     */
+    static ClassDef switchAsArgument(String name) {
+        Map<ExpressionDef.Constant, ExpressionDef> cases = new LinkedHashMap<>();
+        cases.put(ExpressionDef.constant(0), ExpressionDef.constant("10"));
+        return ClassDef.builder(name)
+            .addModifiers(Modifier.PUBLIC)
+            .addMethod(MethodDef.builder("size")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .addParameter("count", TypeDef.Primitive.INT)
+                .returns(TypeDef.Primitive.INT)
+                .build((aThis, parameters) -> ClassTypeDef.of(Integer.class).invokeStatic(
+                    "parseInt",
+                    TypeDef.Primitive.INT,
+                    parameters.get(0).asExpressionSwitch(
+                        TypeDef.STRING,
+                        cases,
+                        new ExpressionDef.SwitchYieldCase(
+                            TypeDef.STRING,
+                            StatementDef.multi(
+                                parameters.get(0).compare(EQUAL_TO, TypeDef.Primitive.INT.constant(1))
+                                    .ifTrue(ExpressionDef.constant("20").returning()),
+                                ExpressionDef.constant("30").returning()
+                            )
+                        )
+                    )
+                ).returning()))
+            .build();
+    }
+
+    private static Class<?> define(ClassDef classDef) {
+        byte[] bytes = new ByteCodeWriter().write(classDef);
+        return new ClassLoader() {
+            Class<?> define() {
+                return defineClass(classDef.getName(), bytes, 0, bytes.length);
+            }
+        }.define();
+    }
+}

--- a/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
+++ b/sourcegen-generator/src/main/java/io/micronaut/sourcegen/generator/visitors/BuilderAnnotationVisitor.java
@@ -772,7 +772,8 @@ public final class BuilderAnnotationVisitor implements TypeElementVisitor<Builde
                     .newLocal(field.name() + "Iterator", iteratorVar ->
                         iteratorVar.invoke("hasNext", TypeDef.primitive(boolean.class)).whileLoop(
                             iteratorVar.invoke("next", TypeDef.OBJECT).cast(Map.Entry.class).newLocal(field.name() + "Entry", entryVar ->
-                                mapVar.invoke("put", TypeDef.of(boolean.class),
+                                // Map.put returns the previous value, not a boolean like Collection.add
+                                mapVar.invoke("put", TypeDef.OBJECT,
                                     entryVar.invoke("getKey", TypeDef.OBJECT).cast(keyType),
                                     entryVar.invoke("getValue", TypeDef.OBJECT).cast(valueType)
                                 ))

--- a/test-suite-tck/src/test/java/io/micronaut/sourcegen/example/UserBuilderSingularTest.java
+++ b/test-suite-tck/src/test/java/io/micronaut/sourcegen/example/UserBuilderSingularTest.java
@@ -17,7 +17,6 @@ package io.micronaut.sourcegen.example;
 
 import io.micronaut.core.util.CollectionUtils;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -120,8 +119,6 @@ class UserBuilderSingularTest {
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "sourcegen.backend", matches = "bytecode",
-        disabledReason = "The ASM backend calls Map.put through the descriptor of Collection.add, so building a singular map fails with NoSuchMethodError")
     void testCombinationsSimple() {
         UserBuilderSingular user = buildUserSingle();
         assertEquals(123L, user.id());
@@ -136,8 +133,6 @@ class UserBuilderSingularTest {
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "sourcegen.backend", matches = "bytecode",
-        disabledReason = "The ASM backend calls Map.put through the descriptor of Collection.add, so building a singular map fails with NoSuchMethodError")
     void testCombinationsComplex() {
         UserBuilderSingular user = buildUserComplex();
         assertEquals(123L, user.id());
@@ -152,8 +147,6 @@ class UserBuilderSingularTest {
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "sourcegen.backend", matches = "bytecode",
-        disabledReason = "The ASM backend calls Map.put through the descriptor of Collection.add, so building a singular map fails with NoSuchMethodError")
     void testImmutable() {
         UserBuilderSingular user = buildUserSingle();
         assertThrowsExactly(UnsupportedOperationException.class, () -> {
@@ -197,8 +190,6 @@ class UserBuilderSingularTest {
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "sourcegen.backend", matches = "bytecode",
-        disabledReason = "The ASM backend calls Map.put through the descriptor of Collection.add, so building a singular map fails with NoSuchMethodError")
     void mapOrder() {
         UserBuilderSingular user = buildUserComplex();
         Map<String, Integer> maps = user.maps();
@@ -210,8 +201,6 @@ class UserBuilderSingularTest {
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "sourcegen.backend", matches = "bytecode",
-        disabledReason = "The ASM backend calls Map.put through the descriptor of Collection.add, so building a singular map fails with NoSuchMethodError")
     void sortedMapOrder() {
         UserBuilderSingular user = buildUserComplex();
         ArrayList<Map.Entry<String, Integer>> entries = new ArrayList<>(user.sortedMaps().entrySet());

--- a/test-suite-tck/src/test/java/io/micronaut/sourcegen/example/UserSuperSingularTest.java
+++ b/test-suite-tck/src/test/java/io/micronaut/sourcegen/example/UserSuperSingularTest.java
@@ -17,7 +17,6 @@ package io.micronaut.sourcegen.example;
 
 import io.micronaut.core.util.CollectionUtils;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -120,8 +119,6 @@ class UserSuperSingularTest {
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "sourcegen.backend", matches = "bytecode",
-        disabledReason = "The ASM backend calls Map.put through the descriptor of Collection.add, so building a singular map fails with NoSuchMethodError")
     void testCombinationsSimple() {
         UserSuperSingular user = buildUserSingle();
         assertEquals(123L, user.id());
@@ -136,8 +133,6 @@ class UserSuperSingularTest {
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "sourcegen.backend", matches = "bytecode",
-        disabledReason = "The ASM backend calls Map.put through the descriptor of Collection.add, so building a singular map fails with NoSuchMethodError")
     void testCombinationsComplex() {
         UserSuperSingular user = buildUserComplex();
         assertEquals(123L, user.id());
@@ -152,8 +147,6 @@ class UserSuperSingularTest {
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "sourcegen.backend", matches = "bytecode",
-        disabledReason = "The ASM backend calls Map.put through the descriptor of Collection.add, so building a singular map fails with NoSuchMethodError")
     void testImmutable() {
         UserSuperSingular user = buildUserSingle();
         assertThrowsExactly(UnsupportedOperationException.class, () -> {
@@ -197,8 +190,6 @@ class UserSuperSingularTest {
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "sourcegen.backend", matches = "bytecode",
-        disabledReason = "The ASM backend calls Map.put through the descriptor of Collection.add, so building a singular map fails with NoSuchMethodError")
     void mapOrder() {
         UserSuperSingular user = buildUserComplex();
         Map<String, Integer> maps = user.maps();
@@ -210,8 +201,6 @@ class UserSuperSingularTest {
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "sourcegen.backend", matches = "bytecode",
-        disabledReason = "The ASM backend calls Map.put through the descriptor of Collection.add, so building a singular map fails with NoSuchMethodError")
     void sortedMapOrder() {
         UserSuperSingular user = buildUserComplex();
         ArrayList<Map.Entry<String, Integer>> entries = new ArrayList<>(user.sortedMaps().entrySet());

--- a/test-suite-tck/src/test/java/io/micronaut/sourcegen/example/UserTest.java
+++ b/test-suite-tck/src/test/java/io/micronaut/sourcegen/example/UserTest.java
@@ -16,7 +16,6 @@
 package io.micronaut.sourcegen.example;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import java.util.List;
 import java.util.Map;
@@ -27,8 +26,6 @@ class UserTest {
 
     //tag::test[]
     @Test
-    @DisabledIfSystemProperty(named = "sourcegen.backend", matches = "bytecode",
-        disabledReason = "The ASM backend calls Map.put through the descriptor of Collection.add, so building a singular map fails with NoSuchMethodError")
     public void testSimple() {
         User user = new UserSuperBuilder()
             .id(123L)
@@ -44,8 +41,6 @@ class UserTest {
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "sourcegen.backend", matches = "bytecode",
-        disabledReason = "The ASM backend calls Map.put through the descriptor of Collection.add, so building a singular map fails with NoSuchMethodError")
     public void testAddAll() {
         User user = new UserSuperBuilder()
             .id(123L)
@@ -63,8 +58,6 @@ class UserTest {
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "sourcegen.backend", matches = "bytecode",
-        disabledReason = "The ASM backend calls Map.put through the descriptor of Collection.add, so building a singular map fails with NoSuchMethodError")
     public void testClear() {
         User user = new UserSuperBuilder()
             .id(123L)


### PR DESCRIPTION
Builders generated for a singular `Map` property failed at runtime on both bytecode backends (ASM and JDK ClassFile) with:

```
java.lang.NoSuchMethodError: 'boolean java.util.LinkedHashMap.put(java.lang.String, java.lang.Integer)'
    at io.micronaut.sourcegen.example.UserBuilderSingularBuilder.build(Unknown Source)
```

Two bugs, one behind the other.

## The `Map.put` descriptor

`BuilderAnnotationVisitor` asked for `put` with a `boolean` return — the return type of `Collection.add`, which the neighbouring singular collection path uses. No declaration matches that, so `Invocations.resolve` gave up and the call shape was inferred from the argument types instead, naming `(String, Integer)boolean`. Asking for `Object` back lets the call resolve against `Map.put`, which erases the parameters as well: the emitted call is now `LinkedHashMap.put:(Object,Object)Object`.

## Switch yield cases outside return position

With the descriptor fixed the tests failed differently — `ClassCastException: Collections$UnmodifiableMap cannot be cast to UserBuilderSingular`. The case that builds the map is a `SwitchYieldCase`, and both bytecode backends wrote its yielding return as a method return. That is only correct while the yield case sits in a switch that is itself what the method returns, which was true of every existing test; here the switch is a constructor argument, so `build()` returned the map instead of the built object.

Both backends now hold the yielded value in a local of the case and jump to its end, where the case loads it — the same lowering the Java backend expresses as `yield`:

- ASM: `SwitchYieldCaseExpressionWriter` pushes a target onto a stack carried by `MethodContext`, which `ReturnStatementWriter` consults; `writeScoped` passes the stack on, and lambdas are written with their own context so a return inside one stays a return.
- JDK: `writeYieldCase` / `writeYield` in `JdkMethodWriter`. A yield runs only the finally blocks opened inside the case, not the ones the enclosing method had pending.

## Tests

The singular map tests in `UserBuilderSingularTest`, `UserSuperSingularTest` and `UserTest` are no longer disabled on the bytecode backends. `./gradlew build` is green: `test-suite-bytecode` 152 tests, `test-suite-bytecode-jdk` 152, `test-suite-java` 161, no failures. The remaining skips are the pre-existing `MyBean3Test.nullableOnAParameterIsWrittenAsATypeAnnotation` and, on the JDK backend, `HeronTest.copiesAClassValuedAnnotationMember`.

## For the reviewer

This is stacked on the shared-TCK branch, `claude/bytecode-writers-tck-e7cd3a`, which is what makes the singular map tests run on all three backends; the PR is based on it, so the diff is just this one commit. Merge that branch first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
