### PR TITLE
Write class-valued annotation members with the class tag in the JDK backend

### DIFF
--- a/sourcegen-bytecode-writer-jdk/src/main/java/io/micronaut/sourcegen/bytecode/jdk/ByteCodeWriter.java
+++ b/sourcegen-bytecode-writer-jdk/src/main/java/io/micronaut/sourcegen/bytecode/jdk/ByteCodeWriter.java
@@ -542,6 +542,12 @@ public final class ByteCodeWriter {
             return toAnnotationValue(constantValue);
         }
         if (value instanceof VariableDef.StaticField field) {
+            if (field.name().equals("class") && field.type().equals(TypeDef.CLASS)) {
+                // A class-valued member is modelled as `SomeType.class`, not as an enum constant
+                return AnnotationValue.ofClass(ClassDesc.ofDescriptor(
+                    io.micronaut.sourcegen.bytecode.core.TypeUtils.getDescriptor(field.ownerType(), null)
+                ));
+            }
             return AnnotationValue.ofEnum(ClassDesc.of(field.ownerType().getName()), field.name());
         }
         if (value instanceof io.micronaut.sourcegen.model.AnnotationDef annotation) {

--- a/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/HeronTest.java
+++ b/test-suite-bytecode/src/test/java/io/micronaut/sourcegen/example/HeronTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.sourcegen.example;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.sourcegen.example.Heron.Color;
+import io.micronaut.sourcegen.example.Heron.Simple;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class HeronTest {
+
+    @Test
+    void copiesEveryMemberOfAnAnnotation() {
+        BeanIntrospection<BlueHeron> intro = BeanIntrospection.getIntrospection(BlueHeron.class);
+
+        AnnotationValue<Simple> simple = intro.getAnnotation(Simple.class);
+        assertNotNull(simple);
+        assertEquals("A", simple.stringValue("name").get());
+        assertEquals(12, simple.intValue("age").getAsInt());
+        assertEquals(Color.WHITE, simple.enumValue("color", Color.class).get());
+        assertSame(String.class, simple.classValue("type").get());
+    }
+}


### PR DESCRIPTION
## What

The JDK ClassFile backend (`sourcegen-bytecode-writer-jdk`) dropped a `Class`-valued annotation member when it copied an annotation. Given a fixture annotated `@Simple(name = "A", age = 12, color = Color.WHITE, type = String.class)`, the generated class came back with `stringValue("name")`, `intValue("age")` and `enumValue("color", Color.class)` all resolving, but `classValue("type")` empty. The ASM backend and the javac backend both handled it correctly.

## Why

A class-valued member is modelled as a `VariableDef.StaticField` named `"class"` whose type is `TypeDef.CLASS` and whose owner is the referenced type — i.e. `SomeType.class`. The JDK backend's `StaticField` branch in `ByteCodeWriter.toAnnotationValue` assumed every static field was an enum constant, so it emitted `AnnotationValue.ofEnum(...)` and wrote the member with the `e` tag rather than the `c` tag. The reader then found no class value under that name.

The fix special-cases that shape and emits `AnnotationValue.ofClass` with the owner type's descriptor, mirroring what the ASM backend already does in `sourcegen-bytecode-writer`'s `ByteCodeWriter#visitAnnotation`. The `ClassTypeDef` / `Class<?>` branches further down were already correct — they were simply never reached for this shape of value.

## Test

`test-suite-java`'s `HeronTest` already asserted `classValue("type")`, which is why the javac backend was known good. There was no bytecode-side equivalent, so neither bytecode backend was held to it. This adds `HeronTest` to `test-suite-bytecode`, whose test sources `test-suite-bytecode-jdk` also compiles — so the assertion now runs against the ASM backend and the JDK backend from one source.

Verified the test catches the bug: with the six-line fix reverted, `:test-suite-bytecode-jdk:test` fails on `copiesEveryMemberOfAnAnnotation()` with the original `java.util.NoSuchElementException: No value present`.

- `:test-suite-bytecode-jdk:test` — 139 pass
- `:test-suite-bytecode:test` — 139 pass
- `:test-suite-java:test` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)